### PR TITLE
doc: document the use of REQUESTS_CA_BUNDLE to work with custom certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,35 @@
 An agent that can run on-premise to download and send data to [Jellyfish](https://jellyfish.co/).
 
 See the documentation [here](https://jellyfish-ai.github.io/jf_agent/)
+
+## Using the agent with custom SSL/TLS certificates
+
+Some organizations have generated their own certificates, usually via an organization-wide Certificate Authority (CA) certificate. If the certificate chain for a system that the jf_agent connects to does not contain a certificate that's known to the agent, the agent will terminate with an error like:
+
+```text
+[2101] Failed to connect to bitbucket_server:
+HTTPSConnectionPool(host='bitbucket.example.com', port=443): Max retries exceeded with url: /rest/
+(Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))
+```
+
+Here's how to fix it:
+
+1. Download a recent certificate bundle from <https://github.com/certifi/python-certifi> such as [`certifi/cacert.pem` as of the `2021.10.08` tag](https://github.com/certifi/python-certifi/blob/2021.10.08/certifi/cacert.pem). ([certifi](https://pypi.org/project/certifi/) is a dependency of [requests](https://pypi.org/project/requests/) and its `cacert.pem` bundle can be found inside the container)
+2. Obtain the entire _chain_ of certificates that the servers are using, in Base-64 encoded X.509 (PEM) format.
+3. Append the certificates obtained in the second step to the `cacert.pem` file obtained in the first step.
+4. The last piece of the puzzle is to make the updated `cacert.pem` bundle accessible to the agent and to point the `REQUESTS_CA_BUNDLE` environment variable to it.  For example, here is what a Bash script could look like when it's invoking `docker run` (notice how we're mounting the local `cacert.pem` file to a path inside the container, and then setting the `REQUESTS_CA_BUNDLE` environment variable in the container to point to it):
+
+    ```bash
+    HERE=$(pwd)
+    PATH_TO_BUNDLE=/home/jf_agent/cacert.pem
+    OUTPUT_FOLDER=${HERE}/jf_agent_output
+    mkdir --parents ${OUTPUT_FOLDER}
+    docker run --rm \
+        --mount type=bind,source=${HERE}/my_config.yml,target=/home/jf_agent/config.yml \
+        --mount type=bind,source=${OUTPUT_FOLDER},target=/home/jf_agent/output \
+        --mount type=bind,source=${HERE}/cacert.pem,target=${PATH_TO_BUNDLE} \
+        --env REQUESTS_CA_BUNDLE=${PATH_TO_BUNDLE} \
+        --env-file ./creds.env \
+        jellyfishco/jf_agent:stable \
+        $@
+    ```

--- a/example.yml
+++ b/example.yml
@@ -3,8 +3,10 @@
 #############################
 
 global:
-  # Set this to True to skip verification of server SSL certificates.
-  # This option is deprecated; see the README.md for how to trust custom certificates.
+  # Set this to True to skip verification of server SSL certificates.  This might
+  # be necessary if your Jira / Bitbucket server has an invalid or a custom
+  # certificate.  Or as an alternative, see the README.md for how to trust custom
+  # certificates.
   no_verify_ssl: False
   # Set this to True if you would like to send your config.yml file to Jellyfish.
   # We use this as a diagnostic tool for customer assistance.

--- a/example.yml
+++ b/example.yml
@@ -3,8 +3,8 @@
 #############################
 
 global:
-  # Set this to True to skip verification of server SSL certificates.  This might
-  # be useful if your Jira / Bitbucket server doesn't have a valid SSL certificate.
+  # Set this to True to skip verification of server SSL certificates.
+  # This option is deprecated; see the README.md for how to trust custom certificates.
   no_verify_ssl: False
   # Set this to True if you would like to send your config.yml file to Jellyfish.
   # We use this as a diagnostic tool for customer assistance.


### PR DESCRIPTION
Rather than use the instance-wide `no_verify_ssl` switch, these changes document how to configure the agent to trust more certificates than those that came with the application.

# Manual testing

Given:
1. a Bash script called `agent.sh` similar to the snippet in the `README.md`
2. a configuration file which contained `no_verify_ssl: False` and 2 Git configurations
3. a `cacert.pem` file which was augmented with some CA certificates our administrators are using to issue certificates for various services

When:
I ran `./agent.sh -m validate`

Then:
1. The first Git entry in our configuration file is our self-hosted Bitbucket server, which has a certificate issued by a custom CA certificate.  The connection was successful. (without these changes, this would fail to connect with the `CERTIFICATE_VERIFY_FAILED` error)
2. The 2nd Git entry in our configuration file is an organization in GitHub Cloud, which also succeeds validation, showing that the certificate bundle was indeed _augmented_.

Mission accomplished!