### PR TITLE
OJ-12951: Allow regex branch names in config

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -178,7 +178,9 @@ git:
 
   # Uncomment this to pull commit data from each of the specified branches for each repository in addition to
   # the repo's default branch. If no branches are provided here, commits will only be pulled from each repository's 
-  # default branch. Branch names may be either a literal branch name or a regex matching a set of branches in a repo.
+  # default branch. Branch names may be either a full branch name or a branch name pattern with the special characters * or ?.
+  #   * will match against all subsequent characters. For example, dev* will match against the branches 'dev', 'develop', 'dev_1' etc.
+  #   ? will match against a single character. For example, dev? will match against the branches 'dev1', 'dev2', 'dev3' etc.
   # 
   # include_branches: 
   #   my_repository: 

--- a/example.yml
+++ b/example.yml
@@ -178,7 +178,7 @@ git:
 
   # Uncomment this to pull commit data from each of the specified branches for each repository in addition to
   # the repo's default branch. If no branches are provided here, commits will only be pulled from each repository's 
-  # default branch.
+  # default branch. Branch names may be either a literal branch name or a regex matching a set of branches in a repo.
   # 
   # include_branches: 
   #   my_repository: 

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import logging
-from typing import List
 import stashy
 import pytz
 from tqdm import tqdm
