### PR TITLE
fix(gitlab): handle exception on group api call

### DIFF
--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -51,12 +51,20 @@ class GitLabAdapter(GitAdapter):
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[NormalizedProject]:
         print('downloading gitlab projects... ', end='', flush=True)
-        projects = [
-            _normalize_project(
-                self.client.get_group(project_id),
-                self.config.git_redact_names_and_urls,  # are group_ids
+        projects = []
+
+        for project_id in self.config.git_include_projects:
+            group = self.client.get_group(project_id)
+
+            if group is None:  # skip groups that errored out when fetching data
+                continue
+
+            projects.append(
+                _normalize_project(
+                    group,
+                    self.config.git_redact_names_and_urls,  # are group_ids
+                )
             )
-            for project_id in self.config.git_include_projects
         ]
         print('✓')
 

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -113,17 +113,25 @@ class GitLabClient:
         return merge_request
 
     def get_group(self, group_id):
-        return self.client.groups.get(group_id)
+        try:
+            return self.client.groups.get(group_id)
+        except gitlab.exceptions.GitlabGetError as e:
+            log_and_print_request_error(e, f'error fetching data for group {group_id}')
+            return None
 
     def get_project(self, project_id):
         return self.client.projects.get(project_id)
 
     def list_group_projects(self, group_id):
         group = self.get_group(group_id)
+        if group is None:
+            return []
         return group.projects.list(as_list=False, include_subgroups=True)
 
     def list_group_members(self, group_id):
         group = self.get_group(group_id)
+        if group is None:
+            return []
         return group.members.list(as_list=False)
 
     def list_project_branches(self, project_id):


### PR DESCRIPTION
we're relying on statically specifying the gitlab groups that the jellyfish agent should be fetching data from; currently, any time someone deletes a group that is specified on the jellyfish config file, the agent will crash when GitLab's API returns an http404 status code, causing no data to be sent to jellyfish even if all the rest of the groups still exist

<details>
  <summary>agent log when this happens</summary>

```python
Will write output files into ./output/20211129_033121
Obtained gitlab configuration, attempting download...
✓
downloading gitlab projects... [3061] Failed to download gitlab data:
404: 404 Group Not Found
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/gitlab/exceptions.py", line 304, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/gitlab/mixins.py", line 112, in get
    server_data = self.gitlab.http_get(path, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/gitlab/client.py", line 663, in http_get
    "get", path, query_data=query_data, streamed=streamed, **kwargs
  File "/usr/local/lib/python3.7/site-packages/gitlab/client.py", line 631, in http_request
    response_body=result.content,
gitlab.exceptions.GitlabHttpError: 404: 404 Group Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/jf_agent/jf_agent/git/__init__.py", line 319, in load_and_dump_git
    endpoint_git_instance_info
  File "/home/jf_agent/jf_agent/git/__init__.py", line 170, in load_and_dump_git
    nrm_projects: List[NormalizedProject] = self.get_projects()
  File "/home/jf_agent/jf_agent/diagnostics.py", line 42, in wrapper
    ret = func(*args, **kwargs)
  File "/home/jf_agent/jf_agent/agent_logging.py", line 44, in wrapper
    ret = func(*args, **kwargs)
  File "/home/jf_agent/jf_agent/git/gitlab_adapter.py", line 59, in get_projects
    for project_id in self.config.git_include_projects
  File "/home/jf_agent/jf_agent/git/gitlab_adapter.py", line 59, in <listcomp>
    for project_id in self.config.git_include_projects
  File "/home/jf_agent/jf_agent/git/gitlab_client.py", line 116, in get_group
    return self.client.groups.get(group_id)
  File "/usr/local/lib/python3.7/site-packages/gitlab/exceptions.py", line 306, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body) from e
gitlab.exceptions.GitlabGetError: 404: 404 Group Not Found

Compressing ./output/20211129_033121/diagnostics.json
Sending data to Jellyfish...
Starting 3 threads
Done!
```

</details>

this behaviour is not really acceptable; the possible exceptions should be handled, error messages should be informative, and the whole execution shouldn't be aborted just because of one missing resource

this pull request addresses the issue by
* handling the http404 status code when getting a group from the GitLab API
* logging the specific group IDs that couldn't be found, for easier config management
* update the functions that need to obtain the group so it handles missing data

---
notes

I haven't spent a lot of time checking the code, so this proposed change might not clearly fit your codebase, feel free to modify this, or let me know and I'll update what's necessary, although expect delayed activity as I'm on vacation; I also didn't find any test for the get group api call, and as I'm doing this as quick fix, or conversation starter, I've decided to not add one on my own

by quickly glancing through the code this problem also exists for other api calls, so I'd suggest addressing all of them, but as we're not affected by other cases so far, I'm leaving that up to you

other improvements that could help with the maintenance of the agent could be:
* use structured logging that can be meaningfully parsed and indexed
* make sure there is specific data about what's causing the errors (attributes, state, etc)
* provide some metrics endpoint that could be scraped and leveraged for alerting