### PR TITLE
OJ-6775: Allow filtering on bitbucket cloud projects

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -117,26 +117,37 @@ git:
   # Only pull from specific projects / organizations / groups.
   # Bitbucket Server: use project keys, not names. Comment this out to pull from all projects.
   # Bitbucket Cloud (required): use your organization name, as it appears in your Bitbucket URLs
-  # GitHub (required): use your organization name, as it appears in your GitHub URLs (ex: MyOrg)
-  # GitLab (required): use the top-level GitLab "Group ID" (ex: 123)
+  # GitHub (required): use your organization name, as it appears in your GitHub URLs (e.g.: MyOrg)
+  # GitLab (required): use the top-level GitLab "Group ID" (e.g.: 123)
   include_projects:
       - PROJ1
 
   # Uncomment this to pull from all but specific projects (not supported for GitHub or Bitbucket Cloud).
-  # Bitbucket Server: use project keys, not names (ex: PROJ1)
-  # GitLab: use the top-level GitLab "Group ID" (ex: 123)
+  # Bitbucket Server: use project keys, not names (e.g.: PROJ1)
+  # GitLab: use the top-level GitLab "Group ID" (e.g.: 123)
   #  exclude_projects:
   #    - PROJ1
 
+  # Bitbucket cloud only: the include_projects filter above maps to
+  # top-level organization for bitbucket cloud. If you've grouped your
+  # repos into Bitbucket Cloud projects, use these filters instead to
+  # pull only from repos in particular projects.  Specify projects by
+  # key (e.g.: PROJ1)
+  # include_bitbucket_cloud_projects:
+  #     - PROJ1
+  #    
+  # exclude_bitbucket_cloud_projects:
+  #     - PROJ1
+  
   # Only pull from specific repos.  Comment this out to pull from all repos.
-  # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (ex: my_repository)
-  # GitLab: use the GitLab "Project ID" (ex: 123)
+  # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (e.g.: my_repository)
+  # GitLab: use the GitLab "Project ID" (e.g.: 123)
   include_repos:
       - my_repository
 
   # Uncomment this to pull from all but specific repos.
-  # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (ex: my_repository)
-  # GitLab: use the GitLab "Project ID" (ex: 123)
+  # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (e.g.: my_repository)
+  # GitLab: use the GitLab "Project ID" (e.g.: 123)
   # exclude_repos:
   #    - repo_to_skip
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -124,7 +124,7 @@ class BitbucketCloudAdapter(GitAdapter):
     def get_default_branch_commits(
         self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedCommit]:
-        print('downloading gitlab default branch commits... ', end='', flush=True)
+        print('downloading bitbucket default branch commits... ', end='', flush=True)
         for i, repo in enumerate(normalized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
@@ -158,7 +158,7 @@ class BitbucketCloudAdapter(GitAdapter):
     def get_pull_requests(
         self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedPullRequest]:
-        print('downloading gitlab prs... ', end='', flush=True)
+        print('downloading bitbucket prs... ', end='', flush=True)
         for i, repo in enumerate(
             tqdm(normalized_repos, desc=f'downloading prs for repos', unit='repos'), start=1
         ):

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -31,12 +31,13 @@ _repo_redactor = NameRedactor()
 
 
 class BitbucketCloudAdapter(GitAdapter):
-    def __init__(self, client: BitbucketCloudClient):
+    def __init__(self, config, client: BitbucketCloudClient):
+        super().__init__(config)
         self.client = client
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_users(self, include_projects) -> List[NormalizedUser]:
+    def get_users(self) -> List[NormalizedUser]:
         # Bitbucket Cloud API doesn't have a way to fetch all users;
         # we'll reconstruct them from repo history (commiters, PR
         # authors, etc)
@@ -44,11 +45,14 @@ class BitbucketCloudAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_projects(self, include_projects, redact_names_and_urls) -> List[NormalizedProject]:
+    def get_projects(self) -> List[NormalizedProject]:
         # Bitbucket Cloud API doesn't have a way to fetch all top-level projects;
         # instead, need to configure the agent with a specific set of projects to pull
         print('downloading bitbucket projects... ', end='', flush=True)
-        projects = [_normalize_project(p, redact_names_and_urls) for p in include_projects]
+        projects = [
+            _normalize_project(p, self.config.git_redact_names_and_urls)
+            for p in self.config.git_include_projects
+        ]
         print('✓')
 
         return projects
@@ -56,11 +60,7 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_repos(
-        self,
-        normalized_projects: List[NormalizedProject],
-        include_repos_ids: List[str],
-        exclude_repos_ids: List[str],
-        redact_names_and_urls: bool,
+        self, normalized_projects: List[NormalizedProject],
     ) -> List[NormalizedRepository]:
         print('downloading bitbucket repos... ', end='', flush=True)
 
@@ -73,20 +73,43 @@ class BitbucketCloudAdapter(GitAdapter):
                     unit='repos',
                 )
             ):
