### PR TITLE
OJ- 11977: Case insensitive comparisons for repo names

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -166,13 +166,13 @@ git:
 
   # Only pull from specific repos.  Comment this out to pull from all repos.
   # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (e.g.: my_repository)
-  # GitLab: use the GitLab "Project ID" (e.g.: 123)
+  # GitLab: use project ID (e.g.: 123) (not project name)
   include_repos:
       - my_repository
 
   # Uncomment this to pull from all but specific repos.
   # Bitbucket Server, Bitbucket Cloud, or GitHub: use repository name (e.g.: my_repository)
-  # GitLab: use the GitLab "Project ID" (e.g.: 123)
+  # GitLab: use project ID (e.g.: 123) (not project name)
   # exclude_repos:
   #    - repo_to_skip
 

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -457,7 +457,7 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
         if config.git_exclude_repos:
             filters.append(lambda r: r['name'] not in config.git_exclude_repos)
 
-        for api_project in projects:
+        for (api_project, _normalized_project_dict) in projects:
             project_repos = []
             project = git_connection.projects[api_project['key']]
             for repo in project.repos.list():

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -506,9 +506,12 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
 
         projects = gl_adapter.get_projects()
         for project in projects:
-            project_repos = [x.name for x in gl_adapter.get_repos([project])]
+            # For GitLab, the config file specifies repo IDs not names -- so that's what we want to validate with
+            # project_repos = [x.name for x in gl_adapter.get_repos([project])]
+            project_repos = [x.id for x in gl_adapter.get_repos([project])]
             output_dict[project.name] = project_repos
 
     else:
         raise ValueError(f'{config.git_provider} is not a supported git_provider for this run_mode')
+
     return output_dict

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -446,7 +446,6 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
     if config.git_provider == 'bitbucket_server':
 
         from jf_agent.git.bitbucket_server import get_projects as get_projects_bbs
-        from jf_agent.git.bitbucket_server import get_repos as get_repos_bbs, _normalize_repo
 
         projects = get_projects_bbs(
             git_connection, config.git_include_projects, config.git_exclude_projects, False
@@ -481,7 +480,7 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
 
     elif config.git_provider == 'github':
 
-        from jf_agent.git.github import get_repos as get_repos_gh, get_projects, _normalize_repo
+        from jf_agent.git.github import _normalize_repo
 
         filters = []
         if config.git_include_repos:

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -453,9 +453,14 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
 
         filters = []
         if config.git_include_repos:
-            filters.append(lambda r: r['name'] in config.git_include_repos)
+            filters.append(
+                lambda r: r['name'].lower() in set([r.lower() for r in config.git_include_repos])
+            )
         if config.git_exclude_repos:
-            filters.append(lambda r: r['name'] not in config.git_exclude_repos)
+            filters.append(
+                lambda r: r['name'].lower()
+                not in set([r.lower() for r in config.git_exclude_repos])
+            )
 
         for (api_project, _normalized_project_dict) in projects:
             project_repos = []
@@ -484,9 +489,14 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
 
         filters = []
         if config.git_include_repos:
-            filters.append(lambda r: r['name'] in config.git_include_repos)
+            filters.append(
+                lambda r: r['name'].lower() in set([r.lower() for r in config.git_include_repos])
+            )
         if config.git_exclude_repos:
-            filters.append(lambda r: r['name'] not in config.git_exclude_repos)
+            filters.append(
+                lambda r: r['name'].lower()
+                not in set([r.lower() for r in config.git_exclude_repos])
+            )
 
         for org in config.git_include_projects:
             org_repos = [

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -87,7 +87,11 @@ class BitbucketCloudAdapter(GitAdapter):
                     and api_repo['uuid'] not in self.config.git_include_repos
                 ):
                     if self.config.git_verbose:
-                        print(f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's not in git_include_repos''')
+                        agent_logging.log_and_print(
+                            logger,
+                            logging.INFO,
+                            f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's not in git_include_repos'''
+                        )
                     continue
 
                 # If we have an explicit repo deny list and this is in it, skip
@@ -96,7 +100,11 @@ class BitbucketCloudAdapter(GitAdapter):
                     or api_repo['uuid'] in self.config.git_exclude_repos
                 ):
                     if self.config.git_verbose:
