### PR TITLE
fix: sanitize GitHub PR comment bodies

### DIFF
--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -369,7 +369,7 @@ def _normalize_pr(client: GithubClient, pr, strip_text_content, redact_names_and
         comments=[
             NormalizedPullRequestComment(
                 user=_normalize_user(client.get_json(c['user']['url'])),
-                body=c['body'],
+                body=sanitize_text(c['body'], strip_text_content),
                 created_at=c['created_at'],
             )
             for c in client.get_pr_comments(pr['base']['repo']['full_name'], pr['number'])


### PR DESCRIPTION
We noticed that, despite having configured `strip_text_content: True` for our GitHub organization, the pull request comments were still visible in the output files.  We traced it to what appears to have been an oversight, as the `bitbucket_server` implementation does sanitize PR comments.

# Manual testing

Given:
1. a configuration file which contained (among others) a Git configuration pointing to one of our GitHub Cloud organizations, with `strip_text_content: True`
2. a custom-built container (leveraging the included `hooks/build` script) tagged as `jf_agent:kxs`

When:
I ran `docker run (...) jf_agent:kxs -m download_only`

Then:
1. The `bb_prs.json` file for the GitHub repositories had the values of the `body` key under `comments` contain either nothing or the agent's guess at JIRA issue keys.

Mission accomplished!