### PR TITLE
[OJ-11721] Clean up, add verbose logging for bitbucket server

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from contextlib import contextmanager
 from functools import wraps
 import logging
@@ -135,3 +136,9 @@ def log_and_print_error_or_warning(logger, level, error_code, msg_args=[], exc_i
     print(msg, flush=True)
     if exc_info:
         print(traceback.format_exc())
+
+
+# TODO(asm,2021-08-12): This is sloppy, we should figure out a way to
+# get Python's native logging to behave the way we want.
+def verbose(msg):
+    print(f"[{datetime.now().isoformat()}] {msg}")

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -470,7 +470,9 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
 
         from jf_agent.git.bitbucket_cloud_adapter import BitbucketCloudAdapter
 
-        bbc_adapter = BitbucketCloudAdapter(config=config, outdir='', compress_output_files=False, client=git_connection)
+        bbc_adapter = BitbucketCloudAdapter(
+            config=config, outdir='', compress_output_files=False, client=git_connection
+        )
 
         projects = bbc_adapter.get_projects()
         for project in projects:


### PR DESCRIPTION
A customer is experiencing exceptionally long loading times when adding a new repository to their git configuration. This adds some extra diagnostic information (timestamps, pull_from date) when running bitbucket server in `verbose` mode.