### PR TITLE
[OJ-9533] - Classify errors in the agent

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -65,7 +65,7 @@ def log_loop_iters(
 # Represents the classification of the logging error/warning/info.
 # Provides a way of understanding what groups of people the errors relate to.
 ERROR_MESSAGES = {
-    '000': 'Null Classification',
+    '000': 'Unclassified',
     '100': 'Success General', # General Customer Success Errors
     '200': 'Client', # General Client Errors
     '201': 'Client Config', # Client Errors related to their configuration
@@ -78,7 +78,6 @@ def log_and_print(logger, level, msg, error_code: str = '000', exc_info=False):
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
-    msg = f'[{error_code}] {msg}'
     if level != logging.INFO:  # Don’t care to track codes for info-level logging
         error_message = ERROR_MESSAGES.get(error_code, 'Null Classfication')
         msg = f'[{error_code} - {error_message}] {msg}'

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -73,7 +73,7 @@ ERROR_MESSAGES = {
     '300': 'Engineering', # General Engineering Errors
 }
 
-def log_and_print(logger, level, msg, error_code: str, exc_info=False):
+def log_and_print(logger, level, msg, error_code: str = '000', exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -115,23 +115,23 @@ ERROR_MESSAGES = {
 }
 
 
-def log_and_print(logger, level, msg, exc_info=False):
+def log_and_print(logger, level, msg):
     '''
     For an info-level message that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
-    logger.log(level, msg, exc_info=exc_info)
+    logger.log(level, msg)
     print(msg, flush=True)
-    if exc_info:
-        print(traceback.format_exc())
 
 
-def log_and_print_error_or_warning(logger, level, error_code, msg_args=[]):
+def log_and_print_error_or_warning(logger, level, error_code, msg_args=[], exc_info=False):
     '''
     For a failure that should be sent to the logger with an error_code, and also written
     to stdout (for user visibility)
     '''
     assert level >= logger.WARNING
     msg = f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}'
-    logger.log(level, msg)
+    logger.log(level, msg, exc_info=exc_info)
     print(msg, flush=True)
+    if exc_info:
+        print(traceback.format_exc())

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -62,6 +62,7 @@ def log_loop_iters(
     else:
         yield
 
+
 # Mapping of error/warning codes to templated error messages to be called by
 # log_and_print_error_or_warning(). This allows for Jellyfish to better categorize errors/warnings.
 ERROR_MESSAGES = {
@@ -69,18 +70,16 @@ ERROR_MESSAGES = {
     3010: 'Rate limiter: thought we were operating within our limit (made {}/{} calls for {}), but got HTTP 429 anyway!',
     3020: 'Next available time to make call is after the timeout of {} seconds. Giving up.',
     3030: 'ERROR: Could not parse response with status code {}. Contact an administrator for help.',
-    3001: 'PR {} doesn\'t reference a source and/or destination repository; skipping it...',
     3011: 'Error normalizing PR {} from repo {}. Skipping...',
     3021: 'Error getting PRs for repo {}. Skipping...',
     3031: 'Unable to parse the diff For PR {} in repo {}; proceeding as though no files were changed.',
-    3041: 'For PR {} in repo {}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' 'proceeding as though no files were changed',
+    3041: 'For PR {} in repo {}, caught HTTPError (HTTP 401) when attempting to retrieve changes; '
+    'proceeding as though no files were changed',
     3051: 'For PR {} in repo {}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
     3061: 'Failed to download {} data:\n{}',
-    3071: 'ValueError: {} is not a supported git_provider for this run_mode',
     3081: 'Got unexpected HTTP 403 for repo {}.  Skipping...',
     3091: 'Github rate limit exceeded.  Trying again in {}...',
     3101: 'Request to {} has failed {} times -- giving up!',
-    3111: 'Expected an array of json results, but got: {}',
     3121: 'Got HTTP {} when fetching commit {} for "{}", this likely means you are trying to fetch an invalid re',
     3131: 'Got {} {} when {} ({})',
     3141: 'Got {} {} when {}',
@@ -94,29 +93,31 @@ ERROR_MESSAGES = {
     3062: 'Apparently unable to fetch issue based on search_params {}',
     3072: 'Error calling createmeta JIRA endpoint',
     3082: 'OJ-9084: Changelog history item with no \'fieldId\' or \'field\' key: {}',
-    2000: ('''ERROR: Mode should be one of "{}"'''),
     2101: 'Failed to connect to {}:\n{}',
     2102: 'Unable to access project {}, may be a Jira misconfiguration. Skipping...',
     2112: 'Failed to connect to Jira:\n{}',
     2122: 'you do not have the required \'development field\' permissions in jira required to scan for missing repos',
     2132: (
-            'Missing recommended jira_fields! For the best possible experience, '
-            'please add the following to `include_fields` in the '
-            'configuration file: {}'
-        ),
+        'Missing recommended jira_fields! For the best possible experience, '
+        'please add the following to `include_fields` in the '
+        'configuration file: {}'
+    ),
     2142: (
-            'Excluding recommended jira_fields! For the best possible experience, '
-            'please remove the following from `exclude_fields` in the '
-            'configuration file: {}',
-        ),
-    2201: ('\nERROR: Failed to download ({}) repo(s) from the group {}. '
-            'Please check that the appropriate permissions are set for the following repos... ({})'),
+        'Excluding recommended jira_fields! For the best possible experience, '
+        'please remove the following from `exclude_fields` in the '
+        'configuration file: {}',
+    ),
+    2201: (
+        '\nERROR: Failed to download ({}) repo(s) from the group {}. '
+        'Please check that the appropriate permissions are set for the following repos... ({})'
+    ),
     2202: "You do not have the required permissions in jira required to fetch boards for the project {}",
 }
 
+
 def log_and_print(logger, level, msg, exc_info=False):
     '''
-    For a failure that should be sent to the logger, and also written
+    For an info-level message that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
     logger.log(level, msg, exc_info=exc_info)
@@ -125,13 +126,12 @@ def log_and_print(logger, level, msg, exc_info=False):
         print(traceback.format_exc())
 
 
-def log_and_print_error_or_warning(logger, level, error_code,msg_args=[], exc_info=False):
+def log_and_print_error_or_warning(logger, level, error_code, msg_args=[]):
     '''
-    For a failure that should be sent to the logger, and also written
+    For a failure that should be sent to the logger with an error_code, and also written
     to stdout (for user visibility)
     '''
-    msg = (f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}')
-    logger.log(level, msg, exc_info=exc_info)
+    assert level >= logger.WARNING
+    msg = f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}'
+    logger.log(level, msg)
     print(msg, flush=True)
-    if exc_info:
-        print(traceback.format_exc())

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -62,6 +62,8 @@ def log_loop_iters(
     else:
         yield
 
+# Mapping of error/warning codes to templated error messages to be called by
+# log_and_print_error_or_warning(). This allows for Jellyfish to better categorize errors/warnings.
 ERROR_MESSAGES = {
     3000: 'Failed to upload file {} to S3 bucket',
     3010: 'Rate limiter: thought we were operating within our limit (made {}/{} calls for {}), but got HTTP 429 anyway!',
@@ -93,10 +95,10 @@ ERROR_MESSAGES = {
     3072: 'Error calling createmeta JIRA endpoint',
     3082: 'OJ-9084: Changelog history item with no \'fieldId\' or \'field\' key: {}',
     2000: ('''ERROR: Mode should be one of "{}"'''),
-    2101: 'Failed to connect to {}:\n{}', # 201
-    2102: 'Unable to access project {}, may be a Jira misconfiguration. Skipping...', # 201
-    2112: 'Failed to connect to Jira:\n{}', # 201
-    2122: 'you do not have the required \'development field\' permissions in jira required to scan for missing repos', # 201
+    2101: 'Failed to connect to {}:\n{}',
+    2102: 'Unable to access project {}, may be a Jira misconfiguration. Skipping...',
+    2112: 'Failed to connect to Jira:\n{}',
+    2122: 'you do not have the required \'development field\' permissions in jira required to scan for missing repos',
     2132: (
             'Missing recommended jira_fields! For the best possible experience, '
             'please add the following to `include_fields` in the '

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -67,10 +67,10 @@ def log_loop_iters(
 ERROR_MESSAGES = {
     '000': 'Null Classification',
     '100': 'Success General', # General Customer Success Errors
-    '200': 'Client General', # General Client Errors
+    '200': 'Client', # General Client Errors
     '201': 'Client Config', # Client Errors related to their configuration
     '202': 'Client Permissions', # Client Error related to their permissions in Jira, Git, etc. or their config.
-    '300': 'Engineering General', # General Engineering Errors
+    '300': 'Engineering', # General Engineering Errors
 }
 
 def log_and_print(logger, level, msg, error_code: str, exc_info=False):

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -67,9 +67,9 @@ def log_loop_iters(
 ERROR_MESSAGES = {
     '000': 'Unclassified',
     '100': 'Success General', # General Customer Success Errors
-    '200': 'Client', # General Client Errors
-    '201': 'Client Config', # Client Errors related to their configuration
-    '202': 'Client Permissions', # Client Error related to their permissions in Jira, Git, etc. or their config.
+    '200': 'Customer', # General Customer Errors
+    '201': 'Customer Config', # Customer Errors related to their configuration
+    '202': 'Customer Permissions', # Customer Error related to their permissions in Jira, Git, etc. or their config.
     '300': 'Engineering', # General Engineering Errors
 }
 

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -68,25 +68,25 @@ def log_loop_iters(
 # 1XX : SUCCESS
 # 1XX : ENGINEERING
 # 1XX : CLIENT
+# XX0 : GENERAL
 # XX1 : CONFIG Related
-# XX2 : JIRA Related
-# XX3 : GIT Related
-# XX2 : INFRA Related
-class ErrorCodes(Enum):
-    NOT_DEFINED = 0
-    SUCCESS = 100
-    SUCCESS_CONFIG = 101 #
-    CLIENT = 200 #
-    CLIENT_CONFIG = 201 #
-    ENGINEERING = 300
-    ENGINEERING_CONFIG = 301 #
-    ENGINEERING_INFRA = 302 #
+# XX2 : PERMISSIONS Related
+class ErrorClassification(Enum):
+    NOT_DEFINED = 'Null Classification'
+    SUCCESS = 'Success General'
+    SUCCESS_CONFIG = 'Success Config' #
+    CLIENT = 'Client General' #
+    CLIENT_CONFIG = 'Client Config' #
+    CLIENT_PERMISSIONS = 'Client Permissions' #
+    ENGINEERING = 'Engineering General'
+    ENGINEERING_CONFIG = 'Engineering Config' #
 
-def log_and_print(logger, level, msg, status: ErrorCodes = ErrorCodes.NOT_DEFINED, exc_info=False):
+def log_and_print(logger, level, msg, error_classification: ErrorClassification = ErrorClassification.NOT_DEFINED, exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
+    msg = f'[{error_classification}] {msg}'
     logger.log(level, msg, exc_info=exc_info)
     print(msg, flush=True)
     if exc_info:

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -63,23 +63,26 @@ def log_loop_iters(
     else:
         yield
 
-
 # Represents the classification of the logging error/warning/info.
 # Provides a way of understanding what groups of people the errors relate to.
-class ErrorClassification(Enum):
-    NOT_DEFINED = 'Null Classification'
-    SUCCESS = 'Success General' # General Customer Success Errors
-    CLIENT = 'Client General' # General Client Errors
-    CLIENT_CONFIG = 'Client Config' # Client Errors related to their configuration
-    CLIENT_PERMISSIONS = 'Client Permissions' # Client Error related to their permissions in Jira, Git, etc. or their config.
-    ENGINEERING = 'Engineering General' # General Engineering Errors
+ERROR_MESSAGES = {
+    '000': 'Null Classification',
+    '100': 'Success General', # General Customer Success Errors
+    '200': 'Client General', # General Client Errors
+    '201': 'Client Config', # Client Errors related to their configuration
+    '202': 'Client Permissions', # Client Error related to their permissions in Jira, Git, etc. or their config.
+    '300': 'Engineering General', # General Engineering Errors
+}
 
-def log_and_print(logger, level, msg, error_classification: ErrorClassification = ErrorClassification.NOT_DEFINED, exc_info=False):
+def log_and_print(logger, level, msg, error_code: str, exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
-    msg = f'[{error_classification}] {msg}'
+    msg = f'[{error_code}] {msg}'
+    if level != logging.INFO:  # Don’t care to track codes for info-level logging
+        error_message = ERROR_MESSAGES.get(error_code, 'Null Classfication')
+        msg = f'[{error_code} - {error_message}] {msg}'
     logger.log(level, msg, exc_info=exc_info)
     print(msg, flush=True)
     if exc_info:

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -64,22 +64,15 @@ def log_loop_iters(
         yield
 
 
-
-# 1XX : SUCCESS
-# 1XX : ENGINEERING
-# 1XX : CLIENT
-# XX0 : GENERAL
-# XX1 : CONFIG Related
-# XX2 : PERMISSIONS Related
+# Represents the classification of the logging error/warning/info.
+# Provides a way of understanding what groups of people the errors relate to.
 class ErrorClassification(Enum):
     NOT_DEFINED = 'Null Classification'
-    SUCCESS = 'Success General'
-    SUCCESS_CONFIG = 'Success Config' #
-    CLIENT = 'Client General' #
-    CLIENT_CONFIG = 'Client Config' #
-    CLIENT_PERMISSIONS = 'Client Permissions' #
-    ENGINEERING = 'Engineering General'
-    ENGINEERING_CONFIG = 'Engineering Config' #
+    SUCCESS = 'Success General' # General Customer Success Errors
+    CLIENT = 'Client General' # General Client Errors
+    CLIENT_CONFIG = 'Client Config' # Client Errors related to their configuration
+    CLIENT_PERMISSIONS = 'Client Permissions' # Client Error related to their permissions in Jira, Git, etc. or their config.
+    ENGINEERING = 'Engineering General' # General Engineering Errors
 
 def log_and_print(logger, level, msg, error_classification: ErrorClassification = ErrorClassification.NOT_DEFINED, exc_info=False):
     '''

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -65,7 +65,7 @@ def log_loop_iters(
 # Represents the classification of the logging error/warning/info.
 # Provides a way of understanding what groups of people the errors relate to.
 ERROR_MESSAGES = {
-    '000': 'Unclassified',
+    000: 'Unclassified',
     '100': 'Success General', # General Customer Success Errors
     '200': 'Customer', # General Customer Errors
     '201': 'Customer Config', # Customer Errors related to their configuration
@@ -73,7 +73,65 @@ ERROR_MESSAGES = {
     '300': 'Engineering', # General Engineering Errors
 }
 
-def log_and_print(logger, level, msg, error_code: str = '000', exc_info=False):
+{
+    3000: f'Failed to upload file {filename} to S3 bucket',
+    3001: f'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
+    3100: f'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
+    3101: f'Next available time to make call is after the timeout of {self.timeout_secs} seconds. Giving up.',
+    3200: f'PR {api_pr['id']} doesn't reference a source and/or destination repository; skipping it...',
+    3201: f'Error normalizing PR {api_pr["id"]} from repo {repo.id}. Skipping...',
+    3202: f'Error getting PRs for repo {repo.id}. Skipping...',
+    3203: f'Unable to parse the diff For PR {api_pr["id"]} in repo {repo.id}; proceeding as though no files were changed.',
+    3204: f'For PR {api_pr["id"]} in repo {repo.id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' f'proceeding as though no files were changed',
+    3205: f'For PR {api_pr["id"]} in repo {repo.id}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
+    3300: f'Failed to download {config.git_provider} data:\n{e}',
+    3301: f'ValueError: {config.git_provider} is not a supported git_provider for this run_mode',
+    3400: f'Got unexpected HTTP 403 for repo {m["url"]}.  Skipping...',
+    3401: f'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
+    3402: f'Expected an array of json results, but got: {page}',
+    3403: f'Got HTTP {e.response.status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid ref',
+    3500: f'Got {error_name} {response_code} when {action} ({e})',
+    3501: f'Got {error_name} {response_code} when {action}',
+    3600: f'Failed to download jira data:\n{e}',
+    3700: f'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
+    3701: 'Caught KeyError from search_issues(), batch size is already 0, bailing out',
+    3702: f'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
+    3800: 'Getting HTTP 429s for over an hour; giving up!',
+    3900: f'[Thread {thread_num}] Jira issue downloader FAILED',
+    3901: f'JIRAError ({e}), reducing batch size to {batch_size}',
+    3902: f'Apparently unable to fetch issue based on search_params {search_params}',
+    3903: 'Error calling createmeta JIRA endpoint',
+    2000: (f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''),
+    2100: f'Failed to connect to {config.git_provider}:\n{e}', # 201
+    2101: f'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...', # 201
+    2102: f'Failed to connect to Jira:\n{e}', # 201
+    2103: "you do not have the required 'development field' permissions in jira required to scan for missing repos", # 201
+    2104: (
+            f'Missing recommended jira_fields! For the best possible experience, '
+            f'please add the following to `include_fields` in the '
+            f'configuration file: {list(missing_required_fields)}'
+        ),
+    2105: (
+            f'Excluding recommended jira_fields! For the best possible experience, '
+            f'please remove the following from `exclude_fields` in the '
+            f'configuration file: {list(excluded_required_fields)}',
+        ),
+    2200: (f'\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project.id}. '
+            f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'),
+    2201: f"You do not have the required permissions in jira required to fetch boards for the project {project_id}",
+}
+
+def log_and_print(logger, level, msg, exc_info=False):
+    '''
+    For a failure that should be sent to the logger, and also written
+    to stdout (for user visibility)
+    '''
+    logger.log(level, msg, exc_info=exc_info)
+    print(msg, flush=True)
+    if exc_info:
+        print(traceback.format_exc())
+
+def log_and_print_error_or_warning(logger, level, msg_args=None, error_code=None, exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
+from enum import Enum
 import traceback
 
 '''
@@ -63,7 +64,25 @@ def log_loop_iters(
         yield
 
 
-def log_and_print(logger, level, msg, exc_info=False):
+
+# 1XX : SUCCESS
+# 1XX : ENGINEERING
+# 1XX : CLIENT
+# XX1 : CONFIG Related
+# XX2 : JIRA Related
+# XX3 : GIT Related
+# XX2 : INFRA Related
+class ErrorCodes(Enum):
+    NOT_DEFINED = 0
+    SUCCESS = 100
+    SUCCESS_CONFIG = 101 #
+    CLIENT = 200 #
+    CLIENT_CONFIG = 201 #
+    ENGINEERING = 300
+    ENGINEERING_CONFIG = 301 #
+    ENGINEERING_INFRA = 302 #
+
+def log_and_print(logger, level, msg, status: ErrorCodes = ErrorCodes.NOT_DEFINED, exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
-from enum import Enum
 import traceback
 
 '''

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -62,63 +62,54 @@ def log_loop_iters(
     else:
         yield
 
-# Represents the classification of the logging error/warning/info.
-# Provides a way of understanding what groups of people the errors relate to.
 ERROR_MESSAGES = {
-    000: 'Unclassified',
-    '100': 'Success General', # General Customer Success Errors
-    '200': 'Customer', # General Customer Errors
-    '201': 'Customer Config', # Customer Errors related to their configuration
-    '202': 'Customer Permissions', # Customer Error related to their permissions in Jira, Git, etc. or their config.
-    '300': 'Engineering', # General Engineering Errors
-}
-
-{
-    3000: f'Failed to upload file {filename} to S3 bucket',
-    3001: f'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
-    3100: f'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
-    3101: f'Next available time to make call is after the timeout of {self.timeout_secs} seconds. Giving up.',
-    3200: f'PR {api_pr['id']} doesn't reference a source and/or destination repository; skipping it...',
-    3201: f'Error normalizing PR {api_pr["id"]} from repo {repo.id}. Skipping...',
-    3202: f'Error getting PRs for repo {repo.id}. Skipping...',
-    3203: f'Unable to parse the diff For PR {api_pr["id"]} in repo {repo.id}; proceeding as though no files were changed.',
-    3204: f'For PR {api_pr["id"]} in repo {repo.id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' f'proceeding as though no files were changed',
-    3205: f'For PR {api_pr["id"]} in repo {repo.id}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
-    3300: f'Failed to download {config.git_provider} data:\n{e}',
-    3301: f'ValueError: {config.git_provider} is not a supported git_provider for this run_mode',
-    3400: f'Got unexpected HTTP 403 for repo {m["url"]}.  Skipping...',
-    3401: f'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
-    3402: f'Expected an array of json results, but got: {page}',
-    3403: f'Got HTTP {e.response.status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid ref',
-    3500: f'Got {error_name} {response_code} when {action} ({e})',
-    3501: f'Got {error_name} {response_code} when {action}',
-    3600: f'Failed to download jira data:\n{e}',
-    3700: f'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
-    3701: 'Caught KeyError from search_issues(), batch size is already 0, bailing out',
-    3702: f'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
-    3800: 'Getting HTTP 429s for over an hour; giving up!',
-    3900: f'[Thread {thread_num}] Jira issue downloader FAILED',
-    3901: f'JIRAError ({e}), reducing batch size to {batch_size}',
-    3902: f'Apparently unable to fetch issue based on search_params {search_params}',
-    3903: 'Error calling createmeta JIRA endpoint',
-    2000: (f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''),
-    2100: f'Failed to connect to {config.git_provider}:\n{e}', # 201
-    2101: f'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...', # 201
-    2102: f'Failed to connect to Jira:\n{e}', # 201
-    2103: "you do not have the required 'development field' permissions in jira required to scan for missing repos", # 201
-    2104: (
-            f'Missing recommended jira_fields! For the best possible experience, '
-            f'please add the following to `include_fields` in the '
-            f'configuration file: {list(missing_required_fields)}'
+    3000: 'Failed to upload file {filename} to S3 bucket',
+    3010: 'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
+    3020: 'Next available time to make call is after the timeout of {timeout_secs} seconds. Giving up.',
+    3030: 'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
+    3001: 'PR {id} doesn\'t reference a source and/or destination repository; skipping it...',
+    3011: 'Error normalizing PR {id} from repo {id}. Skipping...',
+    3021: 'Error getting PRs for repo {id}. Skipping...',
+    3031: 'Unable to parse the diff For PR {id} in repo {id}; proceeding as though no files were changed.',
+    3041: 'For PR {id} in repo {id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' 'proceeding as though no files were changed',
+    3051: 'For PR {id} in repo {id}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
+    3061: 'Failed to download {git_provider} data:\n{e}',
+    3071: 'ValueError: {git_provider} is not a supported git_provider for this run_mode',
+    3081: 'Got unexpected HTTP 403 for repo {url}.  Skipping...',
+    3091: 'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
+    3101: 'Request to {url} has failed {i} times -- giving up!',
+    3111: 'Expected an array of json results, but got: {page}',
+    3121: 'Got HTTP {response_status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid re',
+    3131: 'Got {error_name} {response_code} when {action} ({e})',
+    3141: 'Got {error_name} {response_code} when {action}',
+    3151: 'Getting HTTP 429s for over an hour; giving up!',
+    3002: 'Failed to download jira data:\n{e}',
+    3012: 'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
+    3022: 'Caught KeyError from search_issues(), batch size is already 0, bailing out',
+    3032: 'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
+    3042: '[Thread {thread_num}] Jira issue downloader FAILED',
+    3052: 'JIRAError ({e}), reducing batch size to {batch_size}',
+    3062: 'Apparently unable to fetch issue based on search_params {search_params}',
+    3072: 'Error calling createmeta JIRA endpoint',
+    3082: 'OJ-9084: Changelog history item with no \'fieldId\' or \'field\' key: {keys}',
+    2000: ('''ERROR: Mode should be one of "{VALID_RUN_MODES}"'''),
+    2101: 'Failed to connect to {git_provider}:\n{e}', # 201
+    2102: 'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...', # 201
+    2112: 'Failed to connect to Jira:\n{e}', # 201
+    2122: 'you do not have the required \'development field\' permissions in jira required to scan for missing repos', # 201
+    2132: (
+            'Missing recommended jira_fields! For the best possible experience, '
+            'please add the following to `include_fields` in the '
+            'configuration file: {missing_required_fields}'
         ),
-    2105: (
-            f'Excluding recommended jira_fields! For the best possible experience, '
-            f'please remove the following from `exclude_fields` in the '
-            f'configuration file: {list(excluded_required_fields)}',
+    2142: (
+            'Excluding recommended jira_fields! For the best possible experience, '
+            'please remove the following from `exclude_fields` in the '
+            'configuration file: {excluded_required_fields}',
         ),
-    2200: (f'\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project.id}. '
-            f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'),
-    2201: f"You do not have the required permissions in jira required to fetch boards for the project {project_id}",
+    2201: ('\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project_id}. '
+            'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'),
+    2202: "You do not have the required permissions in jira required to fetch boards for the project {project_id}",
 }
 
 def log_and_print(logger, level, msg, exc_info=False):
@@ -131,16 +122,14 @@ def log_and_print(logger, level, msg, exc_info=False):
     if exc_info:
         print(traceback.format_exc())
 
-def log_and_print_error_or_warning(logger, level, msg_args=None, error_code=None, exc_info=False):
+
+def log_and_print_error_or_warning(logger, level, error_code,msg_args=[], exc_info=False):
     '''
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
-    log_msg = msg
-    if level != logging.INFO:  # Don’t care to track codes for info-level logging
-        error_message = ERROR_MESSAGES.get(error_code, 'Null Classfication')
-        log_msg = f'[{error_code} - {error_message}] {msg}'
-    logger.log(level, log_msg, exc_info=exc_info)
+    msg = (f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}')
+    logger.log(level, msg, exc_info=exc_info)
     print(msg, flush=True)
     if exc_info:
         print(traceback.format_exc())

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -63,53 +63,53 @@ def log_loop_iters(
         yield
 
 ERROR_MESSAGES = {
-    3000: 'Failed to upload file {filename} to S3 bucket',
-    3010: 'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
-    3020: 'Next available time to make call is after the timeout of {timeout_secs} seconds. Giving up.',
-    3030: 'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
-    3001: 'PR {id} doesn\'t reference a source and/or destination repository; skipping it...',
-    3011: 'Error normalizing PR {id} from repo {id}. Skipping...',
-    3021: 'Error getting PRs for repo {id}. Skipping...',
-    3031: 'Unable to parse the diff For PR {id} in repo {id}; proceeding as though no files were changed.',
-    3041: 'For PR {id} in repo {id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' 'proceeding as though no files were changed',
-    3051: 'For PR {id} in repo {id}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
-    3061: 'Failed to download {git_provider} data:\n{e}',
-    3071: 'ValueError: {git_provider} is not a supported git_provider for this run_mode',
-    3081: 'Got unexpected HTTP 403 for repo {url}.  Skipping...',
-    3091: 'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
-    3101: 'Request to {url} has failed {i} times -- giving up!',
-    3111: 'Expected an array of json results, but got: {page}',
-    3121: 'Got HTTP {response_status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid re',
-    3131: 'Got {error_name} {response_code} when {action} ({e})',
-    3141: 'Got {error_name} {response_code} when {action}',
+    3000: 'Failed to upload file {} to S3 bucket',
+    3010: 'Rate limiter: thought we were operating within our limit (made {}/{} calls for {}), but got HTTP 429 anyway!',
+    3020: 'Next available time to make call is after the timeout of {} seconds. Giving up.',
+    3030: 'ERROR: Could not parse response with status code {}. Contact an administrator for help.',
+    3001: 'PR {} doesn\'t reference a source and/or destination repository; skipping it...',
+    3011: 'Error normalizing PR {} from repo {}. Skipping...',
+    3021: 'Error getting PRs for repo {}. Skipping...',
+    3031: 'Unable to parse the diff For PR {} in repo {}; proceeding as though no files were changed.',
+    3041: 'For PR {} in repo {}, caught HTTPError (HTTP 401) when attempting to retrieve changes; ' 'proceeding as though no files were changed',
+    3051: 'For PR {} in repo {}, caught UnicodeDecodeError when attempting to decode changes; proceeding as though no files were changed',
+    3061: 'Failed to download {} data:\n{}',
+    3071: 'ValueError: {} is not a supported git_provider for this run_mode',
+    3081: 'Got unexpected HTTP 403 for repo {}.  Skipping...',
+    3091: 'Github rate limit exceeded.  Trying again in {}...',
+    3101: 'Request to {} has failed {} times -- giving up!',
+    3111: 'Expected an array of json results, but got: {}',
+    3121: 'Got HTTP {} when fetching commit {} for "{}", this likely means you are trying to fetch an invalid re',
+    3131: 'Got {} {} when {} ({})',
+    3141: 'Got {} {} when {}',
     3151: 'Getting HTTP 429s for over an hour; giving up!',
-    3002: 'Failed to download jira data:\n{e}',
-    3012: 'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
+    3002: 'Failed to download jira data:\n{}',
+    3012: 'Caught KeyError from search_issues(), reducing batch size to {}',
     3022: 'Caught KeyError from search_issues(), batch size is already 0, bailing out',
-    3032: 'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
-    3042: '[Thread {thread_num}] Jira issue downloader FAILED',
-    3052: 'JIRAError ({e}), reducing batch size to {batch_size}',
-    3062: 'Apparently unable to fetch issue based on search_params {search_params}',
+    3032: 'Exception encountered in thread {}\n{}',
+    3042: '[Thread {}] Jira issue downloader FAILED',
+    3052: 'JIRAError ({}), reducing batch size to {}',
+    3062: 'Apparently unable to fetch issue based on search_params {}',
     3072: 'Error calling createmeta JIRA endpoint',
-    3082: 'OJ-9084: Changelog history item with no \'fieldId\' or \'field\' key: {keys}',
-    2000: ('''ERROR: Mode should be one of "{VALID_RUN_MODES}"'''),
-    2101: 'Failed to connect to {git_provider}:\n{e}', # 201
-    2102: 'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...', # 201
-    2112: 'Failed to connect to Jira:\n{e}', # 201
+    3082: 'OJ-9084: Changelog history item with no \'fieldId\' or \'field\' key: {}',
+    2000: ('''ERROR: Mode should be one of "{}"'''),
+    2101: 'Failed to connect to {}:\n{}', # 201
+    2102: 'Unable to access project {}, may be a Jira misconfiguration. Skipping...', # 201
+    2112: 'Failed to connect to Jira:\n{}', # 201
     2122: 'you do not have the required \'development field\' permissions in jira required to scan for missing repos', # 201
     2132: (
             'Missing recommended jira_fields! For the best possible experience, '
             'please add the following to `include_fields` in the '
-            'configuration file: {missing_required_fields}'
+            'configuration file: {}'
         ),
     2142: (
             'Excluding recommended jira_fields! For the best possible experience, '
             'please remove the following from `exclude_fields` in the '
-            'configuration file: {excluded_required_fields}',
+            'configuration file: {}',
         ),
-    2201: ('\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project_id}. '
-            'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'),
-    2202: "You do not have the required permissions in jira required to fetch boards for the project {project_id}",
+    2201: ('\nERROR: Failed to download ({}) repo(s) from the group {}. '
+            'Please check that the appropriate permissions are set for the following repos... ({})'),
+    2202: "You do not have the required permissions in jira required to fetch boards for the project {}",
 }
 
 def log_and_print(logger, level, msg, exc_info=False):

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -78,10 +78,11 @@ def log_and_print(logger, level, msg, error_code: str = '000', exc_info=False):
     For a failure that should be sent to the logger, and also written
     to stdout (for user visibility)
     '''
+    log_msg = msg
     if level != logging.INFO:  # Don’t care to track codes for info-level logging
         error_message = ERROR_MESSAGES.get(error_code, 'Null Classfication')
-        msg = f'[{error_code} - {error_message}] {msg}'
-    logger.log(level, msg, exc_info=exc_info)
+        log_msg = f'[{error_code} - {error_message}] {msg}'
+    logger.log(level, log_msg, exc_info=exc_info)
     print(msg, flush=True)
     if exc_info:
         print(traceback.format_exc())

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -96,13 +96,11 @@ def obtain_config(args) -> ValidatedConfig:
 
     run_mode = args.mode
     if run_mode not in VALID_RUN_MODES:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.WARNING,
-                (
-                    f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''
-                ),
-                '200',
+                msg_args=[', '.join(VALID_RUN_MODES)],
+                error_code=2000,
         )
         raise BadConfigException()
 
@@ -151,26 +149,20 @@ def obtain_config(args) -> ValidatedConfig:
     if jira_include_fields:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
-            agent_logging.log_and_print(
+            agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.WARNING,
-                (
-                    f'Missing recommended jira_fields! For the best possible experience, '
-                    f'please add the following to `include_fields` in the '
-                    f'configuration file: {list(missing_required_fields)}'
-                ),
+                msg_args=[list(missing_required_fields)],
+                error_code=2104,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
-            agent_logging.log_and_print(
+            agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.WARNING,
-                (
-                    f'Excluding recommended jira_fields! For the best possible experience, '
-                    f'please remove the following from `exclude_fields` in the '
-                    f'configuration file: {list(excluded_required_fields)}',
-                ),
+                msg_args=[list(excluded_required_fields)],
+                error_code=2105,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -102,7 +102,7 @@ def obtain_config(args) -> ValidatedConfig:
                 (
                     f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''
                 ),
-                agent_logging.ErrorCodes.CLIENT,
+                agent_logging.ErrorClassification.CLIENT,
         )
         raise BadConfigException()
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -96,12 +96,7 @@ def obtain_config(args) -> ValidatedConfig:
 
     run_mode = args.mode
     if run_mode not in VALID_RUN_MODES:
-        agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[', '.join(VALID_RUN_MODES)],
-                error_code=2000,
-        )
+        print(f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"''')
         raise BadConfigException()
 
     run_mode_includes_download = run_mode in ('download_and_send', 'download_only')
@@ -150,19 +145,13 @@ def obtain_config(args) -> ValidatedConfig:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[list(missing_required_fields)],
-                error_code=2132,
+                logger, logging.WARNING, msg_args=[list(missing_required_fields)], error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[list(excluded_required_fields)],
-                error_code=2142,
+                logger, logging.WARNING, msg_args=[list(excluded_required_fields)], error_code=2142,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -102,7 +102,7 @@ def obtain_config(args) -> ValidatedConfig:
                 (
                     f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''
                 ),
-                200,
+                '200',
         )
         raise BadConfigException()
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -96,7 +96,14 @@ def obtain_config(args) -> ValidatedConfig:
 
     run_mode = args.mode
     if run_mode not in VALID_RUN_MODES:
-        print(f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"''')
+        agent_logging.log_and_print(
+                logger,
+                logging.WARNING,
+                (
+                    f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''
+                ),
+                agent_logging.ErrorCodes.CLIENT,
+        )
         raise BadConfigException()
 
     run_mode_includes_download = run_mode in ('download_and_send', 'download_only')

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -102,7 +102,7 @@ def obtain_config(args) -> ValidatedConfig:
                 (
                     f'''ERROR: Mode should be one of "{', '.join(VALID_RUN_MODES)}"'''
                 ),
-                agent_logging.ErrorClassification.CLIENT,
+                200,
         )
         raise BadConfigException()
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -153,7 +153,7 @@ def obtain_config(args) -> ValidatedConfig:
                 logger,
                 logging.WARNING,
                 msg_args=[list(missing_required_fields)],
-                error_code=2104,
+                error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
@@ -162,7 +162,7 @@ def obtain_config(args) -> ValidatedConfig:
                 logger,
                 logging.WARNING,
                 msg_args=[list(excluded_required_fields)],
-                error_code=2105,
+                error_code=2142,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -263,7 +263,7 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
         return
 
     # if the git provider is none of the above, throw an error
-    raise ValueError(f'unsupported git provider {config.git_provider}') # Customer Config Error
+    raise ValueError(f'unsupported git provider {config.git_provider}')
 
 
 @diagnostics.capture_timing()
@@ -429,12 +429,5 @@ def get_repos_from_git(git_connection, config: GitConfig):
         projects = gl_adapter.get_projects()
         repos = gl_adapter.get_repos(projects)
     else:
-        agent_logging.log_and_print_error_or_warning(
-            logger,
-            logging.ERROR,
-            msg_args=[config.git_provider],
-            error_code=3071,
-            exc_info=True,
-        )
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')
     return repos

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -260,9 +260,11 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
             exc_info=True,
         )
         return
+        # Client Config
 
     # if the git provider is none of the above, throw an error
     raise ValueError(f'unsupported git provider {config.git_provider}')
+    # Client Config
 
 
 @diagnostics.capture_timing()

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -257,14 +257,13 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
             logger,
             logging.ERROR,
             f'Failed to connect to {config.git_provider}:\n{e}',
+            agent_logging.ErrorClassification.CLIENT_CONFIG,
             exc_info=True,
         )
         return
-        # Client Config
 
     # if the git provider is none of the above, throw an error
-    raise ValueError(f'unsupported git provider {config.git_provider}')
-    # Client Config
+    raise ValueError(f'unsupported git provider {config.git_provider}') # Client Config Error
 
 
 @diagnostics.capture_timing()
@@ -326,6 +325,7 @@ def load_and_dump_git(
             logger,
             logging.ERROR,
             f'Failed to download {config.git_provider} data:\n{e}',
+            agent_logging.ErrorClassification.ENGINEERING,
             exc_info=True,
         )
 
@@ -429,6 +429,12 @@ def get_repos_from_git(git_connection, config: GitConfig):
         projects = gl_adapter.get_projects()
         repos = gl_adapter.get_repos(projects)
     else:
+        agent_logging.log_and_print(
+            logger,
+            logging.ERROR,
+            f'ValueError: {config.git_provider} is not a supported git_provider for this run_mode',
+            agent_logging.ErrorClassification.ENGINEERING,
+            exc_info=True,
+        )
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')
-
     return repos

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -253,11 +253,11 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
             )
 
     except Exception as e:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
             logger,
             logging.ERROR,
-            f'Failed to connect to {config.git_provider}:\n{e}',
-            '201',
+            msg_args=[config.git_provider, e],
+            error_code=2100,
             exc_info=True,
         )
         return
@@ -321,11 +321,11 @@ def load_and_dump_git(
             raise ValueError(f'unsupported git provider {config.git_provider}')
 
     except Exception as e:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
             logger,
             logging.ERROR,
-            f'Failed to download {config.git_provider} data:\n{e}',
-            '300',
+            msg_args=[config.git_provider, e],
+            error_code=3300,
             exc_info=True,
         )
 
@@ -429,11 +429,11 @@ def get_repos_from_git(git_connection, config: GitConfig):
         projects = gl_adapter.get_projects()
         repos = gl_adapter.get_repos(projects)
     else:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
             logger,
             logging.ERROR,
-            f'ValueError: {config.git_provider} is not a supported git_provider for this run_mode',
-            '300',
+            msg_args=[config.git_provider],
+            error_code=3301,
             exc_info=True,
         )
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -257,7 +257,7 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
             logger,
             logging.ERROR,
             f'Failed to connect to {config.git_provider}:\n{e}',
-            agent_logging.ErrorClassification.CLIENT_CONFIG,
+            '201',
             exc_info=True,
         )
         return
@@ -325,7 +325,7 @@ def load_and_dump_git(
             logger,
             logging.ERROR,
             f'Failed to download {config.git_provider} data:\n{e}',
-            agent_logging.ErrorClassification.ENGINEERING,
+            '300',
             exc_info=True,
         )
 
@@ -433,7 +433,7 @@ def get_repos_from_git(git_connection, config: GitConfig):
             logger,
             logging.ERROR,
             f'ValueError: {config.git_provider} is not a supported git_provider for this run_mode',
-            agent_logging.ErrorClassification.ENGINEERING,
+            '300',
             exc_info=True,
         )
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -263,7 +263,7 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
         return
 
     # if the git provider is none of the above, throw an error
-    raise ValueError(f'unsupported git provider {config.git_provider}') # Client Config Error
+    raise ValueError(f'unsupported git provider {config.git_provider}') # Customer Config Error
 
 
 @diagnostics.capture_timing()

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -257,7 +257,7 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
             logger,
             logging.ERROR,
             msg_args=[config.git_provider, e],
-            error_code=2100,
+            error_code=2101,
             exc_info=True,
         )
         return
@@ -325,7 +325,7 @@ def load_and_dump_git(
             logger,
             logging.ERROR,
             msg_args=[config.git_provider, e],
-            error_code=3300,
+            error_code=3061,
             exc_info=True,
         )
 
@@ -433,7 +433,7 @@ def get_repos_from_git(git_connection, config: GitConfig):
             logger,
             logging.ERROR,
             msg_args=[config.git_provider],
-            error_code=3301,
+            error_code=3071,
             exc_info=True,
         )
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -122,7 +122,7 @@ class BitbucketCloudAdapter(GitAdapter):
         if not repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Bitbucket and check your configuration of repos to pull.'
-            ) # Customer Config Error
+            )
 
         return repos
 
@@ -195,10 +195,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 or not api_pr['destination']['repository']
                             ):
                                 agent_logging.log_and_print_error_or_warning(
-                                    logger,
-                                    logging.WARN,
-                                    msg_args=[api_pr['id']],
-                                    error_code=3030
+                                    logger, logging.WARN, msg_args=[api_pr['id']], error_code=3030
                                 )
                                 continue
 
@@ -231,11 +228,7 @@ class BitbucketCloudAdapter(GitAdapter):
                 except Exception:
                     # if something happens when pulling PRs for a repo, just keep going.
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        msg_args=[repo.id],
-                        error_code=3021,
-                        exc_info=True,
+                        logger, logging.ERROR, msg_args=[repo.id], error_code=3021, exc_info=True,
                     )
 
         print('✓')
@@ -359,10 +352,7 @@ def _normalize_pr(
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARN,
-                msg_args=[api_pr["id"], repo.id],
-                error_code=3031,
+                logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3031,
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -376,10 +366,7 @@ def _normalize_pr(
         elif e.response.status_code == 401:
             # Server threw a 401 on the request for the diff; not sure why this would be, but it seems rare
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARN,
-                msg_args=[api_pr["id"], repo.id],
-                error_code=3041,
+                logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3041,
             )
         else:
             # Some other HTTP error happened; Re-raise
@@ -387,10 +374,7 @@ def _normalize_pr(
     except UnicodeDecodeError:
         # Occasional diffs seem to be invalid UTF-8
         agent_logging.log_and_print_error_or_warning(
-            logger,
-            logging.WARN,
-            msg_args=[api_pr["id"], repo.id],
-            error_code=3051,
+            logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3051,
         )
 
     # Comments
@@ -455,12 +439,11 @@ def _normalize_pr(
         and api_pr['merge_commit'].get('hash')
     ):
         api_merge_commit = client.get_commit(
-            repo.project.id,
-            api_pr['source']['repository']['uuid'],
-            api_pr['merge_commit']['hash']
+            repo.project.id, api_pr['source']['repository']['uuid'], api_pr['merge_commit']['hash']
         )
-        merge_commit = _normalize_commit(api_merge_commit, repo, strip_text_content, redact_names_and_urls)
-
+        merge_commit = _normalize_commit(
+            api_merge_commit, repo, strip_text_content, redact_names_and_urls
+        )
 
     # Repo links
     base_repo = _normalize_short_form_repo(

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -123,6 +123,7 @@ class BitbucketCloudAdapter(GitAdapter):
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Bitbucket and check your configuration of repos to pull.'
             )
+            # Client config
 
         return repos
 
@@ -199,6 +200,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                     logging.WARN,
                                     f"PR {api_pr['id']} doesn't reference a source and/or destination repository; skipping it...",
                                 )
+                                # Engineering
                                 continue
 
                             yield _normalize_pr(
@@ -225,6 +227,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 f'Error normalizing PR {api_pr["id"]} from repo {repo.id}. Skipping...',
                                 exc_info=True,
                             )
+                            # Engineering
 
                 except Exception:
                     # if something happens when pulling PRs for a repo, just keep going.
@@ -234,6 +237,7 @@ class BitbucketCloudAdapter(GitAdapter):
                         f'Error getting PRs for repo {repo.id}. Skipping...',
                         exc_info=True,
                     )
+                    # Engineering
 
         print('✓')
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -198,7 +198,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                     logger,
                                     logging.WARN,
                                     f"PR {api_pr['id']} doesn't reference a source and/or destination repository; skipping it...",
-                                    agent_logging.ErrorClassification.ENGINEERING,
+                                    '300',
                                 )
                                 continue
 
