### PR TITLE
OJ-11220: Add support for specifying commit branches for github, bitbucket, gitlab

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -176,6 +176,14 @@ git:
   # exclude_repos:
   #    - repo_to_skip
 
+  # Uncomment this to pull commit data from each of the specified branches for each repository.
+  # By default, we will pull commit data from only the default branch of a repository.
+  # include_branches: 
+  #    - my_repository: 
+  #      - master
+  #      - develop
+
+
   # Strip out long-form text content (commit messages, PR text, etc).
   strip_text_content: False
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -21,6 +21,7 @@ class GitConfig:
     git_exclude_projects: List
     git_include_repos: List
     git_exclude_repos: List
+    git_include_branches: dict
     git_strip_text_content: bool
     git_redact_names_and_urls: bool
     gitlab_per_page_override: bool
@@ -285,6 +286,7 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
     git_exclude_bbcloud_projects = set(git_config.get('exclude_bitbucket_cloud_projects', []))
     git_include_repos = set(git_config.get('include_repos', []))
     git_exclude_repos = set(git_config.get('exclude_repos', []))
+    git_include_branches = dict(git_config.get('include_branches', {}))
 
     if multiple and not git_instance_slug:
         print('ERROR: Git `instance_slug` is required for multiple Git instance mode.')
@@ -342,6 +344,7 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
         git_exclude_projects=list(git_exclude_projects),
         git_include_repos=list(git_include_repos),
         git_exclude_repos=list(git_exclude_repos),
+        git_include_branches=dict(git_include_branches),
         git_strip_text_content=git_config.get('strip_text_content', False),
         git_redact_names_and_urls=git_config.get('redact_names_and_urls', False),
         gitlab_per_page_override=git_config.get('gitlab_per_page_override', None),

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -92,6 +92,7 @@ class NormalizedCommit:
     author_date: str
     author: NormalizedUser
     repo: NormalizedShortRepository
+    branch_name: str
     is_merge: bool
 
 
@@ -156,7 +157,7 @@ class GitAdapter(ABC):
         pass
 
     @abstractmethod
