### PR TITLE
OJ-18867 implement `jira.required_email_domains` config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/example.yml
+++ b/example.yml
@@ -31,7 +31,7 @@ jira:
   # not change it (regular, day-to-day runs of the agent will only pull issues
   # that have been created or updated since the last run).  Comment out or omit
   # to pull all issues into Jellyfish.
-  earliest_issue_dt: 2019-01-01
+  earliest_issue_dt: 2021-01-01
 
   # The number of concurrent threads the agent will use for downloading issue data.
   # It's unusual, but some Jira instances can be overwhelmed by more than one or
@@ -102,16 +102,13 @@ jira:
   # send to Jellyfish
   #############################
 
-  # Uncomment this to pull only specific fields on issues.
-  # include_fields:
-  #   - id
-  #   - summary
-
   # Uncomment this to pull all but specific fields on issues.
   # exclude_fields:
   #   - description
   #   - comment
 
+
+  # is_email_required
 
 #############################
 # 3. Git configuration

--- a/example.yml
+++ b/example.yml
@@ -108,7 +108,17 @@ jira:
   #   - comment
 
 
-  # is_email_required
+  # if your Jira Users include customer records, you may wish to filter 
+  # the users sent to Jellyfish by enumerating a set of required email domains
+  #
+  # required_email_domains:
+  #   - jellyfish.co
+
+  # it's possible for a user to have no email.  if we need to restrict users
+  # by email domain, should null-email users be included?  uncomment this 
+  # if they shouldn't:
+  #
+  # is_email_required = True
 
 #############################
 # 3. Git configuration

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -154,19 +154,13 @@ def obtain_config(args) -> ValidatedConfig:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[list(missing_required_fields)],
-                error_code=2132,
+                logger, logging.WARNING, msg_args=[list(missing_required_fields)], error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[list(excluded_required_fields)],
-                error_code=2142,
+                logger, logging.WARNING, msg_args=[list(excluded_required_fields)], error_code=2142,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -55,7 +55,7 @@ ValidatedConfig = namedtuple(
         'jira_exclude_projects',
         'jira_include_project_categories',
         'jira_exclude_project_categories',
-        'jira_include_email_domains',
+        'jira_required_email_domains',
         'jira_is_email_required',
         'jira_issue_jql',
         'jira_download_worklogs',
@@ -139,7 +139,7 @@ def obtain_config(args) -> ValidatedConfig:
     jira_exclude_fields = set(jira_config.get('exclude_fields', []))
     jira_issue_batch_size = jira_config.get('issue_batch_size', 100)
     jira_gdpr_active = jira_config.get('gdpr_active', False)
-    jira_include_email_domains = jira_config.get('include_email_domains', [])
+    jira_required_email_domains = jira_config.get('required_email_domains', [])
     jira_is_email_required = jira_config.get('is_email_required', False)
     jira_include_projects = set(jira_config.get('include_projects', []))
     jira_exclude_projects = set(jira_config.get('exclude_projects', []))
@@ -248,7 +248,7 @@ def obtain_config(args) -> ValidatedConfig:
         jira_exclude_fields,
         jira_issue_batch_size,
         jira_gdpr_active,
-        jira_include_email_domains,
+        jira_required_email_domains,
         jira_is_email_required,
         jira_include_projects,
         jira_exclude_projects,

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -55,6 +55,8 @@ ValidatedConfig = namedtuple(
         'jira_exclude_projects',
         'jira_include_project_categories',
         'jira_exclude_project_categories',
+        'jira_include_email_domains',
+        'jira_include_users_without_email',
         'jira_issue_jql',
         'jira_download_worklogs',
         'jira_download_sprints',
@@ -137,6 +139,8 @@ def obtain_config(args) -> ValidatedConfig:
     jira_exclude_fields = set(jira_config.get('exclude_fields', []))
     jira_issue_batch_size = jira_config.get('issue_batch_size', 100)
     jira_gdpr_active = jira_config.get('gdpr_active', False)
+    jira_include_email_domains = jira_config.get('include_email_domains', [])
+    jira_include_users_without_email = jira_config.get('include_users_without_email', False)
     jira_include_projects = set(jira_config.get('include_projects', []))
     jira_exclude_projects = set(jira_config.get('exclude_projects', []))
     jira_include_project_categories = set(jira_config.get('include_project_categories', []))
@@ -238,6 +242,8 @@ def obtain_config(args) -> ValidatedConfig:
         jira_exclude_fields,
         jira_issue_batch_size,
         jira_gdpr_active,
+        jira_include_email_domains,
+        jira_include_users_without_email,
         jira_include_projects,
         jira_exclude_projects,
         jira_include_project_categories,

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -139,7 +139,7 @@ def obtain_config(args) -> ValidatedConfig:
     jira_exclude_fields = set(jira_config.get('exclude_fields', []))
     jira_issue_batch_size = jira_config.get('issue_batch_size', 100)
     jira_gdpr_active = jira_config.get('gdpr_active', False)
-    jira_required_email_domains = jira_config.get('required_email_domains', [])
+    jira_required_email_domains = set(jira_config.get('required_email_domains', []))
     jira_is_email_required = jira_config.get('is_email_required', False)
     jira_include_projects = set(jira_config.get('include_projects', []))
     jira_exclude_projects = set(jira_config.get('exclude_projects', []))
@@ -248,12 +248,12 @@ def obtain_config(args) -> ValidatedConfig:
         jira_exclude_fields,
         jira_issue_batch_size,
         jira_gdpr_active,
-        jira_required_email_domains,
-        jira_is_email_required,
         jira_include_projects,
         jira_exclude_projects,
         jira_include_project_categories,
         jira_exclude_project_categories,
+        jira_required_email_domains,
+        jira_is_email_required,
         jira_issue_jql,
         jira_download_worklogs,
         jira_download_sprints,

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -56,7 +56,7 @@ ValidatedConfig = namedtuple(
         'jira_include_project_categories',
         'jira_exclude_project_categories',
         'jira_include_email_domains',
-        'jira_include_users_without_email',
+        'jira_is_email_required',
         'jira_issue_jql',
         'jira_download_worklogs',
         'jira_download_sprints',
@@ -140,7 +140,7 @@ def obtain_config(args) -> ValidatedConfig:
     jira_issue_batch_size = jira_config.get('issue_batch_size', 100)
     jira_gdpr_active = jira_config.get('gdpr_active', False)
     jira_include_email_domains = jira_config.get('include_email_domains', [])
-    jira_include_users_without_email = jira_config.get('include_users_without_email', False)
+    jira_is_email_required = jira_config.get('is_email_required', False)
     jira_include_projects = set(jira_config.get('include_projects', []))
     jira_exclude_projects = set(jira_config.get('exclude_projects', []))
     jira_include_project_categories = set(jira_config.get('include_project_categories', []))
@@ -154,13 +154,19 @@ def obtain_config(args) -> ValidatedConfig:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger, logging.WARNING, msg_args=[list(missing_required_fields)], error_code=2132,
+                logger,
+                logging.WARNING,
+                msg_args=[list(missing_required_fields)],
+                error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
             agent_logging.log_and_print_error_or_warning(
-                logger, logging.WARNING, msg_args=[list(excluded_required_fields)], error_code=2142,
+                logger,
+                logging.WARNING,
+                msg_args=[list(excluded_required_fields)],
+                error_code=2142,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)
@@ -243,7 +249,7 @@ def obtain_config(args) -> ValidatedConfig:
         jira_issue_batch_size,
         jira_gdpr_active,
         jira_include_email_domains,
-        jira_include_users_without_email,
+        jira_is_email_required,
         jira_include_projects,
         jira_exclude_projects,
         jira_include_project_categories,
@@ -288,8 +294,12 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
     git_url = git_config.get('url', None)
     git_include_projects = set(git_config.get('include_projects', []))
     git_exclude_projects = set(git_config.get('exclude_projects', []))
-    git_include_all_repos_inside_projects = set(git_config.get('include_all_repos_inside_projects', []))
-    git_exclude_all_repos_inside_projects = set(git_config.get('exclude_all_repos_inside_projects', []))
+    git_include_all_repos_inside_projects = set(
+        git_config.get('include_all_repos_inside_projects', [])
+    )
+    git_exclude_all_repos_inside_projects = set(
+        git_config.get('exclude_all_repos_inside_projects', [])
+    )
     git_instance_slug = git_config.get('instance_slug', None)
     creds_envvar_prefix = git_config.get('creds_envvar_prefix', None)
     git_include_bbcloud_projects = set(git_config.get('include_bitbucket_cloud_projects', []))

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -135,7 +135,7 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
             download_users(
                 jira_connection,
                 config.jira_gdpr_active,
-                required_email_domains=config.jira_include_email_domains,
+                required_email_domains=config.jira_required_email_domains,
                 is_email_required=config.jira_is_email_required,
             ),
         )

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -135,8 +135,8 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
             download_users(
                 jira_connection,
                 config.jira_gdpr_active,
-                filter_email_domains=config.jira_include_email_domains,
-                include_users_without_email=config.jira_include_users_without_email
+                required_email_domains=config.jira_include_email_domains,
+                is_email_required=config.jira_is_email_required,
             ),
         )
         write_file(

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -132,7 +132,12 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
             config.outdir,
             'jira_users',
             config.compress_output_files,
-            download_users(jira_connection, config.jira_gdpr_active),
+            download_users(
+                jira_connection,
+                config.jira_gdpr_active,
+                filter_email_domains=config.jira_include_email_domains,
+                include_users_without_email=config.jira_include_users_without_email
+            ),
         )
         write_file(
             config.outdir,

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -201,10 +201,7 @@ def download_projects_and_versions(
                 == f"A value with ID '{project_id}' does not exist for the field 'project'."
             ):
                 agent_logging.log_and_print_error_or_warning(
-                    logger,
-                    logging.ERROR,
-                    msg_args=[project_id],
-                    error_code=2112,
+                    logger, logging.ERROR, msg_args=[project_id], error_code=2112,
                 )
                 return False
             else:
@@ -265,10 +262,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
             except JIRAError as e:
                 if e.status_code == 400:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        msg_args=[project_id],
-                        error_code=2202,
+                        logger, logging.ERROR, msg_args=[project_id], error_code=2202,
                     )
                     break
                 raise
@@ -381,17 +375,12 @@ def download_all_issue_metadata(
                         batch_size = int(batch_size / 2)
                         if batch_size > 0:
                             agent_logging.log_and_print_error_or_warning(
-                                logger,
-                                logging.WARNING,
-                                msg_args=[batch_size],
-                                error_code=3012,
+                                logger, logging.WARNING, msg_args=[batch_size], error_code=3012,
                             )
                             continue
                         else:
                             agent_logging.log_and_print_error_or_warning(
-                                logger,
-                                logging.ERROR,
-                                error_code=3022,
+                                logger, logging.ERROR, error_code=3022,
                             )
                             raise
 
@@ -579,10 +568,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
             field_id_field = _get_field_identifier(i)
             if not field_id_field:
                 agent_logging.log_and_print_error_or_warning(
-                    logger=logger,
-                    level=logging.WARNING,
-                    error_code=3082,
-                    msg_args=[i.keys()],
+                    logger=logger, level=logging.WARNING, error_code=3082, msg_args=[i.keys()],
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
                 continue
@@ -640,11 +626,7 @@ def _download_jira_issues_segment(
 
     except BaseException as e:
         agent_logging.log_and_print_error_or_warning(
-            logger,
-            logging.ERROR,
-            msg_args=[thread_num],
-            error_code=3042,
-            exc_info=True,
+            logger, logging.ERROR, msg_args=[thread_num], error_code=3042, exc_info=True,
         )
         q.put(e)
 
@@ -683,21 +665,14 @@ def _download_jira_issues_page(
 
             batch_size = int(batch_size / 2)
             agent_logging.log_and_print_error_or_warning(
-                logger,
-                logging.WARNING,
-                msg_args=[e, batch_size],
-                error_code=3052,
-                exc_info=True,
+                logger, logging.WARNING, msg_args=[e, batch_size], error_code=3052, exc_info=True,
             )
             if batch_size == 0:
                 if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
                     return [], 1
                 elif not get_changelog:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.WARNING,
-                        msg_args=[search_params],
-                        error_code=3062,
+                        logger, logging.WARNING, msg_args=[search_params], error_code=3062,
                     )
                     return [], 0
                 else:
@@ -966,9 +941,7 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
             except JIRAError as e:
                 if e.status_code == 403:
                     agent_logging.log_and_print_error_or_warning(
-                        logger,
-                        logging.ERROR,
-                        error_code=2122,
+                        logger, logging.ERROR, error_code=2122,
                     )
                     return []
 


### PR DESCRIPTION
A potential customer has loaded many thousands of customer records (including PII) into their Jira Data; they wish to have a way to filter this data out of what is sent to Jellyfish.

This PR adds the following capabilities to our `config.yml`:

```
  # if your Jira Users include customer records, you may wish to filter 
  # the users sent to Jellyfish by enumerating a set of required email domains
  #
  # required_email_domains:
  #   - jellyfish.co

  # it's possible for a user to have no email.  if we need to restrict users
  # by email domain, should null-email users be included?  uncomment this 
  # if they shouldn't:
  #
  # is_email_required = True
```

NOTE: the changes to `download_all_issue_metadata` are a side effect of formatting with `black, version 19.10b0`