@@ -224,7 +224,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 logger,
                                 logging.ERROR,
                                 f'Error normalizing PR {api_pr["id"]} from repo {repo.id}. Skipping...',
-                                agent_logging.ErrorClassification.ENGINEERING,
+                                '300',
                                 exc_info=True,
                             )
 
@@ -234,7 +234,7 @@ class BitbucketCloudAdapter(GitAdapter):
                         logger,
                         logging.ERROR,
                         f'Error getting PRs for repo {repo.id}. Skipping...',
-                        agent_logging.ErrorClassification.ENGINEERING,
+                        '300',
                         exc_info=True,
                     )
 
@@ -362,7 +362,7 @@ def _normalize_pr(
                 logger,
                 logging.WARN,
                 f'Unable to parse the diff For PR {api_pr["id"]} in repo {repo.id}; proceeding as though no files were changed.',
-                agent_logging.ErrorClassification.ENGINEERING,
+                '300',
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -380,7 +380,7 @@ def _normalize_pr(
                 logging.WARN,
                 f'For PR {api_pr["id"]} in repo {repo.id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; '
                 f'proceeding as though no files were changed',
-                agent_logging.ErrorClassification.ENGINEERING,
+                '300',
             )
         else:
             # Some other HTTP error happened; Re-raise

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -122,7 +122,7 @@ class BitbucketCloudAdapter(GitAdapter):
         if not repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Bitbucket and check your configuration of repos to pull.'
-            ) # Client config Error
+            ) # Customer Config Error
 
         return repos
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -198,7 +198,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                     logger,
                                     logging.WARN,
                                     msg_args=[api_pr['id']],
