### PR TITLE
[OJ-9467] Handle situation where gitlab gives back bogus approvals

### DIFF
--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -44,7 +44,6 @@ class GitLabClient:
         """
         Modifies the merge_request object by obtaining and adding the following attributes:
             - 'approved_by'     [object]
-            - 'approvers'       [object]
             - 'note_list'       [object]
             - 'commit_list'     [object]
             - 'target_project'  object
@@ -88,22 +87,20 @@ class GitLabClient:
             )
             merge_request.diff = ''
 
-        approvals = None
         try:
             approvals = merge_request.approvals.get()
             merge_request.approved_by = approvals.approved_by
-            merge_request.approvers = approvals.approvers
-        except (requests.exceptions.RetryError, gitlab.exceptions.GitlabGetError, AttributeError) as e:
+        except (
+            requests.exceptions.RetryError,
+            gitlab.exceptions.GitlabGetError,
+            AttributeError,
+        ) as e:
             log_and_print_request_error(
                 e,
                 f'fetching approvals for merge_request {merge_request.id} -- '
                 f'handling it as if it has no approvals',
             )
-            merge_request.approved_by = merge_request.approved_by if merge_request.approved_by else []
-            merge_request.approvals = merge_request.approvals if merge_request.approvals else []
-            # OJ-8678: Diagnostics for AttributeError
-            print(f'DIAGNOSTIC: Merge Request = {merge_request}')
-            print(f'DIAGNOSTIC: Approvals = {approvals}')
+            merge_request.approved_by = []
 
         # convert the 'commit_list' generator into a list of objects
         merge_request.commit_list = merge_request.commits()


### PR DESCRIPTION
Removes some wonky error handling, remove unused `merge_request.approvers` variable. This seems to be something that happens in older versions of GitLab.