### PR TITLE
[OJ-10612] Catch `RetryError` when fetching bitbucket server comments

### DIFF
--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -372,7 +372,7 @@ def get_pull_requests(
                     activites = sorted(
                         [a for a in api_pr.activities()], key=lambda x: x['createdDate']
                     )
-                except stashy.errors.GenericException as e:
+                except (stashy.errors.GenericException, RetryError) as e:
                     agent_logging.log_and_print(
                         logger,
                         logging.INFO,


### PR DESCRIPTION
It seems this can throw either a `GenericException` or a `RetryError`, so catch both of them.