### PR TITLE
OJ-9107: Enhance agent logging on `createmeta` permissions.

### DIFF
--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -684,7 +684,7 @@ def download_customfieldoptions(jira_connection, project_ids):
             meta = jira_connection.createmeta(
                 projectIds=[project_id], expand='projects.issuetypes.fields'
             )
-        except JIRAError as e:
+        except JIRAError:
             agent_logging.log_and_print_error_or_warning(
                 logger, logging.WARNING, error_code=3072, exc_info=False
             )

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -685,7 +685,9 @@ def download_customfieldoptions(jira_connection, project_ids):
                 projectIds=[project_id], expand='projects.issuetypes.fields'
             )
         except JIRAError as e:
-            logger.warning(f"{e}. Error calling createmeta JIRA endpoint. Skipping...")
+            agent_logging.log_and_print_error_or_warning(
+                logger, logging.WARNING, error_code=3072, exc_info=False
+            )
             return []
 
         # Custom values are buried deep in the createmeta response:

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -684,10 +684,8 @@ def download_customfieldoptions(jira_connection, project_ids):
             meta = jira_connection.createmeta(
                 projectIds=[project_id], expand='projects.issuetypes.fields'
             )
-        except JIRAError:
-            agent_logging.log_and_print_error_or_warning(
-                logger, logging.ERROR, error_code=3072, exc_info=True
-            )
+        except JIRAError as e:
+            logger.warning(f"{e}. Error calling createmeta JIRA endpoint. Skipping...")
             return []
 
         # Custom values are buried deep in the createmeta response:


### PR DESCRIPTION
## Description
When clients run their agent, sometimes there are comments on the output surrounding createmeta permissions. Most notably we display a 500 error in the traceback. While it's not necessarily an issue for the agent and doesn't stop it from running, for a client who isn't well aware of our Agent and pays attention to this, it can be concerning.

This PR removes the traceback and changes this error from an `Error` to a `Warning`.

## Testing Strategy
None. Straightforward change.

## Screenshots (if applicable)
N/A