### PR TITLE
feat(gitlab): Enable excluding and including repositories recursively on a group/project level

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -19,6 +19,8 @@ class GitConfig:
     git_instance_slug: str
     git_include_projects: List
     git_exclude_projects: List
+    git_include_projects_recursively: List
+    git_exclude_projects_recursively: List
     git_include_repos: List
     git_exclude_repos: List
     git_include_branches: dict
@@ -280,6 +282,8 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
     git_url = git_config.get('url', None)
     git_include_projects = set(git_config.get('include_projects', []))
     git_exclude_projects = set(git_config.get('exclude_projects', []))
+    git_include_projects_recursively = set(git_config.get('include_projects_recursively', []))
+    git_exclude_projects_recursively = set(git_config.get('exclude_projects_recursively', []))
     git_instance_slug = git_config.get('instance_slug', None)
     creds_envvar_prefix = git_config.get('creds_envvar_prefix', None)
     git_include_bbcloud_projects = set(git_config.get('include_bitbucket_cloud_projects', []))
@@ -342,6 +346,8 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
         git_url=git_url,
         git_include_projects=list(git_include_projects),
         git_exclude_projects=list(git_exclude_projects),
+        git_include_projects_recursively=list(git_include_projects_recursively),
+        git_exclude_projects_recursively=list(git_exclude_projects_recursively),
         git_include_repos=list(git_include_repos),
         git_exclude_repos=list(git_exclude_repos),
         git_include_branches=dict(git_include_branches),


### PR DESCRIPTION
This patch adds an ability to recursively and implicitly include all repositories in a certain project when fetching data from Gitlab.

Use case: Let's say I have a main group A with 100 repositories and a subgroup B. My preferred usecase it to be able to pull data from 5 projects in group A and all projects in group B.

With the situation before this patch, I essentially had two options, either:
a) put 5 repos from group A and then X repos from subgroup B in `include_repos` git config section
b) put all _other_ repos that I'm not interested in `exclude_repos`

Both of those ways are quite suboptimal in a sense that they require a lot of manual list management.
That's why this patch introduces two new Git config parameters: `include_projects_recursively` and `exclude_projects_recursively`. Gitlab group IDs can be provided there.
The code is adjusted in such a way that it now checks not only a repo's inclusion in the include list, but also checks the repo's group inclusion in the `include_projects_recursively`. If any of these two is true, then the repo will be fetched
