### PR TITLE
OJ 8347 - catch additional error

### DIFF
--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -321,6 +321,11 @@ def get_pull_requests(
                 except RetryError as e:
                     print(f"Could not retrieve diff data for {pr['id']}")
                     additions, deletions, changed_files = None, None, None
+                except stashy.errors.GenericException as e:
+                    agent_logging.log_and_print(
+                        logger, logging.INFO, f'Got error {e} on diffs for repo {pr["id"]}, skipping...'
+                    )
+                    additions, deletions, changed_files = None, None, None
                 else:
                     additions, deletions, changed_files = 0, 0, 0
 

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -323,7 +323,9 @@ def get_pull_requests(
                     additions, deletions, changed_files = None, None, None
                 except stashy.errors.GenericException as e:
                     agent_logging.log_and_print(
-                        logger, logging.INFO, f'Got error {e} on diffs for repo {pr["id"]}, skipping...'
+                        logger,
+                        logging.INFO,
+                        f'Got error {e} on diffs for repo {pr["id"]}, skipping...',
                     )
                     additions, deletions, changed_files = None, None, None
                 else:


### PR DESCRIPTION
This error is arising for a user; print and log it, then move on instead of crashing.