-                                    error_code=3200
+                                    error_code=3030
                                 )
                                 continue
 
@@ -224,7 +224,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 logger,
                                 logging.ERROR,
                                 msg_args=[api_pr["id"], repo.id],
-                                error_code=3201,
+                                error_code=3011,
                                 exc_info=True,
                             )
 
@@ -234,7 +234,7 @@ class BitbucketCloudAdapter(GitAdapter):
                         logger,
                         logging.ERROR,
                         msg_args=[repo.id],
-                        error_code=3203,
+                        error_code=3021,
                         exc_info=True,
                     )
 
@@ -362,7 +362,7 @@ def _normalize_pr(
                 logger,
                 logging.WARN,
                 msg_args=[api_pr["id"], repo.id],
-                error_code=3203,
+                error_code=3031,
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -379,7 +379,7 @@ def _normalize_pr(
                 logger,
                 logging.WARN,
                 msg_args=[api_pr["id"], repo.id],
-                error_code=3204,
+                error_code=3041,
             )
         else:
             # Some other HTTP error happened; Re-raise
@@ -390,7 +390,7 @@ def _normalize_pr(
             logger,
             logging.WARN,
             msg_args=[api_pr["id"], repo.id],
-            error_code=3205,
+            error_code=3051,
         )
 
     # Comments

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -122,8 +122,7 @@ class BitbucketCloudAdapter(GitAdapter):
         if not repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Bitbucket and check your configuration of repos to pull.'
-            )
-            # Client config
+            ) # Client config Error
 
         return repos
 