+                # If we have an explicit repo allow list and this isn't in it, skip
                 if (
-                    include_repos_ids
-                    and api_repo['name'] not in include_repos_ids
-                    and api_repo['uuid'] not in include_repos_ids
+                    self.config.git_include_repos
+                    and api_repo['name'] not in self.config.git_include_repos
+                    and api_repo['uuid'] not in self.config.git_include_repos
                 ):
-                    # skip
                     continue
-                if exclude_repos_ids and (
-                    api_repo['name'] in exclude_repos_ids or api_repo['uuid'] in exclude_repos_ids
+
+                # If we have an explicit repo deny list and this is in it, skip
+                if self.config.git_exclude_repos and (
+                    api_repo['name'] in self.config.git_exclude_repos
+                    or api_repo['uuid'] in self.config.git_exclude_repos
                 ):
-                    # skip
                     continue
-                branches = self.get_branches(p, api_repo, redact_names_and_urls)
-                repos.append(_normalize_repo(api_repo, branches, p, redact_names_and_urls))
+
+                # If this repo is in a project, apply project filters:
+                repo_project = api_repo.get('project')
+                if repo_project:
+                    # If we have a project allow list and this repo is in a project that's not in it, skip
+                    if (
+                        self.config.git_include_bbcloud_projects
+                        and repo_project['key'] not in self.config.git_include_bbcloud_projects
+                        and repo_project['uuid'] not in self.config.git_include_bbcloud_projects
+                    ):
+                        continue
+
+                    # if we have a project deny list and this repo is in a project that's in it, skip
+                    if self.config.git_exclude_bbcloud_projects and (
+                        repo_project['key'] in self.config.git_exclude_bbcloud_projects
+                        or repo_project['uuid'] in self.config.git_exclude_bbcloud_projects
+                    ):
+                        continue
+
+                branches = self.get_branches(p, api_repo)
+                repos.append(
+                    _normalize_repo(api_repo, branches, p, self.config.git_redact_names_and_urls)
+                )
 
         print('✓')
         if not repos:
@@ -99,11 +122,7 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_default_branch_commits(
-        self,
-        normalized_repos: List[NormalizedRepository],
-        server_git_instance_info,
-        strip_text_content: bool,
-        redact_names_and_urls: bool,
+        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedCommit]:
         print('downloading gitlab default branch commits... ', end='', flush=True)
         for i, repo in enumerate(normalized_repos, start=1):
@@ -121,7 +140,10 @@ class BitbucketCloudAdapter(GitAdapter):
                 ):
                     with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
                         commit = _normalize_commit(
-                            commit, repo, strip_text_content, redact_names_and_urls
+                            commit,
+                            repo,
+                            self.config.git_strip_text_content,
+                            self.config.git_redact_names_and_urls,
                         )
                         yield commit
 
