### PR TITLE
OJ-9295 - Raise exception instead of logging when config missing required fields

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -142,19 +142,15 @@ def obtain_config(args) -> ValidatedConfig:
     if jira_include_fields:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
-            logger.warning(
-                f'Missing recommended jira_fields! For the best possible experience, '
+            raise Exception(f'Missing recommended jira_fields! For the best possible experience, '
                 f'please add the following to `include_fields` in the '
-                f'configuration file: {list(missing_required_fields)}'
-            )
+                f'configuration file: {list(missing_required_fields)}')
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
-            logger.warning(
-                f'Excluding recommended jira_fields! For the best possible experience, '
+            raise Exception(f'Excluding recommended jira_fields! For the best possible experience, '
                 f'please remove the following from `exclude_fields` in the '
-                f'configuration file: {list(excluded_required_fields)}'
-            )
+                f'configuration file: {list(excluded_required_fields)}')
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -142,13 +142,13 @@ def obtain_config(args) -> ValidatedConfig:
     if jira_include_fields:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
-            raise Exception(f'Missing recommended jira_fields! For the best possible experience, '
+            raise BadConfigException(f'Missing recommended jira_fields! For the best possible experience, '
                 f'please add the following to `include_fields` in the '
                 f'configuration file: {list(missing_required_fields)}')
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
-            raise Exception(f'Excluding recommended jira_fields! For the best possible experience, '
+            raise BadConfigException(f'Excluding recommended jira_fields! For the best possible experience, '
                 f'please remove the following from `exclude_fields` in the '
                 f'configuration file: {list(excluded_required_fields)}')
 


### PR DESCRIPTION
To ensure workability, switch to raising an exception instead of just logging a warning when a company does not include a required jira field in their agent config file. 

Tested using company_specific config file.