-    def get_default_branch_commits(
+    def get_commits_for_included_branches(
         self, api_repos, server_git_instance_info
     ) -> List[NormalizedCommit]:
         pass
@@ -193,8 +194,8 @@ class GitAdapter(ABC):
                 self.outdir,
                 'bb_commits',
                 self.compress_output_files,
-                generator_func=self.get_default_branch_commits,
-                generator_func_args=(nrm_repos, endpoint_git_instance_info,),
+                generator_func=self.get_commits_for_included_branches,
+                generator_func_args=(nrm_repos, self.config.git_include_branches, endpoint_git_instance_info,),
                 item_id_dict_key='hash',
             )
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -142,35 +142,44 @@ class BitbucketCloudAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_default_branch_commits(
-        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
+    def get_commits_for_included_branches(
+        self, normalized_repos: List[NormalizedRepository], included_branches: dict, server_git_instance_info,
     ) -> List[NormalizedCommit]:
-        print('downloading bitbucket default branch commits... ', end='', flush=True)
+        print('downloading bitbucket commits on included branches... ', end='', flush=True)
+
         for i, repo in enumerate(normalized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
                     server_git_instance_info, repo.project.login, repo.id, 'commits'
                 )
-                for j, commit in enumerate(
-                    tqdm(
-                        self.client.get_commits(repo.project.id, repo.id, repo.default_branch_name),
-                        desc=f'downloading commits for {repo.name}',
-                        unit='commits',
-                    ),
-                    start=1,
-                ):
-                    with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
-                        commit = _normalize_commit(
-                            commit,
-                            repo,
-                            self.config.git_strip_text_content,
-                            self.config.git_redact_names_and_urls,
-                        )
-                        yield commit
 
-                        # yield one commit older than we want to see
-                        if commit.commit_date < pull_since:
-                            break
+                # Find branches for which we should pull commits, specified by customer in config.
+                # If specific branches are not specified, just pull from default branch.
+                branches_for_repo = included_branches.get(repo.name)
+                branches = branches_for_repo if branches_for_repo else [repo.default_branch_name]
+                
+                for branch in branches:
+                    for j, commit in enumerate(
+                        tqdm(
+                            self.client.get_commits(repo.project.id, repo.id, branch),
+                            desc=f'downloading commits for {repo.name} on branch {branch}',
+                            unit='commits',
+                        ),
+                        start=1,
+                    ):
+                        with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
+                            commit = _normalize_commit(
+                                commit,
+                                repo,
+                                branch,
+                                self.config.git_strip_text_content,
+                                self.config.git_redact_names_and_urls,
+                            )
+                            yield commit
+
+                            # yield one commit older than we want to see
+                            if commit.commit_date < pull_since:
+                                break
 
         print('✓')
 
@@ -313,7 +322,7 @@ def _normalize_branch(api_branch, redact_names_and_urls: bool) -> NormalizedBran
 
 
 def _normalize_commit(
-    api_commit, normalized_repo, strip_text_content: bool, redact_names_and_urls: bool
+    api_commit, normalized_repo, branch_name, strip_text_content: bool, redact_names_and_urls: bool
 ):
     author = _normalize_user(api_commit['author'])
     commit_url = api_commit['links']['html']['href'] if not redact_names_and_urls else None
@@ -326,6 +335,7 @@ def _normalize_commit(
         message=sanitize_text(api_commit['message'], strip_text_content),
         is_merge=len(api_commit['parents']) > 1,
         repo=normalized_repo.short(),  # use short form of repo
+        branch_name=branch_name if not redact_names_and_urls else _branch_redactor.redact_name(branch_name)
     )
 
 

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -67,10 +67,11 @@ def load_and_dump(
             outdir,
             'bb_commits',
             compress_output_files,
-            generator_func=get_default_branch_commits,
+            generator_func=get_commits_for_included_branches,
             generator_func_args=(
                 bb_conn,
                 api_repos,
+                config.git_include_branches,
                 config.git_strip_text_content,
                 endpoint_git_instance_info,
                 config.git_redact_names_and_urls,
@@ -219,7 +220,7 @@ def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_a
     print('✓')
 
 
-def _normalize_commit(commit, repo, strip_text_content, redact_names_and_urls):
+def _normalize_commit(commit, repo, branch_name, strip_text_content, redact_names_and_urls):
     return {
         'hash': commit['id'],
         'commit_date': datetime_from_bitbucket_server_timestamp(commit['committerTimestamp']),
@@ -233,12 +234,22 @@ def _normalize_commit(commit, repo, strip_text_content, redact_names_and_urls):
         'message': sanitize_text(commit.get('message'), strip_text_content),
         'is_merge': len(commit['parents']) > 1,
         'repo': _normalize_pr_repo(repo, redact_names_and_urls),
+        'branch_name': branch_name if not redact_names_and_urls else _branch_redactor.redact_name(branch_name)
     }
 
 
-def get_default_branch_commits(
-    client, api_repos, strip_text_content, server_git_instance_info, redact_names_and_urls, verbose,
+def get_commits_for_included_branches(
+    client, api_repos, included_branches, strip_text_content, server_git_instance_info, redact_names_and_urls, verbose,
 ):
+
+    # Determine branches to pull commits from for each repo. If no branches are explicitly
+    # provided in a config, only pull from the repo's default branch.
+    repo_name_to_branch_names = {}
+    for repo in api_repos:
+        repo_name = repo['name']
+        branches_for_repo = included_branches.get(repo_name)
+        repo_name_to_branch_names[repo_name] = branches_for_repo if branches_for_repo else [repo['default_branch']]
+
     for i, api_repo in enumerate(api_repos, start=1):
         with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
             repo = api_repo.get()
@@ -248,36 +259,37 @@ def get_default_branch_commits(
             pull_since = pull_since_date_for_repo(
                 server_git_instance_info, repo['project']['key'], repo['id'], 'commits'
             )
-            try:
 
-                default_branch = (
-                    api_repo.default_branch['displayId'] if api_repo.default_branch else ''
-                )
-                if verbose:
-                    print(f"Beginning download of commits for repo {repo['name']}.")
-                commits = api_project.repos[repo['name']].commits(until=default_branch)
+            # Find branches for which we should pull commits, specified by customer in config.
+            # If specific branches are not specified, just pull from default branch.
+            branches = repo_name_to_branch_names[repo['name']]
+            for branch in branches:
+                try:
+                    if verbose:
+                        print(f"Beginning download of commits on branch {branch} of repo {repo['name']}.")
+                    commits = api_project.repos[repo['name']].commits(until=branch)
 
-                for j, commit in enumerate(
-                    tqdm(commits, desc=f'downloading commits for {repo["name"]}', unit='commits'),
-                    start=1,
-                ):
-                    with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
-                        if verbose:
-                            print(f"Getting {commit['id']} ({repo['name']})")
-                        normalized_commit = _normalize_commit(
-                            commit, repo, strip_text_content, redact_names_and_urls
-                        )
-                        # commits are ordered newest to oldest
-                        # if this is too old, we're done with this repo
-                        if pull_since and normalized_commit['commit_date'] < pull_since:
-                            break
+                    for j, commit in enumerate(
+                        tqdm(commits, desc=f'downloading commits for {repo["name"]}', unit='commits'),
+                        start=1,
+                    ):
+                        with agent_logging.log_loop_iters(logger, 'branch commit inside repo', j, 100):
+                            if verbose:
+                                print(f"Getting {commit['id']} ({repo['name']})")
+                            normalized_commit = _normalize_commit(
+                                commit, repo, branch, strip_text_content, redact_names_and_urls
+                            )
+                            # commits are ordered newest to oldest
+                            # if this is too old, we're done with this repo
+                            if pull_since and normalized_commit['commit_date'] < pull_since:
+                                break
 
-                        yield normalized_commit
+                            yield normalized_commit
 
-            except stashy.errors.NotFoundException as e:
-                print(
-                    f'WARN: Got NotFoundException for branch \"{repo.get("default_branch_name", "")}\": {e}. Skipping...'
-                )
+                except stashy.errors.NotFoundException as e:
+                    print(
+                        f'WARN: Got NotFoundException for branch \"{branch}\": {e}. Skipping...'
+                    )
 
 
 def _normalize_pr_repo(repo, redact_names_and_urls):

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -180,10 +180,10 @@ class GitLabAdapter(GitAdapter):
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
-    def get_default_branch_commits(
-        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
+    def get_commits_for_included_branches(
+        self, normalized_repos: List[NormalizedRepository], included_branches: dict, server_git_instance_info,
     ) -> List[NormalizedCommit]:
-        print('downloading gitlab default branch commits... ', end='', flush=True)
+        print('downloading gitlab commits on included branches... ', end='', flush=True)
         for i, nrm_repo in enumerate(normalized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -160,6 +160,8 @@ def main():
             print(f"  Included Repos: {git_config.git_include_repos}")
             if len(git_config.git_exclude_repos) > 0:
                 print(f"  Excluded Repos: {git_config.git_exclude_repos}")
+            if len(git_config.git_include_branches) > 0:
+                print(f"  Included Branches: {git_config.git_include_branches}")
 
             print('==> Testing Git connection...')
 
@@ -184,6 +186,12 @@ def main():
                         print(
                             f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
                             f" proper permissions to view this repository."
+                        )
+                for repo in git_config.git_include_branches.keys():
+                    if repo not in all_repos:
+                        print(
+                            f"  WARNING: {repo} is explicitly defined as a repo for which specific branches should be" 
+                            f" processed, but Agent doesn't have proper permissions to view this repository."
                         )
 
             except Exception as e:


### PR DESCRIPTION
Description:
The agent assumes that only commits from the default branch of a repo should be downloaded. Customers want additional branches to be included in the download. Add a config option to specify branches for which commits should be downloaded for each repo. If no branches are given, just use the default branch as we do today.

Testing Strategy:
Ran agent locally against orthog's github. Verified that commits from a second non-develop branch are included in the json file outputs after this change. Also verified redaction still works. 

There is additional work required in git_import code to handle commits from new branches. Currently this code assumes that all commits are coming from the default branch
https://github.com/Jellyfish-AI/jellyfish/blob/0b37a88ee2e1de62b234c7bf14c4f3c8af1e924b/jf_github/git_import.py#L192

**Note 1**
I haven't figured out a great way to test non-github implementations. Orthog accounts for bitbucket have been removed per feedback from Alex and Eli and it is difficult to hit an existing customers instances. 
I can limit this PR to ONLY touch Github (which a requesting customer uses) but would have to add a note for customers in the example config that the new include_branches field is useless for non-Github users and this would increase divergence among the 4 git implementations until we can fix this.

**Note 2**
The current Gitlab implementation seems to ignore branches entirely and downloads all commits from a project:
https://github.com/Jellyfish-AI/jf_agent/blob/877d996228345dfdfd54138e9cfddccc27c5b5a3/jf_agent/git/gitlab_client.py#L139-L141

According to the API docs, a ref_name filter is needed to filter down to specific branches
https://python-gitlab.readthedocs.io/en/stable/gl_objects/commits.html

Perhaps I am missing something here, but I left Gitlab mostly untouched for the time being to avoid mucking up existing behavior until I understand this better.

Screenshots (if applicable):