### PR TITLE
OJ-12746: Handle NotFoundException for default branch

### DIFF
--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -495,4 +495,7 @@ def get_pull_requests(
                 )
 
 def _get_default_branch_name(api_repo):
-    return api_repo.default_branch['displayId'] if api_repo.default_branch else ''
+    try:
+        return api_repo.default_branch['displayId'] if api_repo.default_branch else ''
+    except stashy.errors.NotFoundException:
+        return ''


### PR DESCRIPTION
This try catch used to exist:
https://github.com/Jellyfish-AI/jf_agent/blob/471a4f12147005a792e830eb8abd03d1b2a51708/jf_agent/git/bitbucket_server.py#L171-L176

It was not ported over in a refactoring to facilitate pulling commits from non-default branches. Adding it back to avoid NotFoundExceptions in cases where the default branch of a repo can not be retrieved.