@@ -199,8 +198,8 @@ class BitbucketCloudAdapter(GitAdapter):
                                     logger,
                                     logging.WARN,
                                     f"PR {api_pr['id']} doesn't reference a source and/or destination repository; skipping it...",
+                                    agent_logging.ErrorClassification.ENGINEERING,
                                 )
-                                # Engineering
                                 continue
 
                             yield _normalize_pr(
@@ -225,9 +224,9 @@ class BitbucketCloudAdapter(GitAdapter):
                                 logger,
                                 logging.ERROR,
                                 f'Error normalizing PR {api_pr["id"]} from repo {repo.id}. Skipping...',
+                                agent_logging.ErrorClassification.ENGINEERING,
                                 exc_info=True,
                             )
-                            # Engineering
 
                 except Exception:
                     # if something happens when pulling PRs for a repo, just keep going.
@@ -235,9 +234,9 @@ class BitbucketCloudAdapter(GitAdapter):
                         logger,
                         logging.ERROR,
                         f'Error getting PRs for repo {repo.id}. Skipping...',
+                        agent_logging.ErrorClassification.ENGINEERING,
                         exc_info=True,
                     )
-                    # Engineering
 
         print('✓')
 
@@ -363,6 +362,7 @@ def _normalize_pr(
                 logger,
                 logging.WARN,
                 f'Unable to parse the diff For PR {api_pr["id"]} in repo {repo.id}; proceeding as though no files were changed.',
+                agent_logging.ErrorClassification.ENGINEERING,
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -380,6 +380,7 @@ def _normalize_pr(
                 logging.WARN,
                 f'For PR {api_pr["id"]} in repo {repo.id}, caught HTTPError (HTTP 401) when attempting to retrieve changes; '
                 f'proceeding as though no files were changed',
+                agent_logging.ErrorClassification.ENGINEERING,
             )
         else:
             # Some other HTTP error happened; Re-raise

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -126,7 +126,7 @@ class BitbucketCloudClient:
                         continue
                     else:
                         agent_logging.log_and_print_error_or_warning(
-                            logger, logging.ERROR, error_code=3800
+                            logger, logging.ERROR, error_code=3151
                         )
                 raise
 

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -120,13 +120,13 @@ class BitbucketCloudClient:
                     # been too long
                     if (datetime.utcnow() - start) < timedelta(hours=1):
                         agent_logging.log_and_print(
-                            logger, logging.INFO, 'Retrying in 30 seconds...', '300',
+                            logger, logging.INFO, 'Retrying in 30 seconds...',
                         )
                         time.sleep(30)
                         continue
                     else:
-                        agent_logging.log_and_print(
-                            logger, logging.ERROR, 'Getting HTTP 429s for over an hour; giving up!', '300',
+                        agent_logging.log_and_print_error_or_warning(
+                            logger, logging.ERROR, error_code=3800
                         )
                 raise
 
@@ -143,7 +143,7 @@ class BitbucketCloudClient:
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
                         agent_logging.log_and_print(
-                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring', '300',
+                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring',
                         )
                         return
                     raise

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -120,13 +120,13 @@ class BitbucketCloudClient:
                     # been too long
                     if (datetime.utcnow() - start) < timedelta(hours=1):
                         agent_logging.log_and_print(
-                            logger, logging.INFO, 'Retrying in 30 seconds...'
+                            logger, logging.INFO, 'Retrying in 30 seconds...', agent_logging.ErrorClassification.ENGINEERING,
                         )
                         time.sleep(30)
                         continue
                     else:
                         agent_logging.log_and_print(
-                            logger, logging.ERROR, 'Getting HTTP 429s for over an hour; giving up!'
+                            logger, logging.ERROR, 'Getting HTTP 429s for over an hour; giving up!', agent_logging.ErrorClassification.ENGINEERING,
                         )
                 raise
 
@@ -143,7 +143,7 @@ class BitbucketCloudClient:
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
                         agent_logging.log_and_print(
-                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring'
+                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring', agent_logging.ErrorClassification.ENGINEERING,
                         )
                         return
                     raise

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -120,13 +120,13 @@ class BitbucketCloudClient:
                     # been too long
                     if (datetime.utcnow() - start) < timedelta(hours=1):
                         agent_logging.log_and_print(
-                            logger, logging.INFO, 'Retrying in 30 seconds...', agent_logging.ErrorClassification.ENGINEERING,
+                            logger, logging.INFO, 'Retrying in 30 seconds...', '300',
                         )
                         time.sleep(30)
                         continue
                     else:
                         agent_logging.log_and_print(
-                            logger, logging.ERROR, 'Getting HTTP 429s for over an hour; giving up!', agent_logging.ErrorClassification.ENGINEERING,
+                            logger, logging.ERROR, 'Getting HTTP 429s for over an hour; giving up!', '300',
                         )
                 raise
 
@@ -143,7 +143,7 @@ class BitbucketCloudClient:
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
                         agent_logging.log_and_print(
-                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring', agent_logging.ErrorClassification.ENGINEERING,
+                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring', '300',
                         )
                         return
                     raise

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -277,6 +277,7 @@ def get_default_branch_commits(
                 print(
                     f'WARN: Got NotFoundException for branch \"{repo.get("default_branch_name", "")}\": {e}. Skipping...'
                 )
+                # Engineering
 
 
 def _normalize_pr_repo(repo, redact_names_and_urls):
@@ -370,6 +371,7 @@ def get_pull_requests(
                         logging.INFO,
                         f'Error retrieving activity data for PR {pr["id"]} in repo {api_repo.get()["name"]}.  Assuming no comments, approvals, etc, and continuing...\n{e}',
                     )
+                    # Engineering
 
                 for activity in activites:
                     if activity['action'] == 'COMMENTED':
@@ -418,6 +420,7 @@ def get_pull_requests(
                     print(
                         f'WARN: For PR {pr["id"]}, caught stashy.errors.NotFoundException when attempting to fetch a commit'
                     )
+                    # Engineering
                     commits = []
 
                 normalized_pr = {

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -277,7 +277,6 @@ def get_default_branch_commits(
                 print(
                     f'WARN: Got NotFoundException for branch \"{repo.get("default_branch_name", "")}\": {e}. Skipping...'
                 )
-                # Engineering
 
 
 def _normalize_pr_repo(repo, redact_names_and_urls):
@@ -370,8 +369,8 @@ def get_pull_requests(
                         logger,
                         logging.INFO,
                         f'Error retrieving activity data for PR {pr["id"]} in repo {api_repo.get()["name"]}.  Assuming no comments, approvals, etc, and continuing...\n{e}',
+                        agent_logging.ErrorClassification.ENGINEERING,
                     )
-                    # Engineering
 
                 for activity in activites:
                     if activity['action'] == 'COMMENTED':
@@ -420,7 +419,6 @@ def get_pull_requests(
                     print(
                         f'WARN: For PR {pr["id"]}, caught stashy.errors.NotFoundException when attempting to fetch a commit'
                     )
-                    # Engineering
                     commits = []
 
                 normalized_pr = {

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -369,7 +369,7 @@ def get_pull_requests(
                         logger,
                         logging.INFO,
                         f'Error retrieving activity data for PR {pr["id"]} in repo {api_repo.get()["name"]}.  Assuming no comments, approvals, etc, and continuing...\n{e}',
-                        agent_logging.ErrorClassification.ENGINEERING,
+                        '300',
                     )
 
                 for activity in activites:

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -369,7 +369,6 @@ def get_pull_requests(
                         logger,
                         logging.INFO,
                         f'Error retrieving activity data for PR {pr["id"]} in repo {api_repo.get()["name"]}.  Assuming no comments, approvals, etc, and continuing...\n{e}',
-                        '300',
                     )
 
                 for activity in activites:

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -150,7 +150,7 @@ def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
     if not projects:
         raise ValueError(
             'No projects found.  Make sure your token has appropriate access to GitHub.'
-        ) # Client Config Error
+        ) # Customer Config Error
     return projects
 
 
@@ -210,7 +210,7 @@ def get_repos(
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
         )
-        # Client config
+        Customer Config
     return repos
 
 

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -151,6 +151,7 @@ def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
         raise ValueError(
             'No projects found.  Make sure your token has appropriate access to GitHub.'
         )
+        # Client config
     return projects
 
 
@@ -210,6 +211,7 @@ def get_repos(
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
         )
+        # Client config
     return repos
 
 
@@ -271,6 +273,7 @@ def get_default_branch_commits(
 
             except Exception as e:
                 print(f':WARN: Got exception for branch {repo["default_branch"]}: {e}. Skipping...')
+                # Engineering
 
 
 def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names_and_urls):
@@ -380,4 +383,5 @@ def get_pull_requests(
 
             except Exception as e:
                 print(f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...')
+                # Engineering
     print()

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -18,11 +18,11 @@ _repo_redactor = NameRedactor()
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def load_and_dump(
-        config: GitConfig,
-        outdir: str,
-        compress_output_files: bool,
-        endpoint_git_instance_info: dict,
-        git_conn,
+    config: GitConfig,
+    outdir: str,
+    compress_output_files: bool,
+    endpoint_git_instance_info: dict,
+    git_conn,
 ):
     write_file(
         outdir, 'bb_users', compress_output_files, get_users(git_conn, config.git_include_projects),
@@ -150,7 +150,7 @@ def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
     if not projects:
         raise ValueError(
             'No projects found.  Make sure your token has appropriate access to GitHub.'
-        ) # Customer Config Error
+        )
     return projects
 
 
@@ -189,7 +189,7 @@ def _normalize_repo(client: GithubClient, org_name, repo, redact_names_and_urls)
 
 @agent_logging.log_entry_exit(logger)
 def get_repos(
-        client: GithubClient, include_orgs, include_repos, exclude_repos, redact_names_and_urls
+    client: GithubClient, include_orgs, include_repos, exclude_repos, redact_names_and_urls
 ):
     print('downloading github repos... ', end='', flush=True)
 
@@ -243,11 +243,11 @@ def _normalize_pr_repo(repo, redact_names_and_urls):
 
 
 def get_default_branch_commits(
-        client: GithubClient,
-        api_repos,
-        strip_text_content,
-        server_git_instance_info,
-        redact_names_and_urls,
+    client: GithubClient,
+    api_repos,
+    strip_text_content,
+    server_git_instance_info,
+    redact_names_and_urls,
 ):
     for i, repo in enumerate(api_repos, start=1):
         with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
@@ -256,14 +256,14 @@ def get_default_branch_commits(
             )
             try:
                 for j, commit in enumerate(
-                        tqdm(
-                            client.get_commits(
-                                repo['full_name'], repo['default_branch'], since=pull_since, until=None
-                            ),
-                            desc=f'downloading commits for {repo["name"]}',
-                            unit='commits',
+                    tqdm(
+                        client.get_commits(
+                            repo['full_name'], repo['default_branch'], since=pull_since, until=None
                         ),
-                        start=1,
+                        desc=f'downloading commits for {repo["name"]}',
+                        unit='commits',
+                    ),
+                    start=1,
                 ):
                     with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
                         yield _normalize_commit(
@@ -280,8 +280,9 @@ def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names
             pr['base']['repo']['full_name'], pr['merge_commit_sha']
         )
         if api_merge_commit:
-            return _normalize_commit(api_merge_commit, pr['base']['repo'],
-                                     strip_text_content, redact_names_and_urls)
+            return _normalize_commit(
+                api_merge_commit, pr['base']['repo'], strip_text_content, redact_names_and_urls
+            )
         else:
             return None
     else:
@@ -344,16 +345,16 @@ def _normalize_pr(client: GithubClient, pr, strip_text_content, redact_names_and
                 unit='commits',
             )
         ],
-        'merge_commit': _get_merge_commit(client, pr, strip_text_content, redact_names_and_urls)
+        'merge_commit': _get_merge_commit(client, pr, strip_text_content, redact_names_and_urls),
     }
 
 
 def get_pull_requests(
-        client: GithubClient,
-        api_repos,
-        strip_text_content,
-        server_git_instance_info,
-        redact_names_and_urls,
+    client: GithubClient,
+    api_repos,
+    strip_text_content,
+    server_git_instance_info,
+    redact_names_and_urls,
 ):
     for i, repo in enumerate(api_repos, start=1):
         with agent_logging.log_loop_iters(logger, 'repo for pull requests', i, 1):
@@ -362,12 +363,12 @@ def get_pull_requests(
             )
             try:
                 for j, pr in enumerate(
-                        tqdm(
-                            client.get_pullrequests(repo['full_name']),
-                            desc=f'downloading PRs for {repo["name"]}',
-                            unit='prs',
-                        ),
-                        start=1,
+                    tqdm(
+                        client.get_pullrequests(repo['full_name']),
+                        desc=f'downloading PRs for {repo["name"]}',
+                        unit='prs',
+                    ),
+                    start=1,
                 ):
                     with agent_logging.log_loop_iters(logger, 'pr inside repo', j, 10):
                         updated_at = parser.parse(pr['updated_at'])

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -210,7 +210,7 @@ def get_repos(
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
         )
-        Customer Config
+        # Customer Config
     return repos
 
 

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -210,7 +210,6 @@ def get_repos(
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
         )
-        # Customer Config
     return repos
 
 

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -150,8 +150,7 @@ def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
     if not projects:
         raise ValueError(
             'No projects found.  Make sure your token has appropriate access to GitHub.'
-        )
-        # Client config
+        ) # Client Config Error
     return projects
 
 
@@ -273,7 +272,6 @@ def get_default_branch_commits(
 
             except Exception as e:
                 print(f':WARN: Got exception for branch {repo["default_branch"]}: {e}. Skipping...')
-                # Engineering
 
 
 def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names_and_urls):
@@ -383,5 +381,4 @@ def get_pull_requests(
 
             except Exception as e:
                 print(f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...')
-                # Engineering
     print()

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -52,7 +52,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     msg_args=[m["url"]],
-                    error_code=3400,
+                    error_code=3081,
                 )
 
     def get_branches(self, full_repo):
@@ -94,7 +94,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     msg_args=[e.response.status_code, ref, full_repo_name],
-                    error_code=3403,
+                    error_code=3121,
                 )
                 return None
 
@@ -131,7 +131,7 @@ class GithubClient:
                         logger,
                         logging.ERROR,
                         msg_args=[url, i],
-                        error_code=3401,
+                        error_code=3101,
                     )
                     raise
 
@@ -156,7 +156,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     msg_args=[reset_wait_str],
-                    error_code=3401,
+                    error_code=3091,
                 )
                 time.sleep(reset_wait_in_seconds)
                 continue  # retry
@@ -178,7 +178,7 @@ class GithubClient:
                         logger,
                         logging.WARNING,
                         msg_args=[page],
-                        error_code=3402,
+                        error_code=3111,
                     )
                     raise ValueError(f'Expected an array of json results, but got: {page}')
 

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -49,10 +49,7 @@ class GithubClient:
                 # we've seen some strange behavior with ghe, where we can get a 403 for
                 # a repo that comes back in the list.  SKip them.
                 agent_logging.log_and_print_error_or_warning(
-                    logger,
-                    logging.WARNING,
-                    msg_args=[m["url"]],
-                    error_code=3081,
+                    logger, logging.WARNING, msg_args=[m["url"]], error_code=3081,
                 )
 
     def get_branches(self, full_repo):
@@ -128,10 +125,7 @@ class GithubClient:
 
                 if i >= max_retries:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        msg_args=[url, i],
-                        error_code=3101,
+                        logger, logging.ERROR, msg_args=[url, i], error_code=3101,
                     )
                     raise
 
@@ -153,10 +147,7 @@ class GithubClient:
                 reset_wait_in_seconds = min(reset_wait_in_seconds, 3600)
                 reset_wait_str = str(timedelta(seconds=reset_wait_in_seconds))
                 agent_logging.log_and_print_error_or_warning(
-                    logger,
-                    logging.WARNING,
-                    msg_args=[reset_wait_str],
-                    error_code=3091,
+                    logger, logging.WARNING, msg_args=[reset_wait_str], error_code=3091,
                 )
                 time.sleep(reset_wait_in_seconds)
                 continue  # retry
@@ -174,12 +165,6 @@ class GithubClient:
                 result = self.get_raw_result(url)
                 page = result.json()
                 if type(page) != list:
-                    agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.WARNING,
-                        msg_args=[page],
-                        error_code=3111,
-                    )
                     raise ValueError(f'Expected an array of json results, but got: {page}')
 
                 if len(page) == 0:

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -53,6 +53,7 @@ class GithubClient:
                     logging.WARNING,
                     f'Got unexpected HTTP 403 for repo {m["url"]}.  Skipping...',
                 )
+                # Engineering
 
     def get_branches(self, full_repo):
         url = f'{self.base_url}/repos/{full_repo}/branches'
@@ -92,6 +93,7 @@ class GithubClient:
                 logger.warning(
                     f'Got HTTP {e.response.status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid ref'
                 )
+                # Engineering
                 return None
 
     # Raw web service operations with optional rate limiting
@@ -128,6 +130,7 @@ class GithubClient:
                         logging.ERROR,
                         f'Request to {url} has failed {i} times -- giving up!',
                     )
