### PR TITLE
fix(git/gitlab_adapter): don't use the total attribute of python-gitab objects to enable pulling MRs from large repos

### DIFF
--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -251,17 +251,10 @@ class GitLabAdapter(GitAdapter):
 
                     api_prs = self.client.list_project_merge_requests(nrm_repo.id)
 
-                    if not api_prs or not api_prs.total:
-                        agent_logging.log_and_print(
-                            logger, logging.WARNING, f"No PRs returned for repo {nrm_repo.id}"
-                        )
-                        continue
-
                     for api_pr in tqdm(
                         api_prs,
                         desc=f'processing prs for {nrm_repo.name} ({nrm_repo.id})',
                         unit='prs',
-                        total=api_prs.total,
                     ):
                         try:
                             updated_at = parser.parse(api_pr.updated_at)


### PR DESCRIPTION
Code in the the Gitlab Adapter was using the `.total` attribute of underlying python-gitlab objects
to determine whether to print a message when there were no MRs pulled from a repository.
It was also used in a call to `tqdm` to draw a fancy progress bar.

The implementation of this `.total` property in `python-gitlab` relies on parsing the `X-Total` HTTP header
from the GL API response. See https://github.com/python-gitlab/python-gitlab/blob/64d01ef23b1269b705350106d8ddc2962a780dce/gitlab/client.py#L1007
According to Gitlab's API reference, these heders are ommited for large repos, see: https://docs.gitlab.com/ee/user/gitlab_com/index.html#pagination-response-headers

In the end, this results in erroneusly skipping pulling the MRs from repositories that contain a large amount of MRs.
Since the value of `.total` is now None, the code assumes that a repo has no MRs, while it's not the case.
Additionally, Gitlab Cloud (and possibly on-premise as well) will be removing these headers altogether in GL 13.5 and higher, see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/43159

Thus, this patch removes the usage of `.total`.