### PR TITLE
OJ-9792: Changes to introduce merge_commits

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -130,6 +130,7 @@ class NormalizedPullRequest:
     author: NormalizedUser
     merged_by: NormalizedUser
     commits: List[NormalizedCommit]
+    merge_commit: NormalizedCommit
     comments: List[NormalizedPullRequestComment]
     approvals: List[NormalizedPullRequestReview]
     base_repo: NormalizedShortRepository

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -443,7 +443,12 @@ def _normalize_pr(
         _normalize_commit(c, repo, strip_text_content, redact_names_and_urls)
         for c in client.pr_commits(repo.project.id, repo.id, api_pr['id'])
     ]
-    if api_pr['state'] == 'MERGED' and api_pr['merge_commit'].get('hash'):
+    if (
+        api_pr['state'] == 'MERGED'
+        and 'merge_commit' in api_pr
+        and api_pr['merge_commit']
+        and api_pr['merge_commit'].get('hash')
+    ):
         api_merge_commit = client.get_commit(
             repo.project.id,
             api_pr['source']['repository']['uuid'],

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -443,6 +443,13 @@ def _normalize_pr(
         _normalize_commit(c, repo, strip_text_content, redact_names_and_urls)
         for c in client.pr_commits(repo.project.id, repo.id, api_pr['id'])
     ]
+    if api_pr['state'] == 'MERGED' and api_pr['merge_commit'].get('hash'):
+        api_merge_commit = client.get_commit(
+            repo.organization.login,
+            api_pr['source']['repository']['uuid'],
+            api_pr['merge_commit']['hash']
+        )
+        merge_commit = _normalize_commit(api_merge_commit, repo, strip_text_content, redact_names_and_urls)
 
     # Repo links
     base_repo = _normalize_short_form_repo(
@@ -472,6 +479,7 @@ def _normalize_pr(
         merged_by=merged_by,
         approvals=approvals,
         commits=commits,
+        merge_commit=merge_commit,
         comments=comments,
     )
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -445,7 +445,7 @@ def _normalize_pr(
     ]
     if api_pr['state'] == 'MERGED' and api_pr['merge_commit'].get('hash'):
         api_merge_commit = client.get_commit(
-            repo.organization.login,
+            repo.project.id,
             api_pr['source']['repository']['uuid'],
             api_pr['merge_commit']['hash']
         )

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -443,6 +443,7 @@ def get_pull_requests(
                     'merge_date': merge_date,
                     'merged_by': merged_by,
                     'commits': commits,
+                    'merge_commit': None,
                 }
 
                 yield normalized_pr

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -1,7 +1,7 @@
 from dateutil import parser
 import logging
 from tqdm import tqdm
-import traceback
+
 from jf_agent.git import GithubClient
 from jf_agent.git import pull_since_date_for_repo
 from jf_agent.name_redactor import NameRedactor, sanitize_text
@@ -379,5 +379,5 @@ def get_pull_requests(
                         yield _normalize_pr(client, pr, strip_text_content, redact_names_and_urls)
 
             except Exception as e:
-                print(f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. {traceback.format_exc()} Skipping...')
+                print(f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...')
     print()

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -133,7 +133,6 @@ class GitLabAdapter(GitAdapter):
 
             # if there were any repositories we had issues with... print them out now.
             if repos_that_failed_to_download:
-
                 def __repo_log_string(api_repo):
                     # build log string
                     name = (
@@ -279,12 +278,24 @@ class GitLabAdapter(GitAdapter):
                                 )
                                 for commit in api_pr.commit_list
                             ]
+                            merge_request = self.client.expand_merge_request_data(api_pr)
+                            merge_commit = None
+                            if merge_request.state == 'merged' and nrm_commits is not None and merge_request.merge_commit_sha:
+                                merge_commit = _normalize_commit(
+                                    self.client.get_project_commit(
+                                        merge_request.project_id, merge_request.merge_commit_sha
+                                    ),
+                                    nrm_repo,
+                                    self.config.git_strip_text_content,
+                                    self.config.git_redact_names_and_urls,
+                                )
 
                             yield _normalize_pr(
                                 api_pr,
                                 nrm_commits,
                                 self.config.git_strip_text_content,
                                 self.config.git_redact_names_and_urls,
+                                merge_commit
                             )
                         except Exception as e:
                             # if something goes wrong with normalizing one of the prs - don't stop pulling. try
@@ -355,10 +366,10 @@ def _normalize_branch(api_branch, redact_names_and_urls: bool) -> NormalizedBran
 
 
 def _normalize_repo(
-    api_repo,
-    normalized_branches: List[NormalizedBranch],
-    normalized_project: NormalizedProject,
-    redact_names_and_urls: bool,
+        api_repo,
+        normalized_branches: List[NormalizedBranch],
+        normalized_project: NormalizedProject,
+        redact_names_and_urls: bool,
 ) -> NormalizedRepository:
     repo_name = (
         api_repo.name if not redact_names_and_urls else _repo_redactor.redact_name(api_repo.name)
@@ -388,7 +399,7 @@ def _normalize_short_form_repo(api_repo, redact_names_and_urls):
 
 
 def _normalize_commit(
-    api_commit, normalized_repo, strip_text_content: bool, redact_names_and_urls: bool
+        api_commit, normalized_repo, strip_text_content: bool, redact_names_and_urls: bool
 ):
     author = NormalizedUser(
         id=f'{api_commit.author_name}<{api_commit.author_email}>',
@@ -412,7 +423,7 @@ def _normalize_commit(
 
 
 def _get_normalized_pr_comments(
-    merge_request, strip_text_content
+        merge_request, strip_text_content
 ) -> List[NormalizedPullRequestComment]:
     try:
         return [
@@ -453,10 +464,11 @@ def _get_normalized_approvals(merge_request):
 
 
 def _normalize_pr(
-    merge_request,
-    normalized_commits: List[NormalizedCommit],
-    strip_text_content: bool,
-    redact_names_and_urls: bool,
+        merge_request,
+        normalized_commits: List[NormalizedCommit],
+        strip_text_content: bool,
+        redact_names_and_urls: bool,
+        merge_commit
 ):
     base_branch_name = merge_request.target_branch
     head_branch_name = merge_request.source_branch
@@ -498,6 +510,7 @@ def _normalize_pr(
         body=sanitize_text(merge_request.description, strip_text_content),
         # normalized fields
         commits=normalized_commits,
+        merge_commit=merge_commit,
         author=_normalize_user(merge_request.author),
         merged_by=_normalize_user(merge_request.merged_by),
         approvals=_get_normalized_approvals(merge_request),

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -139,3 +139,10 @@ class GitLabClient:
     def list_project_commits(self, project_id, since_date):
         project = self.get_project(project_id)
         return project.commits.list(since=since_date, as_list=False)
+
+    def get_project_commit(self, project_id, sha):
+        project = self.get_project(project_id)
+        try:
+            return project.commits.get(sha)
+        except gitlab.exceptions.GitlabGetError:
+            return None


### PR DESCRIPTION
### Description:
This provides support to agent for collecting merge_commit data as a component of git data for Github, Gitlab and Bitbucket Cloud. This is inversely queried by JFGithubCommit.merged_pull_requests. Useful for tracking the commit on the base branch that a PR resulted in.

Bitbucket server does not support getting this information, but it is added here for github, gitlab, and bitbucket cloud. 

### Testing Strategy:
Tested with our Github, Gitlab and bitbucket cloud