+                    # Engineering
                     raise
 
                 # rate-limited!  Sleep until it's ok, then try again
@@ -152,6 +155,7 @@ class GithubClient:
                     logging.WARNING,
                     f'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
                 )
+                # Engineering infra
                 time.sleep(reset_wait_in_seconds)
                 continue  # retry
 
@@ -169,6 +173,7 @@ class GithubClient:
                 page = result.json()
                 if type(page) != list:
                     raise ValueError(f'Expected an array of json results, but got: {page}')
+                    # Engineering
 
                 if len(page) == 0:
                     return  # no new values returned

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -52,7 +52,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     f'Got unexpected HTTP 403 for repo {m["url"]}.  Skipping...',
-                    agent_logging.ErrorClassification.ENGINEERING,
+                    '300',
                 )
 
     def get_branches(self, full_repo):
@@ -94,7 +94,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     f'Got HTTP {e.response.status_code} when fetching commit {ref} for "{full_repo_name}", this likely means you are trying to fetch an invalid ref',
-                    agent_logging.ErrorClassification.ENGINEERING,
+                    '300',
                 )
                 return None
 
@@ -131,7 +131,7 @@ class GithubClient:
                         logger,
                         logging.ERROR,
                         f'Request to {url} has failed {i} times -- giving up!',
-                        agent_logging.ErrorClassification.ENGINEERING,
+                        '300',
                     )
                     raise
 
@@ -156,7 +156,7 @@ class GithubClient:
                     logger,
                     logging.WARNING,
                     f'Github rate limit exceeded.  Trying again in {reset_wait_str}...',
-                    agent_logging.ErrorClassification.ENGINEERING,
+                    '300',
                 )
                 time.sleep(reset_wait_in_seconds)
                 continue  # retry
@@ -178,7 +178,7 @@ class GithubClient:
                         logger,
                         logging.WARNING,
                         f'Expected an array of json results, but got: {page}',
-                        agent_logging.ErrorClassification.ENGINEERING,
+                        '300',
                     )
                     raise ValueError(f'Expected an array of json results, but got: {page}')
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -62,7 +62,7 @@ class GitLabAdapter(GitAdapter):
         if not projects:
             raise ValueError(
                 'No projects found.  Make sure your token has appropriate access to GitLab.'
-            ) # Customer Permissions Error
+            )
         return projects
 
     @diagnostics.capture_timing()
@@ -132,6 +132,7 @@ class GitLabAdapter(GitAdapter):
 
             # if there were any repositories we had issues with... print them out now.
             if repos_that_failed_to_download:
+
                 def __repo_log_string(api_repo):
                     # build log string
                     name = (
@@ -153,12 +154,11 @@ class GitLabAdapter(GitAdapter):
                     error_code=2201,
                 )
 
-
         print('✓')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
-            ) # Customer Permissions Error
+            )
         return nrm_repos
 
     @diagnostics.capture_timing()
@@ -278,7 +278,11 @@ class GitLabAdapter(GitAdapter):
                             ]
                             merge_request = self.client.expand_merge_request_data(api_pr)
                             merge_commit = None
-                            if merge_request.state == 'merged' and nrm_commits is not None and merge_request.merge_commit_sha:
+                            if (
+                                merge_request.state == 'merged'
+                                and nrm_commits is not None
+                                and merge_request.merge_commit_sha
+                            ):
                                 merge_commit = _normalize_commit(
                                     self.client.get_project_commit(
                                         merge_request.project_id, merge_request.merge_commit_sha
@@ -293,7 +297,7 @@ class GitLabAdapter(GitAdapter):
                                 nrm_commits,
                                 self.config.git_strip_text_content,
                                 self.config.git_redact_names_and_urls,
-                                merge_commit
+                                merge_commit,
                             )
                         except Exception as e:
                             # if something goes wrong with normalizing one of the prs - don't stop pulling. try
@@ -364,10 +368,10 @@ def _normalize_branch(api_branch, redact_names_and_urls: bool) -> NormalizedBran
 
 
 def _normalize_repo(
-        api_repo,
-        normalized_branches: List[NormalizedBranch],
-        normalized_project: NormalizedProject,
-        redact_names_and_urls: bool,
+    api_repo,
+    normalized_branches: List[NormalizedBranch],
+    normalized_project: NormalizedProject,
+    redact_names_and_urls: bool,
 ) -> NormalizedRepository:
     repo_name = (
         api_repo.name if not redact_names_and_urls else _repo_redactor.redact_name(api_repo.name)
@@ -397,7 +401,7 @@ def _normalize_short_form_repo(api_repo, redact_names_and_urls):
 
 
 def _normalize_commit(
-        api_commit, normalized_repo, strip_text_content: bool, redact_names_and_urls: bool
+    api_commit, normalized_repo, strip_text_content: bool, redact_names_and_urls: bool
 ):
     author = NormalizedUser(
         id=f'{api_commit.author_name}<{api_commit.author_email}>',
@@ -421,7 +425,7 @@ def _normalize_commit(
 
 
 def _get_normalized_pr_comments(
-        merge_request, strip_text_content
+    merge_request, strip_text_content
 ) -> List[NormalizedPullRequestComment]:
     try:
         return [
@@ -462,11 +466,11 @@ def _get_normalized_approvals(merge_request):
 
 
 def _normalize_pr(
-        merge_request,
-        normalized_commits: List[NormalizedCommit],
-        strip_text_content: bool,
-        redact_names_and_urls: bool,
-        merge_commit
+    merge_request,
+    normalized_commits: List[NormalizedCommit],
+    strip_text_content: bool,
+    redact_names_and_urls: bool,
+    merge_commit,
 ):
     base_branch_name = merge_request.target_branch
     head_branch_name = merge_request.source_branch

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -4,7 +4,6 @@ import requests
 from dateutil import parser
 from typing import List
 import logging
-
 from jf_agent.git import (
     GitAdapter,
     NormalizedUser,
@@ -63,8 +62,7 @@ class GitLabAdapter(GitAdapter):
         if not projects:
             raise ValueError(
                 'No projects found.  Make sure your token has appropriate access to GitLab.'
-            )
-            # Client perms
+            ) # Client Permissions Error
         return projects
 
     @diagnostics.capture_timing()
@@ -107,16 +105,16 @@ class GitLabAdapter(GitAdapter):
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because not in include_repos...',
+                        agent_logging.ErrorClassification.CLIENT_CONFIG,
                     )
-                    # Client Config
                     continue  # skip this repo
                 if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
                     agent_logging.log_and_print(
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because in exclude_repos...',
+                        agent_logging.ErrorClassification.CLIENT_CONFIG,
                     )
-                    # Client Config
                     continue  # skip this repo
 
                 try:
@@ -157,15 +155,15 @@ class GitLabAdapter(GitAdapter):
                         f'\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project.id}. '
                         f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'
                     ),
+                    agent_logging.ErrorClassification.CLIENT_PERMISSIONS,
                 )
-                # Client perms
+
 
         print('✓')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
-            )
-            # Client perms
+            ) # Client Permissions Error
         return nrm_repos
 
     @diagnostics.capture_timing()
@@ -183,7 +181,6 @@ class GitLabAdapter(GitAdapter):
                 f'pulling branches from repo {api_repo.id}'
                 'This is most likely because no repo was in the GitlabProject -- will treat like there are no branches',
             )
-            # Engineering
             return []
 
     @diagnostics.capture_timing()
@@ -220,7 +217,6 @@ class GitLabAdapter(GitAdapter):
                     print(
                         f':WARN: Got exception for branch {nrm_repo.default_branch_name}: {e}. Skipping...'
                     )
-                    # Engineering
         print('✓')
 
     @diagnostics.capture_timing()
@@ -274,7 +270,6 @@ class GitLabAdapter(GitAdapter):
                                     f'fetching source project {api_pr.source_project_id} '
                                     f'for merge_request {api_pr.id}. Skipping...',
                                 )
-                                # Engineering
                                 continue
 
                             nrm_commits: List[NormalizedCommit] = [
@@ -314,14 +309,12 @@ class GitLabAdapter(GitAdapter):
                                 f'normalizing PR {pr_id} from repo {nrm_repo.id}. Skipping...',
                                 log_as_exception=True,
                             )
-                            # Engineering
 
                 except Exception as e:
                     # if something happens when pulling PRs for a repo, just keep going.
                     log_and_print_request_error(
                         e, f'getting PRs for repo {nrm_repo.id}. Skipping...', log_as_exception=True
                     )
-                    # Engineering
 
     print('✓')
 
@@ -451,7 +444,6 @@ def _get_normalized_pr_comments(
             f'standardizing PR comments for merge_request {merge_request.id} -- '
             f'handling it as if it has no comments',
         )
-        # Engineering
         return []
 
 
@@ -471,7 +463,6 @@ def _get_normalized_approvals(merge_request):
             f'standardizing PR approvals for merge_request {merge_request.id} -- '
             f'handling it as if it has no approvals',
         )
-        # Engineering
         return []
 
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -105,7 +105,7 @@ class GitLabAdapter(GitAdapter):
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because not in include_repos...',
-                        agent_logging.ErrorClassification.CLIENT_CONFIG,
+                        '201',
                     )
                     continue  # skip this repo
                 if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
@@ -113,7 +113,7 @@ class GitLabAdapter(GitAdapter):
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because in exclude_repos...',
-                        agent_logging.ErrorClassification.CLIENT_CONFIG,
+                        '201',
                     )
                     continue  # skip this repo
 
@@ -155,7 +155,7 @@ class GitLabAdapter(GitAdapter):
                         f'\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project.id}. '
                         f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'
                     ),
-                    agent_logging.ErrorClassification.CLIENT_PERMISSIONS,
+                    '202',
                 )
 
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -150,7 +150,7 @@ class GitLabAdapter(GitAdapter):
                     logger,
                     logging.WARNING,
                     msg_args=[total_failed, nrm_project.id, repos_failed_string],
-                    error_code=2200,
+                    error_code=2201,
                 )
 
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -62,7 +62,7 @@ class GitLabAdapter(GitAdapter):
         if not projects:
             raise ValueError(
                 'No projects found.  Make sure your token has appropriate access to GitLab.'
-            ) # Client Permissions Error
+            ) # Customer Permissions Error
         return projects
 
     @diagnostics.capture_timing()
@@ -163,7 +163,7 @@ class GitLabAdapter(GitAdapter):
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
-            ) # Client Permissions Error
+            ) # Customer Permissions Error
         return nrm_repos
 
     @diagnostics.capture_timing()

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -64,6 +64,7 @@ class GitLabAdapter(GitAdapter):
             raise ValueError(
                 'No projects found.  Make sure your token has appropriate access to GitLab.'
             )
