### PR TITLE
OJ-21128: allow printing bearertoken masked

### DIFF
--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -19,9 +19,9 @@ def validate_jira(config, creds):
     print(f'  URL:      {config.jira_url}')
     print(f'  Username: {creds.jira_username}')
     if creds.jira_username and creds.jira_password:
-        print(f'  Password: **********')
+        print('  Password: **********')
     elif creds.jira_bearer_token:
-        print(f'  Token: **********')
+        print('  Token: **********')
     # test Jira connection
     try:
         print('==> Testing Jira connection...')

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -19,11 +19,9 @@ def validate_jira(config, creds):
     print(f'  URL:      {config.jira_url}')
     print(f'  Username: {creds.jira_username}')
     if creds.jira_username and creds.jira_password:
-        masking_stars = len(creds.jira_password) - 2
-        print(f'  Password: {creds.jira_password[:2]:*<{masking_stars}}')
+        print(f'  Password: **********')
     elif creds.jira_bearer_token:
-        masking_stars = len(creds.jira_bearer_token) - 2
-        print(f'  Token: {creds.jira_bearer_token[:2]:*<{masking_stars}}')
+        print(f'  Token: **********')
     # test Jira connection
     try:
         print('==> Testing Jira connection...')

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -18,8 +18,12 @@ def validate_jira(config, creds):
     print('\nJira details:')
     print(f'  URL:      {config.jira_url}')
     print(f'  Username: {creds.jira_username}')
-    pw_len = len(creds.jira_password) - 2
-    print(f'  Password: {creds.jira_password[:2]:*<{pw_len}}')
+    if creds.jira_username and creds.jira_password:
+        masking_stars = len(creds.jira_password) - 2
+        print(f'  Password: {creds.jira_password[:2]:*<{masking_stars}}')
+    elif creds.jira_bearer_token:
+        masking_stars = len(creds.jira_bearer_token) - 2
+        print(f'  Token: {creds.jira_bearer_token[:2]:*<{masking_stars}}')
     # test Jira connection
     try:
         print('==> Testing Jira connection...')


### PR DESCRIPTION
main checks for whether we use bearer or user/pass but `validate` only had a password path until now