-                        print(f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's in git_exclude_repos''')
+                        agent_logging.log_and_print(
+                            logger,
+                            logging.INFO,
+                            f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's in git_exclude_repos'''
+                        )
                     continue
 
                 # If this repo is in a project, apply project filters:
@@ -109,7 +117,9 @@ class BitbucketCloudAdapter(GitAdapter):
                         and repo_project['uuid'] not in self.config.git_include_bbcloud_projects
                     ):
                         if self.config.git_verbose:
-                            print(
+                            agent_logging.log_and_print(
+                                logger,
+                                logging.INFO,
                                 f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because its project '''
                                 f'''("{repo_project['key']}"/{repo_project['uuid']}) is not in git_include_bbcloud_projects'''
                             )
@@ -121,7 +131,9 @@ class BitbucketCloudAdapter(GitAdapter):
                         or repo_project['uuid'] in self.config.git_exclude_bbcloud_projects
                     ):
                         if self.config.git_verbose:
-                            print(
+                            agent_logging.log_and_print(
+                                logger,
+                                logging.INFO,
                                 f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because its project '''
                                 f'''("{repo_project['key']}"/{repo_project['uuid']}) is in git_exclude_bbcloud_projects'''
                             )

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -81,31 +81,38 @@ class BitbucketCloudAdapter(GitAdapter):
                 )
             ):
                 # If we have an explicit repo allow list and this isn't in it, skip
-                if (
-                    self.config.git_include_repos
-                    and api_repo['name'] not in self.config.git_include_repos
-                    and api_repo['uuid'] not in self.config.git_include_repos
-                ):
-                    if self.config.git_verbose:
-                        agent_logging.log_and_print(
-                            logger,
-                            logging.INFO,
-                            f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's not in git_include_repos'''
-                        )
-                    continue
+                if self.config.git_include_repos:
+                    git_include_repos_lowered = set(
+                        n.lower() for n in self.config.git_include_repos
+                    )
+                    if (
+                        api_repo['name'].lower() not in git_include_repos_lowered
+                        and api_repo['uuid'].lower() not in git_include_repos_lowered
+                    ):
+                        if self.config.git_verbose:
+                            agent_logging.log_and_print(
+                                logger,
+                                logging.INFO,
+                                f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's not in git_include_repos''',
+                            )
+                        continue
 
                 # If we have an explicit repo deny list and this is in it, skip
-                if self.config.git_exclude_repos and (
-                    api_repo['name'] in self.config.git_exclude_repos
-                    or api_repo['uuid'] in self.config.git_exclude_repos
-                ):
-                    if self.config.git_verbose:
-                        agent_logging.log_and_print(
-                            logger,
-                            logging.INFO,
-                            f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's in git_exclude_repos'''
-                        )
-                    continue
+                if self.config.git_exclude_repos:
+                    git_exclude_repos_lowered = set(
+                        n.lower() for n in self.config.git_exclude_repos
+                    )
+                    if (
+                        api_repo['name'].lower() in git_exclude_repos_lowered
+                        or api_repo['uuid'].lower() in git_exclude_repos_lowered
+                    ):
+                        if self.config.git_verbose:
+                            agent_logging.log_and_print(
+                                logger,
+                                logging.INFO,
+                                f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because it's in git_exclude_repos''',
+                            )
+                        continue
 
                 # If this repo is in a project, apply project filters:
                 repo_project = api_repo.get('project')