+            # Client perms
         return projects
 
     @diagnostics.capture_timing()
@@ -107,6 +108,7 @@ class GitLabAdapter(GitAdapter):
                         logging.INFO,
                         f'skipping repo {api_repo.id} because not in include_repos...',
                     )
+                    # Client Config
                     continue  # skip this repo
                 if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
                     agent_logging.log_and_print(
@@ -114,6 +116,7 @@ class GitLabAdapter(GitAdapter):
                         logging.INFO,
                         f'skipping repo {api_repo.id} because in exclude_repos...',
                     )
+                    # Client Config
                     continue  # skip this repo
 
                 try:
@@ -155,12 +158,14 @@ class GitLabAdapter(GitAdapter):
                         f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'
                     ),
                 )
+                # Client perms
 
         print('✓')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
             )
+            # Client perms
         return nrm_repos
 
     @diagnostics.capture_timing()
@@ -178,6 +183,7 @@ class GitLabAdapter(GitAdapter):
                 f'pulling branches from repo {api_repo.id}'
                 'This is most likely because no repo was in the GitlabProject -- will treat like there are no branches',
             )
+            # Engineering
             return []
 
     @diagnostics.capture_timing()
@@ -214,6 +220,7 @@ class GitLabAdapter(GitAdapter):
                     print(
                         f':WARN: Got exception for branch {nrm_repo.default_branch_name}: {e}. Skipping...'
                     )
+                    # Engineering
         print('✓')
 
     @diagnostics.capture_timing()
@@ -267,6 +274,7 @@ class GitLabAdapter(GitAdapter):
                                     f'fetching source project {api_pr.source_project_id} '
                                     f'for merge_request {api_pr.id}. Skipping...',
                                 )
+                                # Engineering
                                 continue
 
                             nrm_commits: List[NormalizedCommit] = [
@@ -306,12 +314,14 @@ class GitLabAdapter(GitAdapter):
                                 f'normalizing PR {pr_id} from repo {nrm_repo.id}. Skipping...',
                                 log_as_exception=True,
                             )
+                            # Engineering
 
                 except Exception as e:
                     # if something happens when pulling PRs for a repo, just keep going.
                     log_and_print_request_error(
                         e, f'getting PRs for repo {nrm_repo.id}. Skipping...', log_as_exception=True
                     )
+                    # Engineering
 
     print('✓')
 
@@ -441,6 +451,7 @@ def _get_normalized_pr_comments(
             f'standardizing PR comments for merge_request {merge_request.id} -- '
             f'handling it as if it has no comments',
         )
+        # Engineering
         return []
 
 
@@ -460,6 +471,7 @@ def _get_normalized_approvals(merge_request):
             f'standardizing PR approvals for merge_request {merge_request.id} -- '
             f'handling it as if it has no approvals',
         )
+        # Engineering
         return []
 
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -105,7 +105,6 @@ class GitLabAdapter(GitAdapter):
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because not in include_repos...',
-                        '201',
                     )
                     continue  # skip this repo
                 if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
@@ -113,7 +112,6 @@ class GitLabAdapter(GitAdapter):
                         logger,
                         logging.INFO,
                         f'skipping repo {api_repo.id} because in exclude_repos...',
-                        '201',
                     )
                     continue  # skip this repo
 
@@ -148,14 +146,11 @@ class GitLabAdapter(GitAdapter):
                 )
                 total_failed = len(repos_that_failed_to_download)
 
-                agent_logging.log_and_print(
+                agent_logging.log_and_print_error_or_warning(
                     logger,
                     logging.WARNING,
-                    (
-                        f'\nERROR: Failed to download ({total_failed}) repo(s) from the group {nrm_project.id}. '
-                        f'Please check that the appropriate permissions are set for the following repos... ({repos_failed_string})'
-                    ),
-                    '202',
+                    msg_args=[total_failed, nrm_project.id, repos_failed_string],
+                    error_code=2200,
                 )
 
 

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -11,7 +11,7 @@ class MissingSourceProjectException(Exception):
     pass
 
 
-def log_and_print_request_error(e, action='making request', error_code=agent_logging.ErrorClassification.ENGINEERING, log_as_exception=False):
+def log_and_print_request_error(e, action='making request', error_code='300', log_as_exception=False):
     try:
         response_code = e.response_code
     except AttributeError:

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -80,6 +80,7 @@ class GitLabClient:
                 f'fetching notes for merge_request {merge_request.id} -- '
                 f'handling it as if it has no notes',
             )
+            # Engineering
             merge_request.note_list = []
 
         try:
@@ -90,6 +91,7 @@ class GitLabClient:
                 f'fetching changes for merge_request {merge_request.id} -- '
                 f'handling it as if it has no diffs',
             )
+            # Engineering
             merge_request.diff = ''
 
         try:
@@ -105,6 +107,7 @@ class GitLabClient:
                 f'fetching approvals for merge_request {merge_request.id} -- '
                 f'handling it as if it has no approvals',
             )
+            # Engineering
             merge_request.approved_by = []
 
         # convert the 'commit_list' generator into a list of objects

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -11,7 +11,7 @@ class MissingSourceProjectException(Exception):
     pass
 
 
-def log_and_print_request_error(e, action='making request', error_code='300', log_as_exception=False):
+def log_and_print_request_error(e, action='making request', log_as_exception=False):
     try:
         response_code = e.response_code
     except AttributeError:
@@ -21,12 +21,12 @@ def log_and_print_request_error(e, action='making request', error_code='300', lo
     error_name = type(e).__name__
 
     if log_as_exception:
-        agent_logging.log_and_print(
-            logger, logging.ERROR, f'Got {error_name} {response_code} when {action} ({e})', error_code
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.ERROR, msg_args=[error_name, response_code, action, e], error_code=3500,
         )
     else:
-        agent_logging.log_and_print(
-            logger, logging.WARNING, f'Got {error_name} {response_code} when {action}', error_code
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3501
         )
 
 

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -22,11 +22,11 @@ def log_and_print_request_error(e, action='making request', log_as_exception=Fal
 
     if log_as_exception:
         agent_logging.log_and_print_error_or_warning(
-            logger, logging.ERROR, msg_args=[error_name, response_code, action, e], error_code=3500,
+            logger, logging.ERROR, msg_args=[error_name, response_code, action, e], error_code=3131,
         )
     else:
         agent_logging.log_and_print_error_or_warning(
-            logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3501
+            logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3141
         )
 
 

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -22,11 +22,11 @@ def log_and_print_request_error(e, action='making request', error_code='300', lo
 
     if log_as_exception:
         agent_logging.log_and_print(
-            logger, logging.ERROR, f'Got {error_name} {response_code} when {action} ({e})'
+            logger, logging.ERROR, f'Got {error_name} {response_code} when {action} ({e})', error_code
         )
     else:
         agent_logging.log_and_print(
-            logger, logging.WARNING, f'Got {error_name} {response_code} when {action}'
+            logger, logging.WARNING, f'Got {error_name} {response_code} when {action}', error_code
         )
 
 

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -11,7 +11,7 @@ class MissingSourceProjectException(Exception):
     pass
 
 
-def log_and_print_request_error(e, action='making request', log_as_exception=False):
+def log_and_print_request_error(e, action='making request', error_code=agent_logging.ErrorClassification.ENGINEERING, log_as_exception=False):
     try:
         response_code = e.response_code
     except AttributeError:
@@ -80,7 +80,6 @@ class GitLabClient:
                 f'fetching notes for merge_request {merge_request.id} -- '
                 f'handling it as if it has no notes',
             )
-            # Engineering
             merge_request.note_list = []
 
         try:
@@ -91,7 +90,6 @@ class GitLabClient:
                 f'fetching changes for merge_request {merge_request.id} -- '
                 f'handling it as if it has no diffs',
             )
-            # Engineering
             merge_request.diff = ''
 
         try:
@@ -107,7 +105,6 @@ class GitLabClient:
                 f'fetching approvals for merge_request {merge_request.id} -- '
                 f'handling it as if it has no approvals',
             )
-            # Engineering
             merge_request.approved_by = []
 
         # convert the 'commit_list' generator into a list of objects

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -53,8 +53,8 @@ def get_basic_jira_connection(config, creds):
     try:
         return _get_raw_jira_connection(config, creds)
     except Exception as e:
-        agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', '201', exc_info=True
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.ERROR, msg_args=[e], error_code=2102, exc_info=True
         )
 
 
@@ -276,7 +276,7 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
         return {'type': 'Jira', 'status': 'success'}
 
     except Exception as e:
-        agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to download jira data:\n{e}', '300', exc_info=True
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.ERROR, msg_args=[e], error_code=3600, exc_info=True
         )
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -54,9 +54,8 @@ def get_basic_jira_connection(config, creds):
         return _get_raw_jira_connection(config, creds)
     except Exception as e:
         agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', exc_info=True
+            logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', agent_logging.ErrorClassification.CLIENT_CONFIG, exc_info=True
         )
-        # Client Perms / Config
 
 
 @diagnostics.capture_timing()
@@ -75,7 +74,6 @@ def print_missing_repos_found_by_jira(config, creds, issues_to_scan):
     print(
         f'\nScanning the "Development" field on the Jira issues revealed {len(missing_repos)} Git repos apparently missing from Jellyfish'
     )
-    # Engineering
     for missing_repo in missing_repos:
         print(f"* {missing_repo['name']:30}\t{missing_repo['url']}")
     print('\n')
@@ -279,7 +277,6 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
 
     except Exception as e:
         agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to download jira data:\n{e}', exc_info=True
+            logger, logging.ERROR, f'Failed to download jira data:\n{e}', agent_logging.ErrorClassification.ENGINEERING, exc_info=True
         )
-        # Engineering
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -277,6 +277,6 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
 
     except Exception as e:
         agent_logging.log_and_print_error_or_warning(
-            logger, logging.ERROR, msg_args=[e], error_code=3600, exc_info=True
+            logger, logging.ERROR, msg_args=[e], error_code=3002, exc_info=True
         )
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -54,7 +54,7 @@ def get_basic_jira_connection(config, creds):
         return _get_raw_jira_connection(config, creds)
     except Exception as e:
         agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', agent_logging.ErrorClassification.CLIENT_CONFIG, exc_info=True
+            logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', '201', exc_info=True
         )
 
 
@@ -277,6 +277,6 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
 
     except Exception as e:
         agent_logging.log_and_print(
-            logger, logging.ERROR, f'Failed to download jira data:\n{e}', agent_logging.ErrorClassification.ENGINEERING, exc_info=True
+            logger, logging.ERROR, f'Failed to download jira data:\n{e}', '300', exc_info=True
         )
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -56,6 +56,7 @@ def get_basic_jira_connection(config, creds):
         agent_logging.log_and_print(
             logger, logging.ERROR, f'Failed to connect to Jira:\n{e}', exc_info=True
         )
+        # Client Perms / Config
 
 
 @diagnostics.capture_timing()
@@ -74,6 +75,7 @@ def print_missing_repos_found_by_jira(config, creds, issues_to_scan):
     print(
         f'\nScanning the "Development" field on the Jira issues revealed {len(missing_repos)} Git repos apparently missing from Jellyfish'
     )
+    # Engineering
     for missing_repo in missing_repos:
         print(f"* {missing_repo['name']:30}\t{missing_repo['url']}")
     print('\n')
@@ -279,4 +281,5 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
         agent_logging.log_and_print(
             logger, logging.ERROR, f'Failed to download jira data:\n{e}', exc_info=True
         )
+        # Engineering
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -151,11 +151,11 @@ def download_projects_and_versions(
                 and e.text
                 == f"A value with ID '{project_id}' does not exist for the field 'project'."
             ):
-                agent_logging.log_and_print(
+                agent_logging.log_and_print_error_or_warning(
                     logger,
                     logging.ERROR,
-                    f'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...',
-                    '201'
+                    msg_args=[project_id],
+                    error_code=2101,
                 )
                 return False
             else:
@@ -215,12 +215,11 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                 ).json()['values']
             except JIRAError as e:
                 if e.status_code == 400:
