### PR TITLE
OJ-10070: Support bitbucket cloud PRs with no merge commit

### DIFF
--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -443,6 +443,7 @@ def _normalize_pr(
         _normalize_commit(c, repo, strip_text_content, redact_names_and_urls)
         for c in client.pr_commits(repo.project.id, repo.id, api_pr['id'])
     ]
+    merge_commit = None
     if (
         api_pr['state'] == 'MERGED'
         and 'merge_commit' in api_pr
@@ -455,6 +456,7 @@ def _normalize_pr(
             api_pr['merge_commit']['hash']
         )
         merge_commit = _normalize_commit(api_merge_commit, repo, strip_text_content, redact_names_and_urls)
+
 
     # Repo links
     base_repo = _normalize_short_form_repo(


### PR DESCRIPTION
### Description:
With the recent change to include merge_commit data, I'd failed to account for the case where we receive no merge_commit data for Bitbucket Cloud. This resulted in PRs being dropped when the data was missing. This fixes that issue by setting merge_commit to None initially.

### Testing Strategy:
Local with Orthog bitbucket cloud
