### PR TITLE
OJ-8692: Upload agent build timestamp to S3, along with SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM python:3.7.4-slim
 ARG SHA=develop
 ENV SHA="${SHA}"
 
+ARG BUILDTIME=unknown
+ENV BUILDTIME="${BUILDTIME}"
+
 COPY --from=py-deps /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 RUN pip install awscli && \
     mkdir -p /home/jf_agent && \
@@ -18,10 +21,6 @@ COPY --chown=jf_agent:jf_agent . /home/jf_agent
 RUN rm /home/jf_agent/Pipfile /home/jf_agent/Pipfile.lock
 WORKDIR /home/jf_agent
 ENV PYTHONPATH=/home/jf_agent
-
-# Run as last command to prevent caching
-ARG TIMESTAMP=$(date -u "+%Y%m%dT%H%M%SZ")
-ENV BUILD_TIMESTAMP="${TIMESTAMP}"
 
 USER jf_agent
 ENTRYPOINT ["python", "jf_agent/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,10 @@ COPY --chown=jf_agent:jf_agent . /home/jf_agent
 RUN rm /home/jf_agent/Pipfile /home/jf_agent/Pipfile.lock
 WORKDIR /home/jf_agent
 ENV PYTHONPATH=/home/jf_agent
+
+# Run as last command to prevent caching
+ARG TIMESTAMP=$(date -u "+%Y%m%dT%H%M%SZ")
+ENV BUILD_TIMESTAMP="${TIMESTAMP}"
+
 USER jf_agent
 ENTRYPOINT ["python", "jf_agent/main.py"]

--- a/hooks/build
+++ b/hooks/build
@@ -1,3 +1,6 @@
 #!/bin/bash
-
-docker build --build-arg SHA="$(git rev-parse HEAD)" -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build \
+       --build-arg SHA="$(git rev-parse HEAD)" \
+       --build-arg BUILDTIME="$(date -u '+%Y%m%dT%H%M%SZ')" \
+       -f "$DOCKERFILE_PATH" \
+       -t "$IMAGE_NAME" .

--- a/jf_agent/diagnostics.py
+++ b/jf_agent/diagnostics.py
@@ -27,8 +27,7 @@ def _write_diagnostic(obj):
 def capture_agent_version():
     git_head_hash = os.getenv('SHA')
     build_timestamp = os.getenv('BUILDTIME')
-    _write_diagnostic({'type': 'agent_version', 'sha': git_head_hash})
-    _write_diagnostic({'type': 'agent_version', 'timestamp': build_timestamp})
+    _write_diagnostic({'type': 'agent_version', 'sha': git_head_hash, 'timestamp': build_timestamp})
 
 
 def capture_timing(*args, **kwargs):

--- a/jf_agent/diagnostics.py
+++ b/jf_agent/diagnostics.py
@@ -23,7 +23,9 @@ def _write_diagnostic(obj):
 
 def capture_agent_version():
     git_head_hash = os.getenv('SHA')
+    build_timestamp = os.getenv('BUILD_TIMESTAMP')
     _write_diagnostic({'type': 'agent_version', 'sha': git_head_hash})
+    _write_diagnostic({'type': 'agent_version', 'timestamp': build_timestamp})
 
 
 def capture_timing(*args, **kwargs):

--- a/jf_agent/diagnostics.py
+++ b/jf_agent/diagnostics.py
@@ -26,7 +26,7 @@ def _write_diagnostic(obj):
 
 def capture_agent_version():
     git_head_hash = os.getenv('SHA')
-    build_timestamp = os.getenv('BUILD_TIMESTAMP')
+    build_timestamp = os.getenv('BUILDTIME')
     _write_diagnostic({'type': 'agent_version', 'sha': git_head_hash})
     _write_diagnostic({'type': 'agent_version', 'timestamp': build_timestamp})
 


### PR DESCRIPTION
Allows for more detailed messaging to be logged by the Jellyfish API. 