### PR TITLE
OJ-9530: Add Git diagnostic information to agent "validate" mode

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -406,9 +406,8 @@ def get_repos_from_git(git_connection, config: GitConfig):
 
     elif config.git_provider == 'github':
 
-        from jf_agent.git.github import get_repos as get_repos_gh, get_projects
+        from jf_agent.git.github import get_repos as get_repos_gh
 
-        projects = get_projects(git_connection, config.git_include_projects, config.git_redact_names_and_urls)
         _, repos = zip(
             *get_repos_gh(
                 git_connection,
@@ -431,7 +430,7 @@ def get_repos_from_git(git_connection, config: GitConfig):
         repos = gl_adapter.get_repos(projects)
     else:
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')
-    return repos, projects
+    return repos
 
 
 def get_nested_repos_from_git(git_connection, config: GitConfig):

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -406,8 +406,9 @@ def get_repos_from_git(git_connection, config: GitConfig):
 
     elif config.git_provider == 'github':
 
-        from jf_agent.git.github import get_repos as get_repos_gh
+        from jf_agent.git.github import get_repos as get_repos_gh, get_projects
 
+        projects = get_projects(git_connection, config.git_include_projects, config.git_redact_names_and_urls)
         _, repos = zip(
             *get_repos_gh(
                 git_connection,
@@ -430,4 +431,4 @@ def get_repos_from_git(git_connection, config: GitConfig):
         repos = gl_adapter.get_repos(projects)
     else:
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')
-    return repos
+    return repos, projects

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -903,9 +903,10 @@ def _remove_repos_present_in_git_instance(git_connection, git_config, missing_re
 
     try:
         # Cross reference any apparently missing repos found by Jira with actual Git repo sources since
-        # Jira may return inexact repo names/urls. Remove any mismatches found.
+        # Jira may return inexact repo names/urls. Remove any mismatches found.'
+        repos, _ = get_repos_from_git(git_connection, git_config)
         _remove_mismatched_repos(
-            missing_repositories, get_repos_from_git(git_connection, git_config), git_config
+            missing_repositories, repos, git_config
         )
     except Exception as e:
         print(

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -903,7 +903,7 @@ def _remove_repos_present_in_git_instance(git_connection, git_config, missing_re
 
     try:
         # Cross reference any apparently missing repos found by Jira with actual Git repo sources since
-        # Jira may return inexact repo names/urls. Remove any mismatches found.'
+        # Jira may return inexact repo names/urls. Remove any mismatches found.
         _remove_mismatched_repos(
             missing_repositories, get_repos_from_git(git_connection, git_config), git_config
         )

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -904,9 +904,8 @@ def _remove_repos_present_in_git_instance(git_connection, git_config, missing_re
     try:
         # Cross reference any apparently missing repos found by Jira with actual Git repo sources since
         # Jira may return inexact repo names/urls. Remove any mismatches found.'
-        repos, _ = get_repos_from_git(git_connection, git_config)
         _remove_mismatched_repos(
-            missing_repositories, repos, git_config
+            missing_repositories, get_repos_from_git(git_connection, git_config), git_config
         )
     except Exception as e:
         print(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -167,17 +167,17 @@ def main():
                     skip_ssl_verification=config.skip_ssl_verification,
                 )
 
-                all_repos, projects = git.get_repos_from_git(client, git_config)
+                project_repo_dict = git.get_nested_repos_from_git(client, git_config)
+                all_repos = sum(project_repo_dict.values(), [])
 
-                print(
-                    f"  Agent can view the following projects for this instance: {[proj.login for proj in projects]}"
-                )
-                print(
-                    f"  Agent can view the following repos for this instance: {[repo.name for repo in all_repos]}"
-                )
+                print("  All projects and repositories available to agent:")
+                for project_name, repo_list in project_repo_dict.items():
+                    print(f"  -- {project_name}")
+                    for repo in repo_list:
+                        print(f"    -- {repo}")
 
                 for repo in git_config.git_include_repos:
-                    if repo not in [x.name for x in all_repos]:
+                    if repo not in all_repos:
                         print(f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
                               f" proper permissions to view this repository.")
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -143,6 +143,32 @@ def main():
                     print(f'Error: Unable to access explicitly-included project {proj}.')
                     return
 
+        # Git diagnostics
+        import jf_agent.git as git
+
+        git_configs = config.git_configs
+
+        for i, git_config in enumerate(git_configs, start=1):
+            print(f"Git details for instance {i}/{len(git_configs)}:")
+            print(f"  Git provider: {git_config.git_provider}")
+            print(f"  Included Projects: {git_config.git_include_projects}")
+            if len(git_config.git_exclude_projects) > 0:
+                print(f"  Excluded Projects: {git_config.git_exclude_projects}")
+            print(f"  Included Repos: {git_config.git_include_repos}")
+            if len(git_config.git_exclude_repos) > 0:
+                print(f"  Excluded Projects: {git_config.git_exclude_repos}")
+
+            print(f'==> Testing Git connection...')
+
+            try:
+                client = git.get_git_client(git_config, list(creds.git_instance_to_creds.values())[i - 1],
+                                            skip_ssl_verification=config.skip_ssl_verification)
+
+                all_repos = git.get_repos_from_git(client, git_config)
+                print(f"  Agent can view the following repos for this instance: {[repo.name for repo in all_repos]}")
+            except Exception as e:
+                print("Git connection unsuccessful!")
+
         print('Success!')
 
         return

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -177,7 +177,7 @@ def main():
                 )
 
                 for repo in git_config.git_include_repos:
-                    if repo not in all_repos:
+                    if repo not in [x.name for x in all_repos]:
                         print(f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
                               f" proper permissions to view this repository.")
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -194,7 +194,6 @@ def main():
 
     else:
         jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
-        print(jellyfish_endpoint_info)
 
         print(f'Will write output files into {config.outdir}')
         diagnostics.open_file(config.outdir)

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -156,9 +156,9 @@ def main():
                 print(f"  Excluded Projects: {git_config.git_exclude_projects}")
             print(f"  Included Repos: {git_config.git_include_repos}")
             if len(git_config.git_exclude_repos) > 0:
-                print(f"  Excluded Projects: {git_config.git_exclude_repos}")
+                print(f"  Excluded Repos: {git_config.git_exclude_repos}")
 
-            print(f'==> Testing Git connection...')
+            print('==> Testing Git connection...')
 
             try:
                 client = git.get_git_client(
@@ -167,12 +167,22 @@ def main():
                     skip_ssl_verification=config.skip_ssl_verification,
                 )
 
-                all_repos = git.get_repos_from_git(client, git_config)
+                all_repos, projects = git.get_repos_from_git(client, git_config)
+
+                print(
+                    f"  Agent can view the following projects for this instance: {[proj.login for proj in projects]}"
+                )
                 print(
                     f"  Agent can view the following repos for this instance: {[repo.name for repo in all_repos]}"
                 )
+
+                for repo in git_config.git_include_repos:
+                    if repo not in all_repos:
+                        print(f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
+                              f" proper permissions to view this repository.")
+
             except Exception as e:
-                print("Git connection unsuccessful!")
+                print(f"Git connection unsuccessful! Exception: {e}")
 
         print('Success!')
 
@@ -184,6 +194,7 @@ def main():
 
     else:
         jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
+        print(jellyfish_endpoint_info)
 
         print(f'Will write output files into {config.outdir}')
         diagnostics.open_file(config.outdir)

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -161,11 +161,16 @@ def main():
             print(f'==> Testing Git connection...')
 
             try:
-                client = git.get_git_client(git_config, list(creds.git_instance_to_creds.values())[i - 1],
-                                            skip_ssl_verification=config.skip_ssl_verification)
+                client = git.get_git_client(
+                    git_config,
+                    list(creds.git_instance_to_creds.values())[i - 1],
+                    skip_ssl_verification=config.skip_ssl_verification,
+                )
 
                 all_repos = git.get_repos_from_git(client, git_config)
-                print(f"  Agent can view the following repos for this instance: {[repo.name for repo in all_repos]}")
+                print(
+                    f"  Agent can view the following repos for this instance: {[repo.name for repo in all_repos]}"
+                )
             except Exception as e:
                 print("Git connection unsuccessful!")
 


### PR DESCRIPTION
## Description
Currently, the agent’s “validate” mode checks that the agent can contact Jira, that it can enumerate Jira users, and that it has access to the Jira projects it’s configured for. This PR adds the following functionality:

- Ability to reach the Git instance(s) configured
- ability to see the Git orgs/project(s) configured

## Testing Strategy
Local agent "validate" mode runs
Agent output available upon request