### PR TITLE
Allow redacting names and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ bitbucket:
       
   # Strip out long-form text content (commit messages, PR text, etc)
   strip_text_content: False
-      
+  
+  # Redact names and URLs for projects, repos, branches
+  redact_names_and_urls: False
 ```
 
 5. Run `jf_agent` with the path to your config file, optionally specifying constraints on time to pull git data:

--- a/jf_agent/bb_download.py
+++ b/jf_agent/bb_download.py
@@ -1,8 +1,26 @@
 from datetime import datetime
-from tqdm import tqdm
 import stashy
 import re
 import pytz
+
+
+class NameRedactor:
+    def __init__(self):
+        self.redacted_names = {}
+        self.seq = 0
+
+    def redact_name(self, name):
+        redacted_name = self.redacted_names.get(name)
+        if not redacted_name:
+            redacted_name = f'redacted-{self.seq}'
+            self.seq += 1
+            self.redacted_names[name] = redacted_name
+        return redacted_name
+
+
+_branch_redactor = NameRedactor()
+_project_redactor = NameRedactor()
+_repo_redactor = NameRedactor()
 
 
 def datetime_from_bitbucket_server_timestamp(bb_server_timestamp_str):
@@ -19,13 +37,27 @@ def _normalize_user(user):
 
 
 def get_all_users(client):
-    print('downloading bitbucket users... ✓')
+    print('downloading bitbucket users... ', end='', flush=True)
+    users = [_normalize_user(user) for user in client.admin.users]
+    print('✓')
+    return users
 
-    return [_normalize_user(user) for user in client.admin.users]
+
+def _normalize_project(api_project, redact_names_and_urls):
+    return {
+        'id': api_project['id'],
+        'login': api_project['key'],
+        'name': (
+            api_project.get('name')
+            if not redact_names_and_urls
+            else _project_redactor.redact_name(api_project.get('name'))
+        ),
+        'url': api_project['links']['self'][0]['href'] if not redact_names_and_urls else None,
+    }
 
 
-def get_all_projects(client, include_projects, exclude_projects):
-    print('downloading bitbucket projects... ✓')
+def get_all_projects(client, include_projects, exclude_projects, redact_names_and_urls):
+    print('downloading bitbucket projects... ', end='', flush=True)
 
     filters = []
     if include_projects:
@@ -33,20 +65,54 @@ def get_all_projects(client, include_projects, exclude_projects):
     if exclude_projects:
         filters.append(lambda p: p['key'] not in exclude_projects)
 
-    return [
-        {
-            'id': p['id'],
-            'login': p['key'],
-            'name': p.get('name'),
-            'description': p.get('description'),
-            'url': p['links']['self'][0]['href'],
-        }
+    projects = [
+        (p, _normalize_project(p, redact_names_and_urls))
         for p in client.projects.list()
         if all(filt(p) for filt in filters)
     ]
+    print('✓')
+    return projects
 
 
-def get_all_repos(client, projects, include_repos, exclude_repos):
+def _normalize_repo(api_project, api_repo, redact_names_and_urls):
+    repo = api_repo.get()
+
+    name = (
+        repo['name'] if not redact_names_and_urls else _project_redactor.redact_name(repo['name'])
+    )
+    url = repo['links']['self'][0]['href'] if not redact_names_and_urls else None
+    try:
+        default_branch_name = (
+            api_repo.default_branch['displayId'] if api_repo.default_branch else ''
+        )
+    except stashy.errors.NotFoundException:
+        default_branch_name = ''
+
+    branches = [
+        {
+            'name': (
+                b['displayId']
+                if not redact_names_and_urls
+                else _branch_redactor.redact_name(b['displayId'])
+            ),
+            'sha': b['latestCommit'],
+        }
+        for b in api_repo.branches()
+    ]
+
+    return {
+        'id': repo['id'],
+        'name': name,
+        'full_name': name,
+        'url': url,
+        'default_branch_name': default_branch_name,
+        'branches': branches,
+        'is_fork': 'origin' in repo,
+        'project': _normalize_project(api_project, redact_names_and_urls),
+    }
+
+
+def get_all_repos(client, api_projects, include_repos, exclude_repos, redact_names_and_urls):
     print('downloading bitbucket repositories... ', end='', flush=True)
 
     filters = []
@@ -55,38 +121,12 @@ def get_all_repos(client, projects, include_repos, exclude_repos):
     if exclude_repos:
         filters.append(lambda r: r['name'] not in exclude_repos)
 
-    api_repos = (
-        (project, api_project.repos[repo['name']])
-        for project in projects
-        for api_project in [client.projects[project['login']]]
-        for repo in api_project.repos.list()
-        if all(filt(repo) for filt in filters)
-    )
-
-    for project, api_repo in api_repos:
-        try:
-            default_branch_name = (
-                api_repo.default_branch['displayId'] if api_repo.default_branch else ''
-            )
-        except stashy.errors.NotFoundException:
-            default_branch_name = ''
-
-        branches = list(
-            {'name': b['displayId'], 'sha': b['latestCommit']} for b in api_repo.branches()
-        )
-
-        repo = api_repo.get()
-        yield {
-            'id': repo['id'],
-            'name': repo['name'],
-            'full_name': repo['name'],
-            'description': repo['name'],
-            'url': repo['links']['self'][0]['href'],
-            'default_branch_name': default_branch_name,
-            'branches': branches,
-            'is_fork': 'origin' in repo,
-            'project': project,
-        }
+    for api_project in api_projects:
+        project = client.projects[api_project['key']]
+        for repo in project.repos.list():
+            if all(filt(repo) for filt in filters):
+                api_repo = project.repos[repo['name']]
+                yield api_repo, _normalize_repo(api_project, api_repo, redact_names_and_urls)
 
     print('✓')
 
@@ -103,40 +143,47 @@ def _sanitize_text(text, strip_text_content):
     )
 
 
-def _normalize_commit(commit, repo, strip_text_content):
+def _normalize_commit(commit, repo, strip_text_content, redact_names_and_urls):
     return {
         'hash': commit['id'],
         'commit_date': datetime_from_bitbucket_server_timestamp(commit['committerTimestamp']),
         'author': commit['author'],
         'author_date': datetime_from_bitbucket_server_timestamp(commit['authorTimestamp']),
-        'url': repo['url'].replace('browse', f'commits/{commit["id"]}'),
+        'url': (
+            repo['links']['self'][0]['href'].replace('browse', f'commits/{commit["id"]}')
+            if not redact_names_and_urls
+            else None
+        ),
         'message': _sanitize_text(commit.get('message'), strip_text_content),
         'is_merge': len(commit['parents']) > 1,
-        'repo': _normalize_pr_repo(repo),
+        'repo': _normalize_pr_repo(repo, redact_names_and_urls),
     }
 
 
-def get_default_branch_commits(client, repos, strip_text_content, pull_since, pull_until):
-    for repo in repos:
-        api_project = client.projects[repo['project']['login']]
+def get_default_branch_commits(
+    client, api_repos, strip_text_content, pull_since, pull_until, redact_names_and_urls
+):
+    print('downloading commits... ', end='', flush=True)
+    for api_repo in api_repos:
+        repo = api_repo.get()
+        api_project = client.projects[repo['project']['key']]
 
         try:
-            commits = api_project.repos[repo['name']].commits(until=repo['default_branch_name'])
+            default_branch = api_repo.default_branch['displayId'] if api_repo.default_branch else ''
+            commits = api_project.repos[repo['name']].commits(until=default_branch)
 
-            for commit in tqdm(
-                commits,
-                desc=f'downloading {repo["project"]["login"]}/{repo["name"]} commits',
-                unit='commit',
-            ):
-                normalized_commit = _normalize_commit(commit, repo, strip_text_content)
+            for commit in commits:
+                normalized_commit = _normalize_commit(
+                    commit, repo, strip_text_content, redact_names_and_urls
+                )
                 # commits are ordered newest to oldest; if this isn't
                 # old enough, skip it and keep going
                 if normalized_commit['commit_date'] >= pull_until:
                     continue
 
-                # if this is too old, we're done
+                # if this is too old, we're done with this repo
                 if pull_since and normalized_commit['commit_date'] < pull_since:
-                    return
+                    break
 
                 yield normalized_commit
 
@@ -144,39 +191,45 @@ def get_default_branch_commits(client, repos, strip_text_content, pull_since, pu
             print(
                 f'WARN: Got NotFoundException for branch {repo["default_branch_name"]}: {e}. Skipping...'
             )
+    print('✓')
 
 
-def _normalize_pr_repo(repo):
-    normal_repo = {'id': repo['id'], 'name': repo['name']}
+def _normalize_pr_repo(repo, redact_names_and_urls):
+    normal_repo = {
+        'id': repo['id'],
+        'name': (
+            repo['name'] if not redact_names_and_urls else _repo_redactor.redact_name(repo['name'])
+        ),
+    }
 
-    if 'links' in repo:
-        normal_repo['url'] = repo['links']['self'][0]['href']
-    elif 'url' in repo:
-        normal_repo['url'] = repo['url']
+    if not redact_names_and_urls:
+        if 'links' in repo:
+            normal_repo['url'] = repo['links']['self'][0]['href']
+        elif 'url' in repo:
+            normal_repo['url'] = repo['url']
 
     return normal_repo
 
 
-def get_pull_requests(client, repos, strip_text_content, pull_since, pull_until):
+def get_pull_requests(
+    client, api_repos, strip_text_content, pull_since, pull_until, redact_names_and_urls
+):
     print('downloading bitbucket PRs... ', end='', flush=True)
 
-    for repo in repos:
-        api_project = client.projects[repo['project']['login']]
+    for api_repo in api_repos:
+        repo = api_repo.get()
+        api_project = client.projects[repo['project']['key']]
         api_repo = api_project.repos[repo['name']]
 
-        for pr in tqdm(
-            api_repo.pull_requests.all(state='ALL', order='NEWEST'),
-            desc=f'downloading PRs for {repo["project"]["login"]}/{repo["name"]}',
-            unit='pr',
-        ):
+        for pr in api_repo.pull_requests.all(state='ALL', order='NEWEST'):
             updated_at = datetime_from_bitbucket_server_timestamp(pr['updatedDate'])
             # PRs are ordered newest to oldest; if this isn't old enough, skip it and keep going
             if updated_at >= pull_until:
                 continue
 
-            # if this is too old, we're done
+            # if this is too old, we're done with this repo
             if pull_since and updated_at < pull_since:
-                return
+                break
 
             api_pr = api_repo.pull_requests[pr['id']]
 
@@ -235,7 +288,10 @@ def get_pull_requests(client, repos, strip_text_content, pull_since, pull_until)
             )
 
             try:
-                commits = (_normalize_commit(c, repo, strip_text_content) for c in api_pr.commits())
+                commits = (
+                    _normalize_commit(c, repo, strip_text_content, redact_names_and_urls)
+                    for c in api_pr.commits()
+                )
             except stashy.errors.NotFoundException:
                 print(
                     f'WARN: For PR {pr["id"]}, caught stashy.errors.NotFoundException when attempting to fetch a commit'
@@ -251,11 +307,19 @@ def get_pull_requests(client, repos, strip_text_content, pull_since, pull_until)
                 'created_at': datetime_from_bitbucket_server_timestamp(pr['createdDate']),
                 'updated_at': updated_at,
                 'closed_date': closed_date,
-                'url': pr['links']['self'][0]['href'],
-                'base_repo': _normalize_pr_repo(pr['toRef']['repository']),
-                'base_branch': pr['toRef']['displayId'],
-                'head_repo': _normalize_pr_repo(pr['fromRef']['repository']),
-                'head_branch': pr['fromRef']['displayId'],
+                'url': (pr['links']['self'][0]['href'] if not redact_names_and_urls else None),
+                'base_repo': _normalize_pr_repo(pr['toRef']['repository'], redact_names_and_urls),
+                'base_branch': (
+                    pr['toRef']['displayId']
+                    if not redact_names_and_urls
+                    else _branch_redactor.redact_name(pr['toRef']['displayId'])
+                ),
+                'head_repo': _normalize_pr_repo(pr['fromRef']['repository'], redact_names_and_urls),
+                'head_branch': (
+                    pr['fromRef']['displayId']
+                    if not redact_names_and_urls
+                    else _branch_redactor.redact_name(pr['fromRef']['displayId'])
+                ),
                 'additions': additions,
                 'deletions': deletions,
                 'changed_files': changed_files,

--- a/jf_agent/bb_download.py
+++ b/jf_agent/bb_download.py
@@ -5,11 +5,15 @@ import pytz
 
 
 class NameRedactor:
-    def __init__(self):
+    def __init__(self, preserve_names=None):
         self.redacted_names = {}
         self.seq = 0
+        self.preserve_names = preserve_names or []
 
     def redact_name(self, name):
+        if name in self.preserve_names:
+            return name
+
         redacted_name = self.redacted_names.get(name)
         if not redacted_name:
             redacted_name = f'redacted-{self.seq}'
@@ -18,7 +22,7 @@ class NameRedactor:
         return redacted_name
 
 
-_branch_redactor = NameRedactor()
+_branch_redactor = NameRedactor(preserve_names=['master', 'develop'])
 _project_redactor = NameRedactor()
 _repo_redactor = NameRedactor()
 

--- a/jf_agent/bb_download.py
+++ b/jf_agent/bb_download.py
@@ -16,7 +16,7 @@ class NameRedactor:
 
         redacted_name = self.redacted_names.get(name)
         if not redacted_name:
-            redacted_name = f'redacted-{self.seq}'
+            redacted_name = f'redacted-{self.seq:04}'
             self.seq += 1
             self.redacted_names[name] = redacted_name
         return redacted_name

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -174,21 +174,34 @@ def load_and_dump_bb(outdir, bb_config, bb_conn, pull_since, pull_until):
     include_repos = set(bb_config.get('include_repos', []))
     exclude_repos = set(bb_config.get('exclude_projects', []))
     strip_text_content = bb_config.get('strip_text_content', False)
+    redact_names_and_urls = bb_config.get('redact_names_and_urls', False)
 
     write_file(outdir, 'bb_users', get_all_users(bb_conn))
 
-    projects = get_all_projects(bb_conn, include_projects, exclude_projects)
-    write_file(outdir, 'bb_projects', projects)
+    project_data = get_all_projects(
+        bb_conn, include_projects, exclude_projects, redact_names_and_urls
+    )
+    write_file(outdir, 'bb_projects', (pd[1] for pd in project_data))
+    api_projects = [pd[0] for pd in project_data]
 
-    repos = list(get_all_repos(bb_conn, projects, include_repos, exclude_repos))
-    write_file(outdir, 'bb_repos', repos)
+    repo_data = list(
+        get_all_repos(bb_conn, api_projects, include_repos, exclude_repos, redact_names_and_urls)
+    )
+    write_file(outdir, 'bb_repos', [rd[1] for rd in repo_data])
+    api_repos = [rd[0] for rd in repo_data]
 
     commits = list(
-        get_default_branch_commits(bb_conn, repos, strip_text_content, pull_since, pull_until)
+        get_default_branch_commits(
+            bb_conn, api_repos, strip_text_content, pull_since, pull_until, redact_names_and_urls
+        )
     )
     write_file(outdir, 'bb_commits', commits)
 
-    prs = list(get_pull_requests(bb_conn, repos, strip_text_content, pull_since, pull_until))
+    prs = list(
+        get_pull_requests(
+            bb_conn, api_repos, strip_text_content, pull_since, pull_until, redact_names_and_urls
+        )
+    )
     write_file(outdir, 'bb_prs', prs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="jf_agent",
-    version="0.0.15",
+    version="0.0.16",
     description="An agent for collecting data for jellyfish",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Also fixes a bug with the --since handling; we were stopping pulling entirely as soon as we hit a single repo with a commit or PR before the since date instead of going on the next repo.  That is now fixed.