### PR TITLE
OJ-12430: Include traceback for Gitlab Exceptions

### DIFF
--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -22,7 +22,7 @@ def log_and_print_request_error(e, action='making request', log_as_exception=Fal
 
     if log_as_exception:
         agent_logging.log_and_print_error_or_warning(
-            logger, logging.ERROR, msg_args=[error_name, response_code, action, e], error_code=3131,
+            logger, logging.ERROR, msg_args=[error_name, response_code, action, e], error_code=3131, exc_info=True
         )
     else:
         agent_logging.log_and_print_error_or_warning(


### PR DESCRIPTION
Currently missing traceback information for logged GitLab exceptions, add this for more information in debugging scenarios.