### PR TITLE
OJ 6166 - agent failing on Bitbucket data

### DIFF
--- a/jf_agent/bb_download.py
+++ b/jf_agent/bb_download.py
@@ -21,9 +21,9 @@ def datetime_from_bitbucket_server_timestamp(bb_server_timestamp_str):
 
 def _normalize_user(user):
     return {
-        'id': user['id'],
-        'login': user['name'],
-        'name': user['displayName'],
+        'id': user.get('id', ''),
+        'login': user.get('name', ''),
+        'name': user.get('displayName', ''),
         'email': user.get('emailAddress', ''),
     }
 


### PR DESCRIPTION
Fix for failing agent that was throwing back

`  File "/usr/local/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`