@@ -134,11 +156,7 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
-        self,
-        normalized_repos: List[NormalizedRepository],
-        server_git_instance_info,
-        strip_text_content: bool,
-        redact_names_and_urls: bool,
+        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedPullRequest]:
         print('downloading gitlab prs... ', end='', flush=True)
         for i, repo in enumerate(
@@ -177,7 +195,11 @@ class BitbucketCloudAdapter(GitAdapter):
                                 continue
 
                             yield _normalize_pr(
-                                self.client, repo, api_pr, strip_text_content, redact_names_and_urls
+                                self.client,
+                                repo,
+                                api_pr,
+                                self.config.git_strip_text_content,
+                                self.config.git_redact_names_and_urls,
                             )
 
                             # PRs are ordered newest to oldest if this
@@ -210,9 +232,9 @@ class BitbucketCloudAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_branches(self, project, api_repo, redact_names_and_urls) -> List[NormalizedBranch]:
+    def get_branches(self, project, api_repo) -> List[NormalizedBranch]:
         return [
-            _normalize_branch(api_branch, redact_names_and_urls)
+            _normalize_branch(api_branch, self.config.git_redact_names_and_urls)
             for api_branch in self.client.get_branches(project.id, api_repo['uuid'])
         ]
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -194,9 +194,13 @@ class GitLabAdapter(GitAdapter):
                         logger.info(f'no prs found for repo {nrm_repo.id}. Skipping... ')
                         continue
 
-                    for j in range(0, total_api_prs):
+                    for api_pr in tqdm(
+                        api_prs,
+                        desc=f'processing prs for {nrm_repo.name}',
+                        unit='prs',
+                        total=total_api_prs,
+                    ):
                         try:
-                            api_pr = api_prs.next()
                             updated_at = parser.parse(api_pr.updated_at)
 
                             # PRs are ordered newest to oldest
@@ -236,11 +240,9 @@ class GitLabAdapter(GitAdapter):
                             pr_id = f' {api_pr.id}' if api_pr else ''
                             log_and_print_request_error(
                                 e,
-                                f'fetching pr{pr_id} index={j} page={api_prs.current_page} '
-                                f'from repo {nrm_repo.id}. Skipping...',
+                                f'normalizing PR {pr_id} from repo {nrm_repo.id}. Skipping...',
                                 log_as_exception=True,
                             )
-                            continue
 
                 except Exception as e:
                     # if something happens when pulling PRs for a repo, just keep going.

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -33,27 +33,27 @@ _project_redactor = NameRedactor()
 _repo_redactor = NameRedactor()
 
 '''
-    
+
     Data Fetching
 
 '''
 
 
 class GitLabAdapter(GitAdapter):
-    def __init__(self, client: GitLabClient):
+    def __init__(self, config, client: GitLabClient):
+        super().__init__(config)
         self.client = client
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_projects(
-        self, include_project_ids: List[int], redact_names_and_urls: bool
-    ) -> List[NormalizedProject]:
+    def get_projects(self) -> List[NormalizedProject]:
         print('downloading gitlab projects... ', end='', flush=True)
         projects = [
             _normalize_project(
-                self.client.get_group(project_id), redact_names_and_urls  # are group_ids
+                self.client.get_group(project_id),
+                self.config.git_redact_names_and_urls,  # are group_ids
             )
-            for project_id in include_project_ids
+            for project_id in self.config.git_include_projects
         ]
         print('✓')
 
@@ -65,11 +65,11 @@ class GitLabAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_users(self, include_project_ids: List[int]) -> List[NormalizedUser]:
+    def get_users(self) -> List[NormalizedUser]:
         print('downloading gitlab users... ', end='', flush=True)
         users = [
             _normalize_user(user)
-            for project_id in include_project_ids
+            for project_id in self.config.git_include_projects
             for user in self.client.list_group_members(project_id)
         ]
         print('✓')
@@ -78,11 +78,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_repos(
-        self,
-        normalized_projects: List[NormalizedProject],
-        include_repos_ids: List[int],
-        exclude_repos_ids: List[int],
-        redact_names_and_urls: bool,
+        self, normalized_projects: List[NormalizedProject],
     ) -> List[NormalizedRepository]:
         print('downloading gitlab repos... ', end='', flush=True)
 
@@ -97,14 +93,19 @@ class GitLabAdapter(GitAdapter):
                 ),
                 start=1,
             ):
-                if len(include_repos_ids) > 0 and api_repo.id not in include_repos_ids:
+                if (
+                    self.config.git_include_repos
+                    and api_repo.id not in self.config.git_include_repos
+                ):
                     continue  # skip this repo
-                if len(exclude_repos_ids) > 0 and api_repo.id in exclude_repos_ids:
+                if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
                     continue  # skip this repo
 
-                nrm_branches = self.get_branches(api_repo, redact_names_and_urls)
+                nrm_branches = self.get_branches(api_repo)
                 nrm_repos.append(
-                    _normalize_repo(api_repo, nrm_branches, nrm_project, redact_names_and_urls)
+                    _normalize_repo(
+                        api_repo, nrm_branches, nrm_project, self.config.git_redact_names_and_urls
+                    )
                 )
 
         print('✓')
