### PR TITLE
[OJ-12496] Add bearer token authorization for Jira Server

### DIFF
--- a/docs/_setups/jira-setup.md
+++ b/docs/_setups/jira-setup.md
@@ -2,6 +2,10 @@
 title: Jira Setup
 ---
 
+Before you begin, determine which credential setup you will need to use. Most of the time, you will want to set up credentials using basic auth. If you are running Jira server (i.e. not Jira cloud) and have [disabled basic authentication](https://confluence.atlassian.com/enterprise/disabling-basic-authentication-1044776464.html), you will want to use bearer token auth. If you aren't sure, use basic auth.
+
+## Basic Auth
+
 1. Add the following section to your environment variable file. This is the same file mentioned in step 3 above. Adding the following variables allows the agent to access your Jira data:
     <p class="code-block"><code>
         JIRA_USERNAME=...<br/>
@@ -11,5 +15,18 @@ title: Jira Setup
 2. Get a value for `JIRA_USERNAME`. Choose a Jira username that has read access to all of the projects you would like to use in Jellyfish.
 
 3. The value for `JIRA_PASSWORD` will vary. If you are using Jira server, enter the password for the user specified with `JIRA_USERNAME`. If you are using Jira Cloud, create a personal API token, following the instructions [here](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
+
+4. Populate the appropriate values for your Jira configuration in the `example.yml` file you copied above from step 1. This is [this](https://github.com/Jellyfish-AI/jf_agent/blob/master/example.yml#L13-L111) section of the yml file. Follow the instructions provided in the yml file.
+
+## Bearer Token Auth
+
+1. Create a user in your Jira server that has read access to all projects you would like the agent to ingest. If you have already created such a user, open a browser while logged in as said user.
+
+2. Retrieve a Personal Access Token for the user from step 2 following [this guide](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html).
+
+3. Add the following section to your environment variable file. This is the same file mentioned in step 3 above. Adding the following variables allows the agent to access your Jira data:
+    <p class="code-block"><code>
+        JIRA_BEARER_TOKEN=...<br/>
+    </code></p>
 
 4. Populate the appropriate values for your Jira configuration in the `example.yml` file you copied above from step 1. This is [this](https://github.com/Jellyfish-AI/jf_agent/blob/master/example.yml#L13-L111) section of the yml file. Follow the instructions provided in the yml file.


### PR DESCRIPTION
In cases where a customer has disabled basic authentication on Jira server (see [here](https://confluence.atlassian.com/enterprise/disabling-basic-authentication-1044776464.html)) we want to allow using `Authorization: Bearer <token>` headers directly instead of forcing all users to use basic auth. This is a bit hacky but will allow customers to use bearer tokens in the short term.

Tested this locally against a Jira server running in Docker on which I disabled basic authentication and against the Jellyfish cloud Jira instance, both of which worked.

Patch has also been submitted upstream, so we should use that if/when it is merged.