@@ -121,7 +128,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 logger,
                                 logging.INFO,
                                 f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because its project '''
-                                f'''("{repo_project['key']}"/{repo_project['uuid']}) is not in git_include_bbcloud_projects'''
+                                f'''("{repo_project['key']}"/{repo_project['uuid']}) is not in git_include_bbcloud_projects''',
                             )
                         continue
 
@@ -135,7 +142,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 logger,
                                 logging.INFO,
                                 f'''Skipping repo "{api_repo['name']}" ({api_repo['uuid']}) because its project '''
-                                f'''("{repo_project['key']}"/{repo_project['uuid']}) is in git_exclude_bbcloud_projects'''
+                                f'''("{repo_project['key']}"/{repo_project['uuid']}) is in git_exclude_bbcloud_projects''',
                             )
                         continue
 

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -207,9 +207,9 @@ def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_a
 
     filters = []
     if include_repos:
-        filters.append(lambda r: r['name'] in include_repos)
+        filters.append(lambda r: r['name'].lower() in set([r.lower() for r in include_repos]))
     if exclude_repos:
-        filters.append(lambda r: r['name'] not in exclude_repos)
+        filters.append(lambda r: r['name'].lower() not in set([r.lower() for r in exclude_repos]))
 
     for api_project in api_projects:
         project = client.projects[api_project['key']]

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -205,9 +205,9 @@ def get_repos(
 
     filters = []
     if include_repos:
-        filters.append(lambda r: r['name'] in include_repos)
+        filters.append(lambda r: r['name'].lower() in set([r.lower() for r in include_repos]))
     if exclude_repos:
-        filters.append(lambda r: r['name'] not in exclude_repos)
+        filters.append(lambda r: r['name'].lower() not in set([r.lower() for r in exclude_repos]))
 
     repos = [
         (r, _normalize_repo(client, org, r, redact_names_and_urls))

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -99,6 +99,8 @@ class GitLabAdapter(GitAdapter):
             ):
                 if (
                     self.config.git_include_repos
+                    # For GitLab, git_include_repos holds IDs instead of names (probably unintentionally), so
+                    # no need to be case insensitive
                     and api_repo.id not in self.config.git_include_repos
                 ):
                     if self.config.git_verbose:
@@ -108,7 +110,13 @@ class GitLabAdapter(GitAdapter):
                             f'skipping repo {api_repo.id} because not in include_repos...',
                         )
                     continue  # skip this repo
-                if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
+
+                if (
+                    self.config.git_exclude_repos
+                    # For GitLab, git_exclude_repos holds IDs instead of names (probably unintentionally), so
+                    # no need to be case insensitive
+                    and api_repo.id in self.config.git_exclude_repos
+                ):
                     if self.config.git_verbose:
                         agent_logging.log_and_print(
                             logger,
@@ -303,7 +311,9 @@ class GitLabAdapter(GitAdapter):
                 except Exception as e:
                     # if something happens when pulling PRs for a repo, just keep going.
                     log_and_print_request_error(
-                        e, f'getting PRs for repo {nrm_repo.name} ({nrm_repo.id}). Skipping...', log_as_exception=True
+                        e,
+                        f'getting PRs for repo {nrm_repo.name} ({nrm_repo.id}). Skipping...',
+                        log_as_exception=True,
                     )
 
     print('✓')

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -101,18 +101,20 @@ class GitLabAdapter(GitAdapter):
                     self.config.git_include_repos
                     and api_repo.id not in self.config.git_include_repos
                 ):
-                    agent_logging.log_and_print(
-                        logger,
-                        logging.INFO,
-                        f'skipping repo {api_repo.id} because not in include_repos...',
-                    )
+                    if self.config.git_verbose:
+                        agent_logging.log_and_print(
+                            logger,
+                            logging.INFO,
+                            f'skipping repo {api_repo.id} because not in include_repos...',
+                        )
                     continue  # skip this repo
                 if self.config.git_exclude_repos and api_repo.id in self.config.git_exclude_repos:
-                    agent_logging.log_and_print(
-                        logger,
-                        logging.INFO,
-                        f'skipping repo {api_repo.id} because in exclude_repos...',
-                    )
+                    if self.config.git_verbose:
+                        agent_logging.log_and_print(
+                            logger,
+                            logging.INFO,
+                            f'skipping repo {api_repo.id} because in exclude_repos...',
+                        )
                     continue  # skip this repo
 
                 try:

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -195,7 +195,7 @@ class GitLabAdapter(GitAdapter):
                     for j, commit in enumerate(
                         tqdm(
                             self.client.list_project_commits(nrm_repo.id, pull_since),
-                            desc=f'downloading commits for {nrm_repo.name}',
+                            desc=f'downloading commits for {nrm_repo.name} ({nrm_repo.id})',
                             unit='commits',
                         ),
                         start=1,
@@ -223,33 +223,22 @@ class GitLabAdapter(GitAdapter):
     ) -> List[NormalizedPullRequest]:
         print('downloading gitlab prs... ', end='', flush=True)
 
-        for i, nrm_repo in enumerate(
-            tqdm(normalized_repos, desc='downloading prs for repos', unit='repos'), start=1
-        ):
+        for i, nrm_repo in enumerate(normalized_repos, start=1):
+            print(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')
 
             with agent_logging.log_loop_iters(logger, 'repo for pull requests', i, 1):
                 try:
-
                     pull_since = pull_since_date_for_repo(
                         server_git_instance_info, nrm_repo.project.login, nrm_repo.id, 'prs'
                     )
 
                     api_prs = self.client.list_project_merge_requests(nrm_repo.id)
-                    total_api_prs = api_prs.total
-
-                    if total_api_prs == 0:
-                        agent_logging.log_and_print(
-                            logger,
-                            logging.INFO,
-                            f'no prs found for repo {nrm_repo.id}. Skipping... ',
-                        )
-                        continue
 
                     for api_pr in tqdm(
                         api_prs,
-                        desc=f'processing prs for {nrm_repo.name}',
+                        desc=f'processing prs for {nrm_repo.name} ({nrm_repo.id})',
                         unit='prs',
-                        total=total_api_prs,
+                        total=api_prs.total,
                     ):
                         try:
                             updated_at = parser.parse(api_pr.updated_at)
@@ -307,14 +296,14 @@ class GitLabAdapter(GitAdapter):
                             pr_id = f' {api_pr.id}' if api_pr else ''
                             log_and_print_request_error(
                                 e,
-                                f'normalizing PR {pr_id} from repo {nrm_repo.id}. Skipping...',
+                                f'normalizing PR {pr_id} from repo {nrm_repo.name} ({nrm_repo.id}). Skipping...',
                                 log_as_exception=True,
                             )
 
                 except Exception as e:
                     # if something happens when pulling PRs for a repo, just keep going.
                     log_and_print_request_error(
-                        e, f'getting PRs for repo {nrm_repo.id}. Skipping...', log_as_exception=True
+                        e, f'getting PRs for repo {nrm_repo.name} ({nrm_repo.id}). Skipping...', log_as_exception=True
                     )
 
     print('✓')

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -104,18 +104,18 @@ def main():
         if config.jira_url and creds.jira_username and creds.jira_password:
             validate_jira(config, creds)
         else:
-            print("No jira URL or credentials provided, skipping jira validation...")
+            print("\nNo Jira URL or credentials provided, skipping Jira validation...")
 
         # Check for Git configs
         if config.git_configs:
             validate_git(config, creds)
         else:
-            print("No git configs provided, skipping git validation...")
+            print("\nNo Git configs provided, skipping Git validation...")
 
         # Finally, display memory usage statistics.
         validate_memory()
 
-        print("Success!")
+        print("\nDone")
 
         return True
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -302,9 +302,7 @@ def _validate_memory():
             f"  Available memory: {round(psutil.virtual_memory().available / (1024 * 1024), 2)}MB"
         )
 
-        output_dir_size = (
-            os.popen('du -hs /home/jf_agent/output/').readlines()[0].split("\t")[0]
-        )
+        output_dir_size = os.popen('du -hs /home/jf_agent/output/').readlines()[0].split("\t")[0]
         usage = shutil.disk_usage('/home/jf_agent/output/')
 
         print(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -29,6 +29,7 @@ from jf_agent.jf_jira import (
     print_missing_repos_found_by_jira,
 )
 from jf_agent.session import retry_session
+from jf_agent.validation import validate_jira, validate_git, validate_memory
 
 logger = logging.getLogger(__name__)
 
@@ -101,18 +102,18 @@ def main():
 
         # Check for Jira credentials
         if config.jira_url and creds.jira_username and creds.jira_password:
-            _validate_jira(config, creds)
+            validate_jira(config, creds)
         else:
             print("No jira URL or credentials provided, skipping jira validation...")
 
         # Check for Git configs
         if config.git_configs:
-            _validate_git(config, creds)
+            validate_git(config, creds)
         else:
             print("No git configs provided, skipping git validation...")
 
         # Finally, display memory usage statistics.
-        _validate_memory()
+        validate_memory()
 
         print("Success!")
 
@@ -184,134 +185,6 @@ def main():
     print('Done!')
 
     return success
-
-
-def _validate_jira(config, creds):
-    """
-    Validates jira configuration and credentials.
-    """
-    from jf_jira import _get_raw_jira_connection
-
-    print('Jira details:')
-    print(f'  Jira URL:      {config.jira_url}')
-    print(f'  Jira Username: {creds.jira_username}')
-    pw_len = len(creds.jira_password) - 2
-    print(f'  Jira Password: {creds.jira_password[:2]:*<{pw_len}}')
-    # test Jira connection
-    try:
-        print('==> Testing jira connection...')
-        jira_connection = _get_raw_jira_connection(config, creds, max_retries=1)
-        jira_connection.myself()
-    except Exception as e:
-        if 'Basic authentication with passwords is deprecated.' in str(e):
-            print(
-                f'Error connecting to Jira instance at {config.jira_url}. Please use a Jira API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html.'
-            )
-        else:
-            print(
-                f'Error connecting to Jira instance at {config.jira_url}, please validate your credentials. Error: {e}'
-            )
-        return False
-
-    # test jira users permission
-    try:
-        print('==> Testing jira user browsing permissions...')
-        from jf_jira.jira_download import download_users
-
-        user_count = len(download_users(jira_connection, config.jira_gdpr_active, quiet=True))
-        print(f'The agent is aware of {user_count} Jira users.')
-
-    except Exception as e:
-        print(
-            f'Error downloading users from Jira instance at {config.jira_url}, please verify that this user has the "browse all users" permission. Error: {e}'
-        )
-        return False
-
-    # test jira project access
-    print('==> Testing jira project permissions...')
-    accessible_projects = [p.key for p in jira_connection.projects()]
-    print(f'The agent has access to projects {accessible_projects}.')
-
-    if config.jira_include_projects:
-        for proj in config.jira_include_projects:
-            if proj not in accessible_projects:
-                print(f'Error: Unable to access explicitly-included project {proj}.')
-                return False
-
-
-def _validate_git(config, creds):
-    """
-    Validates git config and credentials.
-    """
-    import jf_agent.git as git
-
-    git_configs = config.git_configs
-
-    for i, git_config in enumerate(git_configs, start=1):
-        print(f"Git details for instance {i}/{len(git_configs)}:")
-        print(f"  Git provider: {git_config.git_provider}")
-        print(f"  Included Projects: {git_config.git_include_projects}")
-        if len(git_config.git_exclude_projects) > 0:
-            print(f"  Excluded Projects: {git_config.git_exclude_projects}")
-        print(f"  Included Repos: {git_config.git_include_repos}")
-        if len(git_config.git_exclude_repos) > 0:
-            print(f"  Excluded Repos: {git_config.git_exclude_repos}")
-
-        print('==> Testing Git connection...')
-
-        try:
-            client = git.get_git_client(
-                git_config,
-                list(creds.git_instance_to_creds.values())[i - 1],
-                skip_ssl_verification=config.skip_ssl_verification,
-            )
-
-            project_repo_dict = git.get_nested_repos_from_git(client, git_config)
-            all_repos = sum(project_repo_dict.values(), [])
-
-            print("  All projects and repositories available to agent:")
-            for project_name, repo_list in project_repo_dict.items():
-                print(f"  -- {project_name}")
-                for repo in repo_list:
-                    print(f"    -- {repo}")
-
-            for repo in git_config.git_include_repos:
-                if repo not in all_repos:
-                    print(
-                        f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
-                        f" proper permissions to view this repository."
-                    )
-
-        except Exception as e:
-            print(f"Git connection unsuccessful! Exception: {e}")
-            return False
-
-
-def _validate_memory():
-    """
-    Displays memory and disk usage statistics.
-    """
-    import os
-    import shutil
-    import psutil
-
-    print("Memory & Disk Usage:")
-
-    try:
-        print(
-            f"  Available memory: {round(psutil.virtual_memory().available / (1024 * 1024), 2)}MB"
-        )
-
-        output_dir_size = os.popen('du -hs /home/jf_agent/output/').readlines()[0].split("\t")[0]
-        usage = shutil.disk_usage('/home/jf_agent/output/')
-
-        print(
-            f'  Disk space used: {round(usage.used / (1024 ** 3), 5)}GB / {round(usage.total / 1024 ** 3, 5)}GB'
-        )
-        print(f"  Size of output dir: {output_dir_size}")
-    except Exception as e:
-        print(f"  ERROR: Could not obtain memory and/or disk usage information. {e}")
-        return False
 
 
 UserProvidedCreds = namedtuple(

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -1,0 +1,126 @@
+import os
+import psutil
+import shutil
+
+from jf_jira import _get_raw_jira_connection
+from jf_jira.jira_download import download_users
+from jf_agent.git import get_git_client, get_nested_repos_from_git
+
+
+def validate_jira(config, creds):
+    """
+    Validates jira configuration and credentials.
+    """
+
+    print('Jira details:')
+    print(f'  Jira URL:      {config.jira_url}')
+    print(f'  Jira Username: {creds.jira_username}')
+    pw_len = len(creds.jira_password) - 2
+    print(f'  Jira Password: {creds.jira_password[:2]:*<{pw_len}}')
+    # test Jira connection
+    try:
+        print('==> Testing jira connection...')
+        jira_connection = _get_raw_jira_connection(config, creds, max_retries=1)
+        jira_connection.myself()
+    except Exception as e:
+        if 'Basic authentication with passwords is deprecated.' in str(e):
+            print(
+                f'Error connecting to Jira instance at {config.jira_url}. Please use a Jira API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html.'
+            )
+        else:
+            print(
+                f'Error connecting to Jira instance at {config.jira_url}, please validate your credentials. Error: {e}'
+            )
+        return False
+
+    # test jira users permission
+    try:
+        print('==> Testing jira user browsing permissions...')
+        user_count = len(download_users(jira_connection, config.jira_gdpr_active, quiet=True))
+        print(f'The agent is aware of {user_count} Jira users.')
+
+    except Exception as e:
+        print(
+            f'Error downloading users from Jira instance at {config.jira_url}, please verify that this user has the "browse all users" permission. Error: {e}'
+        )
+        return False
+
+    # test jira project access
+    print('==> Testing jira project permissions...')
+    accessible_projects = [p.key for p in jira_connection.projects()]
+    print(f'The agent has access to projects {accessible_projects}.')
+
+    if config.jira_include_projects:
+        for proj in config.jira_include_projects:
+            if proj not in accessible_projects:
+                print(f'Error: Unable to access explicitly-included project {proj}.')
+                return False
+
+
+def validate_git(config, creds):
+    """
+    Validates git config and credentials.
+    """
+    git_configs = config.git_configs
+
+    for i, git_config in enumerate(git_configs, start=1):
+        print(f"Git details for instance {i}/{len(git_configs)}:")
+        print(f"  Git provider: {git_config.git_provider}")
+        print(f"  Included Projects: {git_config.git_include_projects}")
+        if len(git_config.git_exclude_projects) > 0:
+            print(f"  Excluded Projects: {git_config.git_exclude_projects}")
+        print(f"  Included Repos: {git_config.git_include_repos}")
+        if len(git_config.git_exclude_repos) > 0:
+            print(f"  Excluded Repos: {git_config.git_exclude_repos}")
+
+        print('==> Testing Git connection...')
+
+        try:
+            client = get_git_client(
+                git_config,
+                list(creds.git_instance_to_creds.values())[i - 1],
+                skip_ssl_verification=config.skip_ssl_verification,
+            )
+
+            project_repo_dict = get_nested_repos_from_git(client, git_config)
+            all_repos = sum(project_repo_dict.values(), [])
+
+            print("  All projects and repositories available to agent:")
+            for project_name, repo_list in project_repo_dict.items():
+                print(f"  -- {project_name}")
+                for repo in repo_list:
+                    print(f"    -- {repo}")
+
+            for repo in git_config.git_include_repos:
+                if repo not in all_repos:
+                    print(
+                        f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
+                        f" proper permissions to view this repository."
+                    )
+
+        except Exception as e:
+            print(f"Git connection unsuccessful! Exception: {e}")
+            return False
+
+
+def validate_memory():
+    """
+    Displays memory and disk usage statistics.
+    """
+    print("Memory & Disk Usage:")
+
+    try:
+        print(
+            f"  Available memory: {round(psutil.virtual_memory().available / (1024 * 1024), 2)}MB"
+        )
+
+        output_dir_size = os.popen('du -hs /home/jf_agent/output/').readlines()[0].split("\t")[0]
+        usage = shutil.disk_usage('/home/jf_agent/output/')
+
+        print(
+            f'  Disk space used: {round(usage.used / (1024 ** 3), 5)}GB / {round(usage.total / 1024 ** 3, 5)}GB'
+        )
+        print(f"  Size of output dir: {output_dir_size}")
+    except Exception as e:
+        print(f"  ERROR: Could not obtain memory and/or disk usage information. {e}")
+        return False

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -12,14 +12,14 @@ def validate_jira(config, creds):
     Validates jira configuration and credentials.
     """
 
-    print('Jira details:')
-    print(f'  Jira URL:      {config.jira_url}')
-    print(f'  Jira Username: {creds.jira_username}')
+    print('\nJira details:')
+    print(f'  URL:      {config.jira_url}')
+    print(f'  Username: {creds.jira_username}')
     pw_len = len(creds.jira_password) - 2
-    print(f'  Jira Password: {creds.jira_password[:2]:*<{pw_len}}')
+    print(f'  Password: {creds.jira_password[:2]:*<{pw_len}}')
     # test Jira connection
     try:
-        print('==> Testing jira connection...')
+        print('==> Testing Jira connection...')
         jira_connection = _get_raw_jira_connection(config, creds, max_retries=1)
         jira_connection.myself()
     except Exception as e:
@@ -35,7 +35,7 @@ def validate_jira(config, creds):
 
     # test jira users permission
     try:
-        print('==> Testing jira user browsing permissions...')
+        print('==> Testing Jira user browsing permissions...')
         user_count = len(download_users(jira_connection, config.jira_gdpr_active, quiet=True))
         print(f'The agent is aware of {user_count} Jira users.')
 
@@ -46,7 +46,7 @@ def validate_jira(config, creds):
         return False
 
     # test jira project access
-    print('==> Testing jira project permissions...')
+    print('==> Testing Jira project permissions...')
     accessible_projects = [p.key for p in jira_connection.projects()]
     print(f'The agent has access to projects {accessible_projects}.')
 
@@ -64,14 +64,14 @@ def validate_git(config, creds):
     git_configs = config.git_configs
 
     for i, git_config in enumerate(git_configs, start=1):
-        print(f"Git details for instance {i}/{len(git_configs)}:")
-        print(f"  Git provider: {git_config.git_provider}")
-        print(f"  Included Projects: {git_config.git_include_projects}")
+        print(f"\nGit details for instance {i}/{len(git_configs)}:")
+        print(f"  Provider: {git_config.git_provider}")
+        print(f"  Included projects: {git_config.git_include_projects}")
         if len(git_config.git_exclude_projects) > 0:
-            print(f"  Excluded Projects: {git_config.git_exclude_projects}")
-        print(f"  Included Repos: {git_config.git_include_repos}")
+            print(f"  Excluded projects: {git_config.git_exclude_projects}")
+        print(f"  Included repos: {git_config.git_include_repos}")
         if len(git_config.git_exclude_repos) > 0:
-            print(f"  Excluded Repos: {git_config.git_exclude_repos}")
+            print(f"  Excluded repos: {git_config.git_exclude_repos}")
 
         print('==> Testing Git connection...')
 
@@ -94,8 +94,8 @@ def validate_git(config, creds):
             for repo in git_config.git_include_repos:
                 if repo not in all_repos:
                     print(
-                        f"  WARNING: {repo} is explicitly defined as an included repo, but Agent doesn't have"
-                        f" proper permissions to view this repository."
+                        f"  WARNING: {repo} is explicitly defined as an included repo, but agent doesn't seem"
+                        f" to see this repository -- possibly missing permissions."
                     )
 
         except Exception as e:
@@ -107,20 +107,21 @@ def validate_memory():
     """
     Displays memory and disk usage statistics.
     """
-    print("Memory & Disk Usage:")
+    print("\nMemory & Disk Usage:")
 
     try:
         print(
-            f"  Available memory: {round(psutil.virtual_memory().available / (1024 * 1024), 2)}MB"
+            f"  Available memory: {round(psutil.virtual_memory().available / (1024 * 1024), 2)} MB"
         )
 
         output_dir_size = os.popen('du -hs /home/jf_agent/output/').readlines()[0].split("\t")[0]
         usage = shutil.disk_usage('/home/jf_agent/output/')
 
         print(
-            f'  Disk space used: {round(usage.used / (1024 ** 3), 5)}GB / {round(usage.total / 1024 ** 3, 5)}GB'
+            f'  Disk usage for jf_agent/output: {int(round(usage.used / (1024 ** 3)))} GB / {int(round(usage.total / 1024 ** 3))} GB'
         )
-        print(f"  Size of output dir: {output_dir_size}")
+        print(f"  Size of jf_agent/output dir: {output_dir_size}")
+
     except Exception as e:
         print(f"  ERROR: Could not obtain memory and/or disk usage information. {e}")
         return False

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -92,7 +92,15 @@ def validate_git(config, creds):
                     print(f"    -- {repo}")
 
             for repo in git_config.git_include_repos:
-                if repo not in all_repos:
+                # Messy: GitLab repos are specified as as ints, not strings
+                if type(repo) == int:
+                    def comp_func(repo):
+                        return repo not in all_repos
+                else:
+                    def comp_func(repo):
+                        return repo.lower() not in set(n.lower() for n in all_repos)
+
+                if comp_func(repo):
                     print(
                         f"  WARNING: {repo} is explicitly defined as an included repo, but agent doesn't seem"
                         f" to see this repository -- possibly missing permissions."

--- a/tests/test_bitbucket_cloud_adapter.py
+++ b/tests/test_bitbucket_cloud_adapter.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 from jf_agent.git import NormalizedShortRepository
 from jf_agent.git.bitbucket_cloud_adapter import BitbucketCloudAdapter
 
-TEST_INPUT_FILE_PATH = f'tests/test_data/bitbucket_cloud/'
+TEST_INPUT_FILE_PATH = 'tests/test_data/bitbucket_cloud/'
 
 
 class TestBitbucketCloudAdapter(TestCase):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -139,11 +139,7 @@ class TestGithub(TestCase):
         # Act
         result_commits = list(
             github.get_default_branch_commits(
-                mock_client,
-                test_repos,
-                False,
-                test_git_instance_info,
-                False,
+                mock_client, test_repos, False, test_git_instance_info, False,
             )
         )
 

--- a/tests/test_gitlab_adapter.py
+++ b/tests/test_gitlab_adapter.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 from jf_agent.git import NormalizedShortRepository
 from jf_agent.git.gitlab_adapter import GitLabAdapter
 
-TEST_INPUT_FILE_PATH = f'tests/test_data/gitlab/'
+TEST_INPUT_FILE_PATH = 'tests/test_data/gitlab/'
 
 
 class TestGitLabAdapter(TestCase):


### PR DESCRIPTION
When comparing repo names against include_repos/exclude_repos from the config file, use case INsensitive comparisons.

Also a few other small bug fixes, messaging tweaks, minor code re-org.

Have tested for all four providers.