@@ -116,11 +117,11 @@ class GitLabAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_branches(self, api_repo, redact_names_and_urls) -> List[NormalizedBranch]:
+    def get_branches(self, api_repo) -> List[NormalizedBranch]:
         print('downloading gitlab branches... ', end='', flush=True)
         try:
             return [
-                _normalize_branch(api_branch, redact_names_and_urls)
+                _normalize_branch(api_branch, self.config.git_redact_names_and_urls)
                 for api_branch in self.client.list_project_branches(api_repo.id)
             ]
         except requests.exceptions.RetryError as e:
@@ -134,11 +135,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_default_branch_commits(
-        self,
-        normalized_repos: List[NormalizedRepository],
-        server_git_instance_info,
-        strip_text_content: bool,
-        redact_names_and_urls: bool,
+        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedCommit]:
         print('downloading gitlab default branch commits... ', end='', flush=True)
         for i, nrm_repo in enumerate(normalized_repos, start=1):
@@ -159,7 +156,10 @@ class GitLabAdapter(GitAdapter):
                             logger, 'branch commit inside repo', j, 100
                         ):
                             yield _normalize_commit(
-                                commit, nrm_repo, strip_text_content, redact_names_and_urls
+                                commit,
+                                nrm_repo,
+                                self.config.git_strip_text_content,
+                                self.config.git_redact_names_and_urls,
                             )
 
                 except Exception as e:
@@ -171,11 +171,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
-        self,
-        normalized_repos: List[NormalizedRepository],
-        server_git_instance_info,
-        strip_text_content: bool,
-        redact_names_and_urls: bool,
+        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
     ) -> List[NormalizedPullRequest]:
         print('downloading gitlab prs... ', end='', flush=True)
 
@@ -220,13 +216,19 @@ class GitLabAdapter(GitAdapter):
 
                             nrm_commits: List[NormalizedCommit] = [
                                 _normalize_commit(
-                                    commit, nrm_repo, strip_text_content, redact_names_and_urls
+                                    commit,
+                                    nrm_repo,
+                                    self.config.git_strip_text_content,
+                                    self.config.git_redact_names_and_urls,
                                 )
                                 for commit in api_pr.commit_list
                             ]
 
                             yield _normalize_pr(
-                                api_pr, nrm_commits, strip_text_content, redact_names_and_urls
+                                api_pr,
+                                nrm_commits,
+                                self.config.git_strip_text_content,
+                                self.config.git_redact_names_and_urls,
                             )
                         except Exception as e:
                             # if something goes wrong with normalizing one of the prs - don't stop pulling. try

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -184,6 +184,8 @@ ValidatedConfig = namedtuple(
         'git_url',
         'git_include_projects',
         'git_exclude_projects',
+        'git_include_bbcloud_projects',
+        'git_exclude_bbcloud_projects',
         'git_include_repos',
         'git_exclude_repos',
         'git_strip_text_content',
@@ -277,6 +279,8 @@ def obtain_config(args):
     git_url = git_config.get('url', None)
     git_include_projects = set(git_config.get('include_projects', []))
     git_exclude_projects = set(git_config.get('exclude_projects', []))
+    git_include_bbcloud_projects = set(git_config.get('include_bitbucket_cloud_projects', []))
+    git_exclude_bbcloud_projects = set(git_config.get('exclude_bitbucket_cloud_projects', []))
     git_include_repos = set(git_config.get('include_repos', []))
     git_exclude_repos = set(git_config.get('exclude_repos', []))
     git_strip_text_content = git_config.get('strip_text_content', False)
@@ -404,6 +408,8 @@ def obtain_config(args):
         git_url,
         git_include_projects,
         git_exclude_projects,
+        git_include_bbcloud_projects,
+        git_exclude_bbcloud_projects,
         git_include_repos,
         git_exclude_repos,
         git_strip_text_content,


### PR DESCRIPTION
This adds a configuration option to filter on bitbucket cloud projects.

This is a bit messy, because we already have `include_projects` for git, which in the case of Bitbucket Cloud, maps to top-level organization to connect to.  And other providers don't have a perfectly analogous thing.