### PR TITLE
OJ-10065: Add config option to send agent config information to Jellyfish

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -6,7 +6,9 @@ global:
   # Set this to True to skip verification of server SSL certificates.  This might
   # be useful if your Jira / Bitbucket server doesn't have a valid SSL certificate.
   no_verify_ssl: False
-
+  # Set this to False if you would not like to send your config.yml file to Jellyfish.
+  # We use this as a diagnostic tool for customer assistance.
+  send_agent_config_in_payload: True
 
 #############################
 # 2. Jira configuration

--- a/example.yml
+++ b/example.yml
@@ -8,7 +8,7 @@ global:
   no_verify_ssl: False
   # Set this to True if you would like to send your config.yml file to Jellyfish.
   # We use this as a diagnostic tool for customer assistance.
-  send_agent_config: False
+  send_agent_config: True
 
 #############################
 # 2. Jira configuration

--- a/example.yml
+++ b/example.yml
@@ -6,9 +6,9 @@ global:
   # Set this to True to skip verification of server SSL certificates.  This might
   # be useful if your Jira / Bitbucket server doesn't have a valid SSL certificate.
   no_verify_ssl: False
-  # Set this to False if you would not like to send your config.yml file to Jellyfish.
+  # Set this to True if you would like to send your config.yml file to Jellyfish.
   # We use this as a diagnostic tool for customer assistance.
-  send_agent_config_in_payload: True
+  send_agent_config: False
 
 #############################
 # 2. Jira configuration

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -60,7 +60,7 @@ ValidatedConfig = namedtuple(
         'compress_output_files',
         'jellyfish_api_base',
         'skip_ssl_verification',
-        'send_agent_config_in_payload'
+        'send_agent_config'
     ],
 )
 
@@ -116,7 +116,7 @@ def obtain_config(args) -> ValidatedConfig:
 
     yaml_conf_global = yaml_config.get('global', {})
     skip_ssl_verification = yaml_conf_global.get('no_verify_ssl', False)
-    send_agent_config_in_payload = yaml_conf_global.get('send_agent_config_in_payload', False)
+    send_agent_config = yaml_conf_global.get('send_agent_config', False)
 
     # jira configuration
     jira_config = yaml_config.get('jira', {})
@@ -247,7 +247,7 @@ def obtain_config(args) -> ValidatedConfig:
         compress_output_files,
         jellyfish_api_base,
         skip_ssl_verification,
-        send_agent_config_in_payload,
+        send_agent_config,
     )
 
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -60,6 +60,7 @@ ValidatedConfig = namedtuple(
         'compress_output_files',
         'jellyfish_api_base',
         'skip_ssl_verification',
+        'send_agent_config_in_payload'
     ],
 )
 
@@ -115,6 +116,7 @@ def obtain_config(args) -> ValidatedConfig:
 
     yaml_conf_global = yaml_config.get('global', {})
     skip_ssl_verification = yaml_conf_global.get('no_verify_ssl', False)
+    send_agent_config_in_payload = yaml_conf_global.get('send_agent_config_in_payload', False)
 
     # jira configuration
     jira_config = yaml_config.get('jira', {})
@@ -245,6 +247,7 @@ def obtain_config(args) -> ValidatedConfig:
         compress_output_files,
         jellyfish_api_base,
         skip_ssl_verification,
+        send_agent_config_in_payload,
     )
 
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -492,6 +492,11 @@ def send_data(config, creds):
         )
         return
 
+    # If sending agent config flag is on, upload to s3 bucket
+    if config.send_agent_config_in_payload:
+        config_file_dict = get_signed_url(['config.yml'])['config.yml']
+        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'])
+
     # creating .done file
     done_file_path = f'{os.path.join(config.outdir, ".done")}'
     Path(done_file_path).touch()

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -495,7 +495,7 @@ def send_data(config, creds):
         return
 
     # If sending agent config flag is on, upload config.yml to s3 bucket
-    if config.send_agent_config_in_payload:
+    if config.send_agent_config:
         config_file_dict = get_signed_url(['config.yml'])['config.yml']
         upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True)
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -440,8 +440,10 @@ def send_data(config, creds):
                 logger, logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
             )
 
-    def upload_file(filename, path_to_obj, signed_url):
-        with open(f'{config.outdir}/{filename}', 'rb') as f:
+    def upload_file(filename, path_to_obj, signed_url, local=False):
+        filepath = filename if local else f'{config.outdir}/{filename}'
+
+        with open(filepath, 'rb') as f:
             # If successful, returns HTTP status code 204
             session = retry_session()
             upload_resp = session.post(
@@ -492,10 +494,10 @@ def send_data(config, creds):
         )
         return
 
-    # If sending agent config flag is on, upload to s3 bucket
+    # If sending agent config flag is on, upload config.yml to s3 bucket
     if config.send_agent_config_in_payload:
         config_file_dict = get_signed_url(['config.yml'])['config.yml']
-        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'])
+        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True)
 
     # creating .done file
     done_file_path = f'{os.path.join(config.outdir, ".done")}'


### PR DESCRIPTION
# Description
Include a new flag to `config.yml` called `send_agent_config` which will, if `True`, send the customers' config.yml file to the s3 bucket.

# Testing Method
Set flag to `True` in `config.yml`:

```
daviskeene@Davis-Macbook-Pro:~$ aws s3 ls s3://jellyfish-dev-agent-upload/orthogonal-networks/20210603_183816/
2021-06-03 14:38:50          0 .done
2021-06-03 14:38:50        658 config.yml
2021-06-03 14:38:49        478 diagnostics.json.gz
2021-06-03 14:38:49       7849 jf_agent.log
2021-06-03 14:38:49        135 status.json.gz
```

Flag not included in `config.yml`:
```
daviskeene@Davis-Macbook-Pro:~/jf_agent$ aws s3 ls s3://jellyfish-dev-agent-upload/orthogonal-networks/20210603_184116/
2021-06-03 14:42:48          0 .done
2021-06-03 14:42:47        499 diagnostics.json.gz
2021-06-03 14:42:47       7847 jf_agent.log
2021-06-03 14:42:47        135 status.json.gz
```