-                    agent_logging.log_and_print(
+                    agent_logging.log_and_print_error_or_warning(
                         logger,
                         logging.ERROR,
-                        f"You do not have the required permissions in jira required to "
-                        f"fetch boards for the project {project_id}",
-                        '202'
+                        msg_args=[project_id],
+                        error_code=2201,
                     )
                     break
                 raise
@@ -315,19 +314,19 @@ def download_all_issue_metadata(
                     # a smaller ask will prevent the server from choking.
                     batch_size = int(batch_size / 2)
                     if batch_size > 0:
-                        agent_logging.log_and_print(
+                        agent_logging.log_and_print_error_or_warning(
                             logger,
                             logging.WARNING,
-                            f'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
-                            '300',
+                            msg_args=[batch_size],
+                            error_code=3700,
                         )
                         continue
                     else:
-                        agent_logging.log_and_print(
+                        agent_logging.log_and_print_error_or_warning(
                             logger,
                             logging.ERROR,
-                            'Caught KeyError from search_issues(), batch size is already 0, bailing out',
-                            '300',
+                            msg_args=[],
+                            error_code=3701,
                         )
                         raise
 
@@ -340,11 +339,11 @@ def download_all_issue_metadata(
 
         except Exception as e:
             thread_exceptions[thread_num] = e
-            agent_logging.log_and_print(
+            agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.ERROR,
-                f'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
-                '300',
+                msg_args=[thread_num, traceback.format_exc()],
+                error_code=3702,
             )
 
     threads = [
@@ -514,11 +513,11 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
         for i in items:
             field_id_field = _get_field_identifier(i)
             if not field_id_field:
-                agent_logging.log_and_print(
+                agent_logging.log_and_print_error_or_warning(
                     logger=logger,
                     level=logging.WARNING,
-                    msg=f"OJ-9084: Changelog history item with no 'fieldId' or 'field' key: {i.keys()}",
-                    error_classification=agent_logging.ERROR_MESSAGES.ENGINEERING,
+                    error_code= 3904,
+                    msg_args=[i.keys()],
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
                 continue
@@ -575,11 +574,11 @@ def _download_jira_issues_segment(
         q.put(None)
 
     except BaseException as e:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
             logger,
             logging.ERROR,
-            f'[Thread {thread_num}] Jira issue downloader FAILED',
-            '300',
+            msg_args=[thread_num],
+            error_code=3900,
             exc_info=True,
         )
         q.put(e)
@@ -618,21 +617,22 @@ def _download_jira_issues_page(
                 raise
 
             batch_size = int(batch_size / 2)
-            agent_logging.log_and_print(
+            agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.WARNING,
-                f'JIRAError ({e}), reducing batch size to {batch_size}',
+                msg_args=[e, batch_size],
+                error_code=3901,
                 exc_info=True,
             )
             if batch_size == 0:
                 if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
                     return [], 1
                 elif not get_changelog:
-                    agent_logging.log_and_print(
+                    agent_logging.log_and_print_error_or_warning(
                         logger,
                         logging.WARNING,
-                        f'Apparently unable to fetch issue based on search_params {search_params}',
-                        '300',
+                        msg_args=[search_params],
+                        error_code=3902,
                     )
                     return [], 0
                 else:
@@ -705,8 +705,8 @@ def download_customfieldoptions(jira_connection, project_ids):
                 projectIds=[project_id], expand='projects.issuetypes.fields'
             )
         except JIRAError:
-            agent_logging.log_and_print(
-                logger, logging.ERROR, 'Error calling createmeta JIRA endpoint', '300', exc_info=True
+            agent_logging.log_and_print_error_or_warning(
+                logger, logging.ERROR, error_code=3903, exc_info=True
             )
             return []
 
@@ -900,11 +900,10 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
                 )
             except JIRAError as e:
                 if e.status_code == 403:
-                    agent_logging.log_and_print(
+                    agent_logging.log_and_print_error_or_warning(
                         logger,
                         logging.ERROR,
-                        "you do not have the required 'development field' permissions in jira required to scan for missing repos",
-                        '201'
+                        error_code=2103,
                     )
                     return []
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -41,7 +41,7 @@ def download_users(jira_connection, gdpr_active, quiet=False):
     if len(jira_users) == 0:
         raise RuntimeError(
             'The agent is unable to see any users. Please verify that this user has the "browse all users" permission.'
-        ) # Client Permissions Error
+        ) # Customer Permissions Error
 
     if not quiet:
         print('✓')
@@ -171,7 +171,7 @@ def download_projects_and_versions(
     if not projects:
         raise Exception(
             'No Jira projects found that meet all the provided filters for project and project category. Aborting... '
-        ) # Client Config Error
+        ) # Customer Config Error
 
     print('✓')
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -155,7 +155,7 @@ def download_projects_and_versions(
                     logger,
                     logging.ERROR,
                     f'Unable to access project {project_id}, may be a Jira misconfiguration. Skipping...',
-                    agent_logging.ErrorClassification.CLIENT_CONFIG
+                    '201'
                 )
                 return False
             else:
@@ -220,7 +220,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                         logging.ERROR,
                         f"You do not have the required permissions in jira required to "
                         f"fetch boards for the project {project_id}",
-                        agent_logging.ErrorClassification.CLIENT_PERMISSIONS
+                        '202'
                     )
                     break
                 raise
@@ -319,7 +319,7 @@ def download_all_issue_metadata(
                             logger,
                             logging.WARNING,
                             f'Caught KeyError from search_issues(), reducing batch size to {batch_size}',
-                            agent_logging.ErrorClassification.ENGINEERING,
+                            '300',
                         )
                         continue
                     else:
@@ -327,7 +327,7 @@ def download_all_issue_metadata(
                             logger,
                             logging.ERROR,
                             'Caught KeyError from search_issues(), batch size is already 0, bailing out',
-                            agent_logging.ErrorClassification.ENGINEERING,
+                            '300',
                         )
                         raise
 
@@ -344,7 +344,7 @@ def download_all_issue_metadata(
                 logger,
                 logging.ERROR,
                 f'Exception encountered in thread {thread_num}\n{traceback.format_exc()}',
-                agent_logging.ErrorClassification.ENGINEERING,
+                '300',
             )
 
     threads = [
@@ -518,7 +518,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
                     logger=logger,
                     level=logging.WARNING,
                     msg=f"OJ-9084: Changelog history item with no 'fieldId' or 'field' key: {i.keys()}",
-                    error_classification=agent_logging.ErrorClassification.ENGINEERING,
+                    error_classification=agent_logging.ERROR_MESSAGES.ENGINEERING,
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
                 continue
@@ -579,7 +579,7 @@ def _download_jira_issues_segment(
             logger,
             logging.ERROR,
             f'[Thread {thread_num}] Jira issue downloader FAILED',
-            agent_logging.ErrorClassification.ENGINEERING,
+            '300',
             exc_info=True,
         )
         q.put(e)
@@ -632,7 +632,7 @@ def _download_jira_issues_page(
                         logger,
                         logging.WARNING,
                         f'Apparently unable to fetch issue based on search_params {search_params}',
-                        agent_logging.ErrorClassification.ENGINEERING,
+                        '300',
                     )
                     return [], 0
                 else:
@@ -706,7 +706,7 @@ def download_customfieldoptions(jira_connection, project_ids):
             )
         except JIRAError:
             agent_logging.log_and_print(
-                logger, logging.ERROR, 'Error calling createmeta JIRA endpoint', agent_logging.ErrorClassification.ENGINEERING, exc_info=True
+                logger, logging.ERROR, 'Error calling createmeta JIRA endpoint', '300', exc_info=True
             )
             return []
 
@@ -904,7 +904,7 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
                         logger,
                         logging.ERROR,
                         "you do not have the required 'development field' permissions in jira required to scan for missing repos",
-                        agent_logging.ErrorClassification.CLIENT_CONFIG
+                        '201'
                     )
                     return []
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -41,7 +41,7 @@ def download_users(jira_connection, gdpr_active, quiet=False):
     if len(jira_users) == 0:
         raise RuntimeError(
             'The agent is unable to see any users. Please verify that this user has the "browse all users" permission.'
-        ) # Customer Permissions Error
+        )
 
     if not quiet:
         print('✓')
@@ -152,10 +152,7 @@ def download_projects_and_versions(
                 == f"A value with ID '{project_id}' does not exist for the field 'project'."
             ):
                 agent_logging.log_and_print_error_or_warning(
-                    logger,
-                    logging.ERROR,
-                    msg_args=[project_id],
-                    error_code=2112,
+                    logger, logging.ERROR, msg_args=[project_id], error_code=2112,
                 )
                 return False
             else:
@@ -171,7 +168,7 @@ def download_projects_and_versions(
     if not projects:
         raise Exception(
             'No Jira projects found that meet all the provided filters for project and project category. Aborting... '
-        ) # Customer Config Error
+        )
 
     print('✓')
 
@@ -216,10 +213,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
             except JIRAError as e:
                 if e.status_code == 400:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        msg_args=[project_id],
-                        error_code=2202,
+                        logger, logging.ERROR, msg_args=[project_id], error_code=2202,
                     )
                     break
                 raise
@@ -315,17 +309,12 @@ def download_all_issue_metadata(
                     batch_size = int(batch_size / 2)
                     if batch_size > 0:
                         agent_logging.log_and_print_error_or_warning(
-                            logger,
-                            logging.WARNING,
-                            msg_args=[batch_size],
-                            error_code=3012,
+                            logger, logging.WARNING, msg_args=[batch_size], error_code=3012,
                         )
                         continue
                     else:
                         agent_logging.log_and_print_error_or_warning(
-                            logger,
-                            logging.ERROR,
-                            error_code=3022,
+                            logger, logging.ERROR, error_code=3022,
                         )
                         raise
 
@@ -513,10 +502,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
             field_id_field = _get_field_identifier(i)
             if not field_id_field:
                 agent_logging.log_and_print_error_or_warning(
-                    logger=logger,
-                    level=logging.WARNING,
-                    error_code= 3082,
-                    msg_args=[i.keys()],
+                    logger=logger, level=logging.WARNING, error_code=3082, msg_args=[i.keys()],
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
                 continue
@@ -574,11 +560,7 @@ def _download_jira_issues_segment(
 
     except BaseException as e:
         agent_logging.log_and_print_error_or_warning(
-            logger,
-            logging.ERROR,
-            msg_args=[thread_num],
-            error_code=3042,
-            exc_info=True,
+            logger, logging.ERROR, msg_args=[thread_num], error_code=3042, exc_info=True,
         )
         q.put(e)
 
@@ -617,21 +599,14 @@ def _download_jira_issues_page(
 
             batch_size = int(batch_size / 2)
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[e, batch_size],
-                error_code=3052,
-                exc_info=True,
+                logger, logging.WARNING, msg_args=[e, batch_size], error_code=3052, exc_info=True,
             )
             if batch_size == 0:
                 if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
                     return [], 1
                 elif not get_changelog:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.WARNING,
-                        msg_args=[search_params],
-                        error_code=3062,
+                        logger, logging.WARNING, msg_args=[search_params], error_code=3062,
                     )
                     return [], 0
                 else:
@@ -900,9 +875,7 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
             except JIRAError as e:
                 if e.status_code == 403:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        error_code=2122,
+                        logger, logging.ERROR, error_code=2122,
                     )
                     return []
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -155,7 +155,7 @@ def download_projects_and_versions(
                     logger,
                     logging.ERROR,
                     msg_args=[project_id],
-                    error_code=2101,
+                    error_code=2112,
                 )
                 return False
             else:
@@ -219,7 +219,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                         logger,
                         logging.ERROR,
                         msg_args=[project_id],
-                        error_code=2201,
+                        error_code=2202,
                     )
                     break
                 raise
@@ -318,15 +318,14 @@ def download_all_issue_metadata(
                             logger,
                             logging.WARNING,
                             msg_args=[batch_size],
-                            error_code=3700,
+                            error_code=3012,
                         )
                         continue
                     else:
                         agent_logging.log_and_print_error_or_warning(
                             logger,
                             logging.ERROR,
-                            msg_args=[],
-                            error_code=3701,
+                            error_code=3022,
                         )
                         raise
 
@@ -343,7 +342,7 @@ def download_all_issue_metadata(
                 logger,
                 logging.ERROR,
                 msg_args=[thread_num, traceback.format_exc()],
-                error_code=3702,
+                error_code=3032,
             )
 
     threads = [
@@ -516,7 +515,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
                 agent_logging.log_and_print_error_or_warning(
                     logger=logger,
                     level=logging.WARNING,
-                    error_code= 3904,
+                    error_code= 3082,
                     msg_args=[i.keys()],
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
@@ -578,7 +577,7 @@ def _download_jira_issues_segment(
             logger,
             logging.ERROR,
             msg_args=[thread_num],
-            error_code=3900,
+            error_code=3042,
             exc_info=True,
         )
         q.put(e)
@@ -621,7 +620,7 @@ def _download_jira_issues_page(
                 logger,
                 logging.WARNING,
                 msg_args=[e, batch_size],
-                error_code=3901,
+                error_code=3052,
                 exc_info=True,
             )
             if batch_size == 0:
@@ -632,7 +631,7 @@ def _download_jira_issues_page(
                         logger,
                         logging.WARNING,
                         msg_args=[search_params],
-                        error_code=3902,
+                        error_code=3062,
                     )
                     return [], 0
                 else:
@@ -706,7 +705,7 @@ def download_customfieldoptions(jira_connection, project_ids):
             )
         except JIRAError:
             agent_logging.log_and_print_error_or_warning(
-                logger, logging.ERROR, error_code=3903, exc_info=True
+                logger, logging.ERROR, error_code=3072, exc_info=True
             )
             return []
 
@@ -903,7 +902,7 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
                     agent_logging.log_and_print_error_or_warning(
                         logger,
                         logging.ERROR,
-                        error_code=2103,
+                        error_code=2122,
                     )
                     return []
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -518,7 +518,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
                     logger=logger,
                     level=logging.WARNING,
                     msg=f"OJ-9084: Changelog history item with no 'fieldId' or 'field' key: {i.keys()}",
-                    error_code=agent_logging.ErrorClassification.ENGINEERING,
+                    error_classification=agent_logging.ErrorClassification.ENGINEERING,
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
                 continue

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -547,4 +547,4 @@ if __name__ == '__main__':
     try:
         main()
     except BadConfigException:
-        print('ERROR: Bad config; see earlier messages' # Client Config Error
+        print('ERROR: Bad config; see earlier messages') # Client Config Error

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -301,7 +301,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
         print(
             f"ERROR: Couldn't get agent config info from {base_url}/agent/pull-state "
             f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
-        )  #  Customer Permissions Error
+        )
         raise BadConfigException()
 
     agent_config = resp.json()
@@ -313,7 +313,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
         print(
             'ERROR: A Git instance is configured, but no Git instance '
             'info returned from the Jellyfish API -- please contact Jellyfish'
-        )  # Customer Success Config Error
+        )
         raise BadConfigException()
 
     # if there are multiple git configurations
@@ -342,7 +342,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
         print(
             'ERROR: A single Git instance has been configured, but multiple Git instances were returned '
             'from the Jellyfish API -- please contact Jellyfish'
-        )  # Customer Success Config Error
+        )
         raise BadConfigException()
 
     # if multi git instance is configured in the YAML, assert there is a valid git_instance_slug
@@ -489,7 +489,7 @@ def send_data(config, creds):
     if any(thread_exceptions):
         print(
             'ERROR: not all files uploaded to S3. Files have been saved locally. Once connectivity issues are resolved, try running the Agent in send_only mode.'
-        )  # Customer Error
+        )
         return
 
     # creating .done file

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -385,7 +385,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
             logger,
             logging.INFO,
             f'Obtained {git_config.git_provider} configuration, attempting download...',
-            agent_logging.ErrorClassification.CLIENT_CONFIG
+            '201'
         )
         if is_multi_git_config:
             instance_slug = git_config.git_instance_slug
@@ -441,7 +441,7 @@ def send_data(config, creds):
                 logger,
                 logging.ERROR,
                 f'Failed to upload file {filename} to S3 bucket',
-                agent_logging.ErrorClassification.ENGINEERING,
+                '300',
                 exc_info=True,
             )
 
@@ -529,7 +529,7 @@ def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_month
             logger,
             logging.ERROR,
             f'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
-            agent_logging.ErrorClassification.ENGINEERING,
+            '300',
             exc_info=True,
         )
         return None

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -372,7 +372,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 
     if config.jira_url:
         agent_logging.log_and_print(
-            logger, logging.INFO, 'Obtained Jira configuration, attempting download...'
+            logger, logging.INFO, 'Obtained Jira configuration, attempting download...', error_code=''
         )
         jira_connection = get_basic_jira_connection(config, creds)
         if config.run_mode_is_print_all_jira_fields:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -372,7 +372,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 
     if config.jira_url:
         agent_logging.log_and_print(
-            logger, logging.INFO, 'Obtained Jira configuration, attempting download...', error_code=''
+            logger, logging.INFO, 'Obtained Jira configuration, attempting download...',
         )
         jira_connection = get_basic_jira_connection(config, creds)
         if config.run_mode_is_print_all_jira_fields:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -112,10 +112,12 @@ def main():
                 print(
                     f'Error connecting to Jira instance at {config.jira_url}. Please use a Jira API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html.'
                 )
+                # Client Config
             else:
                 print(
                     f'Error connecting to Jira instance at {config.jira_url}, please validate your credentials. Error: {e}'
                 )
+                # Client Config
             return
 
         # test jira users permission
@@ -130,6 +132,7 @@ def main():
             print(
                 f'Error downloading users from Jira instance at {config.jira_url}, please verify that this user has the "browse all users" permission. Error: {e}'
             )
+            # Client Perms
             return
 
         # test jira project access
@@ -141,6 +144,7 @@ def main():
             for proj in config.jira_include_projects:
                 if proj not in accessible_projects:
                     print(f'Error: Unable to access explicitly-included project {proj}.')
+                    # Client Perms
                     return
 
         print('Success!')
@@ -243,6 +247,7 @@ def _get_git_instance_to_creds(git_config):
             print(
                 f'ERROR: Missing environment variable {envvar_name}. Required for instance {git_config.git_instance_slug}.'
             )
