### PR TITLE
OJ-8923: Use repos_dict_v2 instead of repos_dict in pull_since_date_for_repo

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -343,7 +343,7 @@ def pull_since_date_for_repo(instance_info, org_login, repo_id, commits_or_prs: 
     assert commits_or_prs in ('commits', 'prs')
 
     instance_pull_from_dt = pytz.utc.localize(datetime.fromisoformat(instance_info['pull_from']))
-    instance_info_this_repo = instance_info['repos_dict'].get(f'{org_login}-{repo_id}')
+    instance_info_this_repo = instance_info['repos_dict_v2'].get(repo_id)
 
     if instance_info_this_repo:
         if commits_or_prs == 'commits':


### PR DESCRIPTION
Use repos_dict_v2 instead of repos_dict in pull_since_date_for_repo; this is keyed by repo_id instead of by org_login-repo_id