@@ -267,14 +266,14 @@ def get_commits_for_included_branches(
             # provided in a config, only pull from the repo's default branch.
             # We are working with the BBS api object rather than a NormalizedRepository here,
             # so we can not use get_branches_for_normalized_repo  as we do in bitbucket_cloud_adapter and gitlab_adapter.
-            included_branches = [_get_default_branch_name(api_repo)]
+            branches_to_process = [_get_default_branch_name(api_repo)]
             additional_branch_patterns = included_branches.get(api_repo.get()['name'])
         
             if additional_branch_patterns:
                 repo_branches = [b['displayId'] for b in api_repo.branches()]
-                included_branches.extend(get_matching_branches(additional_branch_patterns, repo_branches))
+                branches_to_process.extend(get_matching_branches(additional_branch_patterns, repo_branches))
 
-            for branch in included_branches:
+            for branch in branches_to_process:
                 try:
                     if verbose:
                         agent_logging.verbose(

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -274,16 +274,16 @@ def get_commits_for_included_branches(
             # provided in a config, only pull from the repo's default branch.
             # We are working with the github api object rather than a NormalizedRepository here,
             # so we can not use get_branches_for_normalized_repo as we do in bitbucket_cloud_adapter and gitlab_adapter.
-            included_branches = [repo['default_branch']]
+            branches_to_process = [repo['default_branch']]
             additional_branch_patterns = included_branches.get(repo['name'])
 
             if additional_branch_patterns:
                 repo_branches = [b['name'] for b in client.get_branches(repo['full_name'])]
-                included_branches.extend(
+                branches_to_process.extend(
                     get_matching_branches(additional_branch_patterns, repo_branches)
                 )
 
-            for branch in repo_branches:
+            for branch in branches_to_process:
                 try:
                     for j, commit in enumerate(
                         tqdm(

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -15,6 +15,7 @@ from jf_agent.git import (
     NormalizedUser,
 )
 from jf_agent.git import pull_since_date_for_repo
+from jf_agent.git.utils import get_matching_branches
 from jf_agent.name_redactor import NameRedactor, sanitize_text
 from jf_agent import agent_logging, diagnostics, download_and_write_streaming, write_file
 from jf_agent.config_file_reader import GitConfig
@@ -273,11 +274,13 @@ def get_commits_for_included_branches(
             # provided in a config, only pull from the repo's default branch.
             # We are working with the github api object rather than a NormalizedRepository here,
             # so we can not use get_branches_for_normalized_repo as we do in bitbucket_cloud_adapter and gitlab_adapter.
-            repo_branches = [repo['default_branch']]
-            additional_branches = included_branches.get(repo['name'])
-            if additional_branches:
-                repo_branches.extend(
-                    branch for branch in additional_branches if branch not in repo_branches
+            included_branches = [repo['default_branch']]
+            additional_branch_patterns = included_branches.get(repo['name'])
+
+            if additional_branch_patterns:
+                repo_branches = [b['name'] for b in client.get_branches(repo['full_name'])]
+                included_branches.extend(
+                    get_matching_branches(additional_branch_patterns, repo_branches)
                 )
 
             for branch in repo_branches:

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -213,7 +213,7 @@ class GitLabAdapter(GitAdapter):
                         for j, commit in enumerate(
                             tqdm(
                                 self.client.list_project_commits(nrm_repo.id, pull_since, branch),
-                                desc=f'downloading commits for {nrm_repo.name} ({nrm_repo.id})',
+                                desc=f'downloading commits for branch {branch} in repo {nrm_repo.name} ({nrm_repo.id})',
                                 unit='commits',
                             ),
                             start=1,

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -5,12 +5,12 @@ from jf_agent.git import NormalizedRepository
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
 def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branches: dict):
-    included_branches = [repo.default_branch_name]
+    branches_to_process = [repo.default_branch_name]
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:
         repo_branch_names = [b.name for b in repo.branches]
-        included_branches.extend(get_matching_branches(additional_branches_for_repo, repo_branch_names))
-    return set(included_branches)
+        branches_to_process.extend(get_matching_branches(additional_branches_for_repo, repo_branch_names))
+    return set(branches_to_process)
 
 # Given a list of patterns, either literal branch names or regexes meant to match a set of branches in a repo, 
 # return the list of branches from repo_branches match any of the patterns.

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -1,10 +1,22 @@
+import re
+from typing import List
 from jf_agent.git import NormalizedRepository
 
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
 def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branches: dict):
-    repo_branches = [repo.default_branch_name]
+    included_branches = [repo.default_branch_name]
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:
-        repo_branches.extend(additional_branches_for_repo)
-    return set(repo_branches)
+        repo_branch_names = [b.name for b in repo.branches]
+        included_branches.extend(get_matching_branches(additional_branches_for_repo, repo_branch_names))
+    return set(included_branches)
+
+# Given a list of patterns, either literal branch names or regexes meant to match a set of branches in a repo, 
+# return the list of branches from repo_branches match any of the patterns.
+def get_matching_branches(included_branch_patterns: List[str], repo_branch_names: List[str]) -> List[str]:
+    matching_branches = []
+    for repo_branch_name in repo_branch_names:
+        if any(re.compile(pattern).fullmatch(repo_branch_name) for pattern in included_branch_patterns):
+            matching_branches.append(repo_branch_name)
+    return matching_branches

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -1,4 +1,4 @@
-import re
+import fnmatch
 from typing import List
 from jf_agent.git import NormalizedRepository
 
@@ -12,11 +12,12 @@ def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branch
         branches_to_process.extend(get_matching_branches(additional_branches_for_repo, repo_branch_names))
     return set(branches_to_process)
 
-# Given a list of patterns, either literal branch names or regexes meant to match a set of branches in a repo, 
-# return the list of branches from repo_branches that match any of the branch name patterns.
+# Given a list of patterns, either literal branch names or names with wildcards (*) meant to match a set of branches in a repo, 
+# return the list of branches from repo_branches that match any of the branch name patterns. 
+# fnmatch is used over regex to support wildcards but avoid complicating the requirements on branch naming in a user's config.
 def get_matching_branches(included_branch_patterns: List[str], repo_branch_names: List[str]) -> List[str]:
     matching_branches = []
     for repo_branch_name in repo_branch_names:
-        if any(re.fullmatch(pattern, repo_branch_name) for pattern in included_branch_patterns):
+        if (any(fnmatch.fnmatch(repo_branch_name, pattern) for pattern in included_branch_patterns)):
             matching_branches.append(repo_branch_name)
     return matching_branches

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -17,6 +17,6 @@ def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branch
 def get_matching_branches(included_branch_patterns: List[str], repo_branch_names: List[str]) -> List[str]:
     matching_branches = []
     for repo_branch_name in repo_branch_names:
-        if any(re.compile(pattern).fullmatch(repo_branch_name) for pattern in included_branch_patterns):
+        if any(re.fullmatch(pattern, repo_branch_name) for pattern in included_branch_patterns):
             matching_branches.append(repo_branch_name)
     return matching_branches

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -13,7 +13,7 @@ def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branch
     return set(branches_to_process)
 
 # Given a list of patterns, either literal branch names or regexes meant to match a set of branches in a repo, 
-# return the list of branches from repo_branches match any of the patterns.
+# return the list of branches from repo_branches that match any of the branch name patterns.
 def get_matching_branches(included_branch_patterns: List[str], repo_branch_names: List[str]) -> List[str]:
     matching_branches = []
     for repo_branch_name in repo_branch_names:


### PR DESCRIPTION
This adds the ability for users to use wildcard patterns when specifying the branches from which we should pull commits. 

### Testing
Ran against Github and Gitlab implementations and verified that the expected branches were pulled when using wildcards