+            # Client Config
             raise BadConfigException()
         return envvar_val
 
@@ -268,6 +273,7 @@ def obtain_creds(config):
     jellyfish_api_token = os.environ.get('JELLYFISH_API_TOKEN')
     if not jellyfish_api_token:
         print('ERROR: JELLYFISH_API_TOKEN not found in the environment.')
+                # Client Config
         raise BadConfigException()
 
     jira_username = os.environ.get('JIRA_USERNAME', None)
@@ -283,6 +289,7 @@ def obtain_creds(config):
         print(
             'ERROR: Jira credentials not found. Set environment variables JIRA_USERNAME and JIRA_PASSWORD.'
         )
+                # Client Config
         raise BadConfigException()
 
     return UserProvidedCreds(
@@ -302,6 +309,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
             f"ERROR: Couldn't get agent config info from {base_url}/agent/pull-state "
             f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
         )
+                # Client Config PERMS
         raise BadConfigException()
 
     agent_config = resp.json()
@@ -314,6 +322,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
             'ERROR: A Git instance is configured, but no Git instance '
             'info returned from the Jellyfish API -- please contact Jellyfish'
         )
+        # Success
         raise BadConfigException()
 
     # if there are multiple git configurations
@@ -327,6 +336,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
                     f'ERROR: The Jellyfish API did not return an instance with the git_instance_slug `{slug}` -- '
                     f'please check your configuration or contact Jellyfish'
                 )
+                # Client Config
                 raise BadConfigException()
 
     # If a single Git instance is configured in the YAML, but multiple instances are configured
@@ -343,6 +353,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
             'ERROR: A single Git instance has been configured, but multiple Git instances were returned '
             'from the Jellyfish API -- please contact Jellyfish'
         )
+        # Success
         raise BadConfigException()
 
     # if multi git instance is configured in the YAML, assert there is a valid git_instance_slug
@@ -353,6 +364,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
                     'ERROR: Must specify git_instance slug in multi-git mode -- '
                     'please check your configuration or contact Jellyfish'
                 )
+                # Client Config
                 raise BadConfigException()
 
             if git_config.git_instance_slug not in git_instance_info:
@@ -360,6 +372,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
                     f'ERROR: Invalid `instance_slug` {git_config.git_instance_slug} in configuration. -- '
                     'please check your configuration or contact Jellyfish'
                 )
+                # Client Config
                 raise BadConfigException()
 
     return JellyfishEndpointInfo(jira_info, git_instance_info)
@@ -386,6 +399,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
             logging.INFO,
             f'Obtained {git_config.git_provider} configuration, attempting download...',
         )
+        # Client Config
         if is_multi_git_config:
             instance_slug = git_config.git_instance_slug
             instance_info = endpoint_git_instances_info.get(instance_slug)
@@ -442,6 +456,7 @@ def send_data(config, creds):
                 f'Failed to upload file {filename} to S3 bucket',
                 exc_info=True,
             )
+            # Engineering
 
     def upload_file(filename, path_to_obj, signed_url):
         with open(f'{config.outdir}/{filename}', 'rb') as f:
@@ -493,6 +508,7 @@ def send_data(config, creds):
         print(
             'ERROR: not all files uploaded to S3. Files have been saved locally. Once connectivity issues are resolved, try running the Agent in send_only mode.'
         )
+        # Client
         return
 
     # creating .done file
@@ -526,11 +542,13 @@ def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_month
         print(
             f'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.'
         )
+        # Engineering
         return None
 
     if resp.status_code == 400:
         # additionally, indicate config needs alterations
         raise BadConfigException()
+        # Client Config
     elif not resp.ok:
         return None
 
@@ -541,4 +559,5 @@ if __name__ == '__main__':
     try:
         main()
     except BadConfigException:
-        print('ERROR: Bad config; see earlier messages')
+        print('ERROR: Bad config; see earlier messages'
+        # Client Config

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -385,7 +385,6 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
             logger,
             logging.INFO,
             f'Obtained {git_config.git_provider} configuration, attempting download...',
-            '201'
         )
         if is_multi_git_config:
             instance_slug = git_config.git_instance_slug
@@ -437,11 +436,11 @@ def send_data(config, creds):
             upload_file(filename, path_to_obj, signed_url)
         except Exception as e:
             thread_exceptions.append(e)
-            agent_logging.log_and_print(
+            agent_logging.log_and_print_error_or_warning(
                 logger,
                 logging.ERROR,
-                f'Failed to upload file {filename} to S3 bucket',
-                '300',
+                msg_args=[filename],
+                error_code=3000,
                 exc_info=True,
             )
 
@@ -525,11 +524,11 @@ def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_month
         data = resp.json()
         print(data.get('message', ''))
     except json.decoder.JSONDecodeError:
-        agent_logging.log_and_print(
+        agent_logging.log_and_print_error_or_warning(
             logger,
             logging.ERROR,
-            f'ERROR: Could not parse response with status code {resp.status_code}. Contact an administrator for help.',
-            '300',
+            msg_args=[resp.status_code],
+            error_code=3001,
             exc_info=True,
         )
         return None

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -111,11 +111,11 @@ def main():
             if 'Basic authentication with passwords is deprecated.' in str(e):
                 print(
                     f'Error connecting to Jira instance at {config.jira_url}. Please use a Jira API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html.'
-                ) # Client Config Error
+                ) # Customer Config Error
             else:
                 print(
                     f'Error connecting to Jira instance at {config.jira_url}, please validate your credentials. Error: {e}'
-                ) # Client Config Error
+                ) # Customer Config Error
             return
 
         # test jira users permission
@@ -129,7 +129,7 @@ def main():
         except Exception as e:
             print(
                 f'Error downloading users from Jira instance at {config.jira_url}, please verify that this user has the "browse all users" permission. Error: {e}'
-            ) # Client Permissions Error
+            ) # Customer Permissions Error
             return
 
         # test jira project access
@@ -140,7 +140,7 @@ def main():
         if config.jira_include_projects:
             for proj in config.jira_include_projects:
                 if proj not in accessible_projects:
-                    print(f'Error: Unable to access explicitly-included project {proj}.') # Client Permissions Error
+                    print(f'Error: Unable to access explicitly-included project {proj}.') # Customer Permissions Error
                     return
 
         print('Success!')
@@ -242,7 +242,7 @@ def _get_git_instance_to_creds(git_config):
         if not envvar_val:
             print(
                 f'ERROR: Missing environment variable {envvar_name}. Required for instance {git_config.git_instance_slug}.'
-            ) # Client Config Error
+            ) # Customer Config Error
             raise BadConfigException()
         return envvar_val
 
@@ -267,7 +267,7 @@ def _get_git_instance_to_creds(git_config):
 def obtain_creds(config):
     jellyfish_api_token = os.environ.get('JELLYFISH_API_TOKEN')
     if not jellyfish_api_token:
-        print('ERROR: JELLYFISH_API_TOKEN not found in the environment.') # Client Config Error
+        print('ERROR: JELLYFISH_API_TOKEN not found in the environment.') # Customer Config Error
         raise BadConfigException()
 
     jira_username = os.environ.get('JIRA_USERNAME', None)
@@ -282,7 +282,7 @@ def obtain_creds(config):
     if config.jira_url and not (jira_username and jira_password):
         print(
             'ERROR: Jira credentials not found. Set environment variables JIRA_USERNAME and JIRA_PASSWORD.'
-        ) # Client Config Error
+        ) # Customer Config Error
         raise BadConfigException()
 
     return UserProvidedCreds(
@@ -301,7 +301,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
         print(
             f"ERROR: Couldn't get agent config info from {base_url}/agent/pull-state "
             f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
-        ) #  Client Permissions Error
+        ) #  Customer Permissions Error
         raise BadConfigException()
 
     agent_config = resp.json()
@@ -326,7 +326,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
                 print(
                     f'ERROR: The Jellyfish API did not return an instance with the git_instance_slug `{slug}` -- '
                     f'please check your configuration or contact Jellyfish'
-                ) # Client Config Error
+                ) # Customer Config Error
                 raise BadConfigException()
 
     # If a single Git instance is configured in the YAML, but multiple instances are configured
@@ -352,14 +352,14 @@ def obtain_jellyfish_endpoint_info(config, creds):
                 print(
                     'ERROR: Must specify git_instance slug in multi-git mode -- '
                     'please check your configuration or contact Jellyfish'
-                ) # Client Config Error
+                ) # Customer Config Error
                 raise BadConfigException()
 
             if git_config.git_instance_slug not in git_instance_info:
                 print(
                     f'ERROR: Invalid `instance_slug` {git_config.git_instance_slug} in configuration. -- '
                     'please check your configuration or contact Jellyfish'
-                ) # Client Config Error
+                ) # Customer Config Error
                 raise BadConfigException()
 
     return JellyfishEndpointInfo(jira_info, git_instance_info)
@@ -494,7 +494,7 @@ def send_data(config, creds):
     if any(thread_exceptions):
         print(
             'ERROR: not all files uploaded to S3. Files have been saved locally. Once connectivity issues are resolved, try running the Agent in send_only mode.'
-        ) # Client Error
+        ) # Customer Error
         return
 
     # creating .done file
@@ -536,7 +536,7 @@ def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_month
 
     if resp.status_code == 400:
         # additionally, indicate config needs alterations
-        raise BadConfigException() # Client Config Error
+        raise BadConfigException() # Customer Config Error
     elif not resp.ok:
         return None
 
@@ -547,4 +547,4 @@ if __name__ == '__main__':
     try:
         main()
     except BadConfigException:
-        print('ERROR: Bad config; see earlier messages') # Client Config Error
+        print('ERROR: Bad config; see earlier messages') # Customer Config Error

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -58,7 +58,7 @@ class RateLimiter(object):
                             logger,
                             logging.ERROR,
                             msg_args=[calls_made, max_calls, realm],
-                            error_code=3100
+                            error_code=3010
                         )
                     raise
 
@@ -72,7 +72,7 @@ class RateLimiter(object):
                     logger,
                     logging.ERROR,
                     msg_args=[self.timeout_secs],
-                    error_code=3101
+                    error_code=3020
                 )
                 raise Exception('Rate limit timeout')
 

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -54,11 +54,11 @@ class RateLimiter(object):
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 429:
                         # Got rate limited anyway!
-                        agent_logging.log_and_print(
+                        agent_logging.log_and_print_error_or_warning(
                             logger,
                             logging.ERROR,
-                            f'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
-                            '300',
+                            msg_args=[calls_made, max_calls, realm],
+                            error_code=3100
                         )
                     raise
 
@@ -68,11 +68,11 @@ class RateLimiter(object):
                 f'Rate limiter: exceeded {max_calls} calls in {period_secs} seconds for {realm}!',
             )
             if (sleep_until - start) >= timedelta(seconds=self.timeout_secs):
-                agent_logging.log_and_print(
+                agent_logging.log_and_print_error_or_warning(
                     logger,
                     logging.ERROR,
-                    f'Next available time to make call is after the timeout of {self.timeout_secs} seconds. Giving up.',
-                    '300',
+                    msg_args=[self.timeout_secs],
+                    error_code=3101
                 )
                 raise Exception('Rate limit timeout')
 
@@ -82,7 +82,6 @@ class RateLimiter(object):
                     logger,
                     logging.INFO,
                     f'Sleeping for {sleep_period_secs:.1f} secs ({sleep_period_secs / 60.0:.1f} mins)',
-                    '300',
                 )
                 time.sleep(sleep_period_secs)
 

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -58,7 +58,7 @@ class RateLimiter(object):
                             logger,
                             logging.ERROR,
                             msg_args=[calls_made, max_calls, realm],
-                            error_code=3010
+                            error_code=3010,
                         )
                     raise
 
@@ -69,10 +69,7 @@ class RateLimiter(object):
             )
             if (sleep_until - start) >= timedelta(seconds=self.timeout_secs):
                 agent_logging.log_and_print_error_or_warning(
-                    logger,
-                    logging.ERROR,
-                    msg_args=[self.timeout_secs],
-                    error_code=3020
+                    logger, logging.ERROR, msg_args=[self.timeout_secs], error_code=3020
                 )
                 raise Exception('Rate limit timeout')
 

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -58,7 +58,7 @@ class RateLimiter(object):
                             logger,
                             logging.ERROR,
                             f'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
-                            agent_logging.ErrorClassification.ENGINEERING,
+                            '300',
                         )
                     raise
 
@@ -72,7 +72,7 @@ class RateLimiter(object):
                     logger,
                     logging.ERROR,
                     f'Next available time to make call is after the timeout of {self.timeout_secs} seconds. Giving up.',
-                    agent_logging.ErrorClassification.ENGINEERING,
+                    '300',
                 )
                 raise Exception('Rate limit timeout')
 
@@ -82,7 +82,7 @@ class RateLimiter(object):
                     logger,
                     logging.INFO,
                     f'Sleeping for {sleep_period_secs:.1f} secs ({sleep_period_secs / 60.0:.1f} mins)',
-                    agent_logging.ErrorClassification.ENGINEERING,
+                    '300',
                 )
                 time.sleep(sleep_period_secs)
 

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -58,6 +58,7 @@ class RateLimiter(object):
                             logger,
                             logging.ERROR,
                             f'Rate limiter: thought we were operating within our limit (made {calls_made}/{max_calls} calls for {realm}), but got HTTP 429 anyway!',
+                            agent_logging.ErrorClassification.ENGINEERING,
                         )
                     raise
 
@@ -71,6 +72,7 @@ class RateLimiter(object):
                     logger,
                     logging.ERROR,
                     f'Next available time to make call is after the timeout of {self.timeout_secs} seconds. Giving up.',
+                    agent_logging.ErrorClassification.ENGINEERING,
                 )
                 raise Exception('Rate limit timeout')
 
@@ -80,6 +82,7 @@ class RateLimiter(object):
                     logger,
                     logging.INFO,
                     f'Sleeping for {sleep_period_secs:.1f} secs ({sleep_period_secs / 60.0:.1f} mins)',
+                    agent_logging.ErrorClassification.ENGINEERING,
                 )
                 time.sleep(sleep_period_secs)
 

--- a/jf_agent/session.py
+++ b/jf_agent/session.py
@@ -12,6 +12,7 @@ class ReauthSession(requests.Session):
         response = super().request(method, url, **kwargs)
         if response.status_code == 401:
             print(f'WARN: received 401 for the request [{method}] {url} - resetting client session')
+
             # Clear cookies and re-auth
             self.cookies.clear()
             response = super().request(method, url, **kwargs)


### PR DESCRIPTION
To help start designing more Agent tooling, classify the errors in the Agent to understand what errors are often thrown and provide a small boost to organization of errors in our logs. 

This small boost means just adding a tag to each log that classifies what groups of people are best suited to "fix" the error or be aware of it. This means that when we see a CLIENT_CONFIG error in the logs, it's not engineering's job but the client's.

Ex: 
`2021-02-08 00:00:15 MainThread WARNING [3002] You do not have the required permissions in jira required to fetch boards for the project 123145`

Furthermore, added comments to classify non-logging statements to help with further designing to understand what may need to change and where those errors/prints/raises lie in the codebase.


