### PR TITLE
OJ-21409-add-pre-commit-formatting-rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        language_version: python3.9
+        additional_dependencies: ["click==8.0.4"]

--- a/Pipfile
+++ b/Pipfile
@@ -16,5 +16,8 @@ dateparser = "*"
 jsonstreams = "*"
 psutil = "*"
 python-gitlab = "*"
+pre-commit = "*"
+black = "~=19.10b0"
+click = "~=8.0.4"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -230,6 +230,7 @@
             "hashes": [
                 "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
                 "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
                 "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
                 "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
                 "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
@@ -240,6 +241,7 @@
                 "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
                 "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
                 "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
                 "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
                 "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
                 "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
@@ -293,11 +295,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed",
-                "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"
+                "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe",
+                "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.17"
+            "version": "==2.5.18"
         },
         "idna": {
             "hashes": [
@@ -606,11 +608,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c",
-                "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"
+                "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d",
+                "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.2.0"
+            "version": "==67.3.1"
         },
         "six": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "058162dffd5419d4d6fd0231236f52a3e3ea562ae9472bebb9a98f8fa5cc89c5"
+            "sha256": "252f17dbb99a1671fb42fd1f42a95bd8c0a65de0d0f2b5731197f83e71ecd669"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,29 @@
         ]
     },
     "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==22.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "index": "pypi",
+            "version": "==19.10b0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
@@ -93,52 +116,149 @@
             ],
             "version": "==1.15.1"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
+                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.3.1"
+        },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+                "sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+                "sha256:024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42",
+                "sha256:0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+                "sha256:02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b",
+                "sha256:083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a",
+                "sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+                "sha256:0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154",
+                "sha256:0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+                "sha256:0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+                "sha256:109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a",
+                "sha256:11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d",
+                "sha256:12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+                "sha256:14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+                "sha256:16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b",
+                "sha256:292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+                "sha256:2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5",
+                "sha256:2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918",
+                "sha256:2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+                "sha256:31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+                "sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+                "sha256:358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e",
+                "sha256:37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed",
+                "sha256:39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820",
+                "sha256:39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+                "sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+                "sha256:3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+                "sha256:3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14",
+                "sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+                "sha256:4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e",
+                "sha256:44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+                "sha256:4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+                "sha256:4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c",
+                "sha256:502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+                "sha256:503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3",
+                "sha256:5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+                "sha256:59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6",
+                "sha256:601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+                "sha256:608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+                "sha256:62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+                "sha256:70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+                "sha256:71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+                "sha256:72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+                "sha256:74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea",
+                "sha256:761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+                "sha256:772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+                "sha256:79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+                "sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+                "sha256:7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a",
+                "sha256:81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58",
+                "sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+                "sha256:84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a",
+                "sha256:87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+                "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+                "sha256:8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+                "sha256:8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174",
+                "sha256:8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+                "sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+                "sha256:911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc",
+                "sha256:93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837",
+                "sha256:95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41",
+                "sha256:9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+                "sha256:9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+                "sha256:9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753",
+                "sha256:9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8",
+                "sha256:a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291",
+                "sha256:a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087",
+                "sha256:a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866",
+                "sha256:a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+                "sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+                "sha256:c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1",
+                "sha256:c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+                "sha256:c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+                "sha256:c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+                "sha256:c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72",
+                "sha256:cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d",
+                "sha256:cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc",
+                "sha256:db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+                "sha256:df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d",
+                "sha256:e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af",
+                "sha256:e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b",
+                "sha256:eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602",
+                "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+                "sha256:f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478",
+                "sha256:f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c",
+                "sha256:f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+                "sha256:f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479",
+                "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+                "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
             ],
             "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.1"
+            "version": "==3.0.1"
+        },
+        "click": {
+            "hashes": [
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
+            ],
+            "index": "pypi",
+            "version": "==8.0.4"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0e70da4bdff7601b0ef48e6348339e490ebfb0cbe638e083c9c41fb49f00c8bd",
-                "sha256:10652dd7282de17990b88679cb82f832752c4e8237f0c714be518044269415db",
-                "sha256:175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290",
-                "sha256:1d7e632804a248103b60b16fb145e8df0bc60eed790ece0d12efe8cd3f3e7744",
-                "sha256:1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb",
-                "sha256:2ec2a8714dd005949d4019195d72abed84198d877112abb5a27740e217e0ea8d",
-                "sha256:2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70",
-                "sha256:2fb481682873035600b5502f0015b664abc26466153fab5c6bc92c1ea69d478b",
-                "sha256:3178d46f363d4549b9a76264f41c6948752183b3f587666aff0555ac50fd7876",
-                "sha256:4367da5705922cf7070462e964f66e4ac24162e22ab0a2e9d31f1b270dd78083",
-                "sha256:4eb85075437f0b1fd8cd66c688469a0c4119e0ba855e3fef86691971b887caf6",
-                "sha256:50a1494ed0c3f5b4d07650a68cd6ca62efe8b596ce743a5c94403e6f11bf06c1",
-                "sha256:53049f3379ef05182864d13bb9686657659407148f901f3f1eee57a733fb4b00",
-                "sha256:6391e59ebe7c62d9902c24a4d8bcbc79a68e7c4ab65863536127c8a9cd94043b",
-                "sha256:67461b5ebca2e4c2ab991733f8ab637a7265bb582f07c7c88914b5afb88cb95b",
-                "sha256:78e47e28ddc4ace41dd38c42e6feecfdadf9c3be2af389abbfeef1ff06822285",
-                "sha256:80ca53981ceeb3241998443c4964a387771588c4e4a5d92735a493af868294f9",
-                "sha256:8a4b2bdb68a447fadebfd7d24855758fe2d6fecc7fed0b78d190b1af39a8e3b0",
-                "sha256:8e45653fb97eb2f20b8c96f9cd2b3a0654d742b47d638cf2897afbd97f80fa6d",
-                "sha256:998cd19189d8a747b226d24c0207fdaa1e6658a1d3f2494541cb9dfbf7dcb6d2",
-                "sha256:a10498349d4c8eab7357a8f9aa3463791292845b79597ad1b98a543686fb1ec8",
-                "sha256:b4cad0cea995af760f82820ab4ca54e5471fc782f70a007f31531957f43e9dee",
-                "sha256:bfe6472507986613dc6cc00b3d492b2f7564b02b3b3682d25ca7f40fa3fd321b",
-                "sha256:c9e0d79ee4c56d841bd4ac6e7697c8ff3c8d6da67379057f29e66acffcd1e9a7",
-                "sha256:ca57eb3ddaccd1112c18fc80abe41db443cc2e9dcb1917078e02dfa010a4f353",
-                "sha256:ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c"
+                "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
+                "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
+                "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
+                "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
+                "sha256:6f8ba7f0328b79f08bdacc3e4e66fb4d7aab0c3584e0bd41328dce5262e26b2e",
+                "sha256:706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc",
+                "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad",
+                "sha256:83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505",
+                "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
+                "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
+                "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
+                "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
+                "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
+                "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336",
+                "sha256:ef8b72fa70b348724ff1218267e7f7375b8de4e8194d1636ee60510aae104cd0",
+                "sha256:f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c",
+                "sha256:f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106",
+                "sha256:fdd188c8a6ef8769f148f88f859884507b954cc64db6b52f66ef199bb9ad660a",
+                "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"
             ],
-            "version": "==38.0.4"
+            "version": "==39.0.1"
         },
         "dateparser": {
             "hashes": [
-                "sha256:4431159799b63d8acec5d7d844c5e06edf3d1b0eb2bda6d4cac87134ddddd01c",
-                "sha256:73ec6e44a133c54076ecf9f9dc0fbe3dd4831f154f977ff06f53114d57c5425e"
+                "sha256:fbed8b738a24c9cd7f47c4f2089527926566fe539e1a06125eddba75917b1eef",
+                "sha256:ff047d9cffad4d3113ead8ec0faf8a7fc43bab7d853ac8715e071312b53c465a"
             ],
             "index": "pypi",
-            "version": "==1.1.4"
+            "version": "==1.1.7"
         },
         "decorator": {
             "hashes": [
@@ -155,6 +275,29 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.7.1"
+        },
+        "distlib": {
+            "hashes": [
+                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
+                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
+            ],
+            "version": "==0.3.6"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de",
+                "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.9.0"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed",
+                "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.17"
         },
         "idna": {
             "hashes": [
@@ -180,6 +323,14 @@
             "index": "pypi",
             "version": "==0.6.0"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e",
+                "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.7.0"
+        },
         "oauthlib": {
             "extras": [
                 "signedtoken"
@@ -191,13 +342,37 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.2.2"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+                "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.0"
+        },
         "pbr": {
             "hashes": [
-                "sha256:b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe",
-                "sha256:db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a"
+                "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b",
+                "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"
             ],
             "markers": "python_version >= '2.6'",
-            "version": "==5.11.0"
+            "version": "==5.11.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9",
+                "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.0.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:9e3255edb0c9e7fe9b4f328cb3dc86069f8fdc38026f1bf521018a05eaf4d67b",
+                "sha256:bc4687478d55578c4ac37272fe96df66f73d9b5cf81be6f28627d4e712e752d5"
+            ],
+            "index": "pypi",
+            "version": "==3.0.4"
         },
         "psutil": {
             "hashes": [
@@ -244,18 +419,18 @@
         },
         "python-gitlab": {
             "hashes": [
-                "sha256:567390c2b93690dae62ed9738bf9f221fa45c01378fdf896089dbf7c8a134fbd",
-                "sha256:a5eb36b49783fda34563376674d5251dbbdbd1abd23b287dadf82f67d861b2c1"
+                "sha256:85ae778d8953aba87ad4b78aef7fbb5dae053980d2c20ff200bea29799685743",
+                "sha256:ad502b72b5d1137f4af37d4a68ae20fe7d6c9778f67cbe2aec566f7995053c7d"
             ],
             "index": "pypi",
-            "version": "==3.12.0"
+            "version": "==3.13.0"
         },
         "pytz": {
             "hashes": [
-                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+                "sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0",
+                "sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a"
             ],
-            "version": "==2022.6"
+            "version": "==2022.7.1"
         },
         "pytz-deprecation-shim": {
             "hashes": [
@@ -407,11 +582,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
             ],
             "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==2.28.1"
+            "version": "==2.28.2"
         },
         "requests-oauthlib": {
             "hashes": [
@@ -431,11 +606,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
+                "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c",
+                "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.6.3"
+            "version": "==67.2.0"
         },
         "six": {
             "hashes": [
@@ -452,6 +627,14 @@
             "index": "pypi",
             "version": "==0.7"
         },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
         "tqdm": {
             "hashes": [
                 "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4",
@@ -459,6 +642,36 @@
             ],
             "index": "pypi",
             "version": "==4.64.1"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2",
+                "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1",
+                "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6",
+                "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62",
+                "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac",
+                "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d",
+                "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc",
+                "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2",
+                "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97",
+                "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35",
+                "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6",
+                "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1",
+                "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4",
+                "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c",
+                "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e",
+                "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec",
+                "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f",
+                "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72",
+                "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47",
+                "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72",
+                "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe",
+                "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6",
+                "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3",
+                "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.5.4"
         },
         "tzdata": {
             "hashes": [
@@ -478,11 +691,19 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
-                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
             "index": "pypi",
-            "version": "==1.26.13"
+            "version": "==1.26.14"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590",
+                "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==20.19.0"
         }
     },
     "develop": {}

--- a/jf_agent/__init__.py
+++ b/jf_agent/__init__.py
@@ -19,7 +19,6 @@ class BadConfigException(Exception):
 
 
 def write_file(outdir, filename_prefix, compress, results):
-
     if compress:
         with gzip.open(f'{outdir}/{filename_prefix}.json.gz', 'wb') as outfile:
             outfile.write(json.dumps(results, indent=2, cls=StrDefaultEncoder).encode('utf-8'))

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -259,7 +259,7 @@ def obtain_config(args) -> ValidatedConfig:
         jellyfish_api_base,
         skip_ssl_verification,
         send_agent_config,
-        git_max_concurrent, 
+        git_max_concurrent,
     )
 
 

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -387,7 +387,6 @@ def get_repos_from_git(git_connection, config: GitConfig):
     to compare git repos from git sources against git repos found by jira
     '''
     if config.git_provider == 'bitbucket_server':
-
         from jf_agent.git.bitbucket_server import get_projects as get_projects_bbs
         from jf_agent.git.bitbucket_server import get_repos as get_repos_bbs
 
@@ -401,7 +400,6 @@ def get_repos_from_git(git_connection, config: GitConfig):
         )
 
     elif config.git_provider == 'bitbucket_cloud':
-
         from jf_agent.git.bitbucket_cloud_adapter import BitbucketCloudAdapter
 
         bbc_adapter = BitbucketCloudAdapter(git_connection)
@@ -410,7 +408,6 @@ def get_repos_from_git(git_connection, config: GitConfig):
         repos = bbc_adapter.get_repos(projects)
 
     elif config.git_provider == 'github':
-
         from jf_agent.git.github import get_repos as get_repos_gh
 
         _, repos = zip(
@@ -424,7 +421,6 @@ def get_repos_from_git(git_connection, config: GitConfig):
         )
 
     elif config.git_provider == 'gitlab':
-
         from jf_agent.git.gitlab_adapter import GitLabAdapter
 
         gl_adapter = GitLabAdapter(
@@ -449,7 +445,6 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
     output_dict = {}
 
     if config.git_provider == 'bitbucket_server':
-
         from jf_agent.git.bitbucket_server import get_projects as get_projects_bbs
 
         projects = get_projects_bbs(
@@ -467,7 +462,7 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
                 not in set([r.lower() for r in config.git_exclude_repos])
             )
 
-        for (api_project, _normalized_project_dict) in projects:
+        for api_project, _normalized_project_dict in projects:
             project_repos = []
             project = git_connection.projects[api_project['key']]
             for repo in project.repos.list():
@@ -476,7 +471,6 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
             output_dict[api_project.get('name')] = project_repos
 
     elif config.git_provider == 'bitbucket_cloud':
-
         from jf_agent.git.bitbucket_cloud_adapter import BitbucketCloudAdapter
 
         bbc_adapter = BitbucketCloudAdapter(
@@ -489,7 +483,6 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
             output_dict[project.name] = project_repos
 
     elif config.git_provider == 'github':
-
         from jf_agent.git.github import _normalize_repo
 
         filters = []
@@ -512,7 +505,6 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
             output_dict[org] = [x.name for x in org_repos]
 
     elif config.git_provider == 'gitlab':
-
         from jf_agent.git.gitlab_adapter import GitLabAdapter
 
         gl_adapter = GitLabAdapter(

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -389,7 +389,6 @@ def _normalize_user(api_user):
 def _normalize_pr(
     client, repo, api_pr, strip_text_content: bool, redact_names_and_urls: bool,
 ):
-
     # Process the PR's diff to get additions, deletions, changed_files
     additions, deletions, changed_files = None, None, None
     try:

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -30,18 +30,16 @@ def load_and_dump(
     write_file(outdir, 'bb_users', compress_output_files, get_users(bb_conn))
 
     bitbucket_projects = get_projects(
-            bb_conn,
-            config.git_include_projects,
-            config.git_exclude_projects,
-            config.git_redact_names_and_urls,
-        )
+        bb_conn,
+        config.git_include_projects,
+        config.git_exclude_projects,
+        config.git_redact_names_and_urls,
+    )
     if not bitbucket_projects:
         logger.warn(" No projects and repositories available to agent: Please Check Configuration")
         return
     # turn a generator that produces (api_object, dict) pairs into separate lists of API objects and dicts
-    api_projects, projects = zip(
-        *bitbucket_projects
-    )
+    api_projects, projects = zip(*bitbucket_projects)
     write_file(outdir, 'bb_projects', compress_output_files, projects)
 
     api_repos = None
@@ -272,10 +270,12 @@ def get_commits_for_included_branches(
             # so we can not use get_branches_for_normalized_repo  as we do in bitbucket_cloud_adapter and gitlab_adapter.
             branches_to_process = [_get_default_branch_name(api_repo)]
             additional_branch_patterns = included_branches.get(api_repo.get()['name'])
-        
+
             if additional_branch_patterns:
                 repo_branches = [b['displayId'] for b in api_repo.branches()]
-                branches_to_process.extend(get_matching_branches(additional_branch_patterns, repo_branches))
+                branches_to_process.extend(
+                    get_matching_branches(additional_branch_patterns, repo_branches)
+                )
 
             for branch in branches_to_process:
                 try:

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -43,7 +43,10 @@ class GithubClient:
                     raise
 
                 agent_logging.log_and_print_error_or_warning(
-                    logger, logging.WARNING, msg_args=[m["url"], e.response.status_code], error_code=3061,
+                    logger,
+                    logging.WARNING,
+                    msg_args=[m["url"], e.response.status_code],
+                    error_code=3061,
                 )
 
     def get_all_repos(self, org):
@@ -159,7 +162,7 @@ class GithubClient:
                 agent_logging.log_and_print_error_or_warning(
                     logger, logging.WARNING, msg_args=[reset_wait_str], error_code=3091,
                 )
-                # often the GH reset time is off by <1 second, causing another rate-limit. 2 seconds buffer added. 
+                # often the GH reset time is off by <1 second, causing another rate-limit. 2 seconds buffer added.
                 time.sleep(reset_wait_in_seconds + 2)
                 continue  # retry
 

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -92,7 +92,6 @@ class GitLabAdapter(GitAdapter):
 
         nrm_repos: List[NormalizedRepository] = []
         for nrm_project in normalized_projects:
-
             repos_that_failed_to_download = []
 
             for i, api_repo in enumerate(
@@ -565,8 +564,12 @@ def _should_fetch_repo_data(api_repo: GroupProject, config: GitConfig) -> bool:
     For GitLab, git_include_repos holds IDs instead of names (probably unintentionally), so
     no need to be case insensitive
     """
-    include_rules_defined = bool(config.git_include_repos or config.git_include_all_repos_inside_projects)
-    exclude_rules_defined = bool(config.git_exclude_repos or config.git_exclude_all_repos_inside_projects)
+    include_rules_defined = bool(
+        config.git_include_repos or config.git_include_all_repos_inside_projects
+    )
+    exclude_rules_defined = bool(
+        config.git_exclude_repos or config.git_exclude_all_repos_inside_projects
+    )
 
     if not (include_rules_defined or exclude_rules_defined):
         # Always pull from a repo if there are no special rules
@@ -576,14 +579,18 @@ def _should_fetch_repo_data(api_repo: GroupProject, config: GitConfig) -> bool:
     api_repo_parent_project_id = api_repo.namespace["id"]
 
     included_explicitly = bool(config.git_include_repos) and api_repo.id in config.git_include_repos
-    included_implicitly = bool(config.git_include_all_repos_inside_projects) \
+    included_implicitly = (
+        bool(config.git_include_all_repos_inside_projects)
         and api_repo_parent_project_id in config.git_include_all_repos_inside_projects
+    )
 
     included = included_explicitly or included_implicitly
 
     excluded_explicitly = bool(config.git_exclude_repos) and api_repo.id in config.git_exclude_repos
-    excluded_implicitly = bool(config.git_exclude_all_repos_inside_projects) \
+    excluded_implicitly = (
+        bool(config.git_exclude_all_repos_inside_projects)
         and api_repo_parent_project_id in config.git_exclude_all_repos_inside_projects
+    )
 
     excluded = excluded_explicitly or excluded_implicitly
 

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -2,6 +2,7 @@ import fnmatch
 from typing import List
 from jf_agent.git import NormalizedRepository
 
+
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
 def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branches: dict):
@@ -9,15 +10,20 @@ def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branch
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:
         repo_branch_names = [b.name for b in repo.branches]
-        branches_to_process.extend(get_matching_branches(additional_branches_for_repo, repo_branch_names))
+        branches_to_process.extend(
+            get_matching_branches(additional_branches_for_repo, repo_branch_names)
+        )
     return set(branches_to_process)
 
-# Given a list of patterns, either literal branch names or names with wildcards (*) meant to match a set of branches in a repo, 
-# return the list of branches from repo_branches that match any of the branch name patterns. 
+
+# Given a list of patterns, either literal branch names or names with wildcards (*) meant to match a set of branches in a repo,
+# return the list of branches from repo_branches that match any of the branch name patterns.
 # fnmatch is used over regex to support wildcards but avoid complicating the requirements on branch naming in a user's config.
-def get_matching_branches(included_branch_patterns: List[str], repo_branch_names: List[str]) -> List[str]:
+def get_matching_branches(
+    included_branch_patterns: List[str], repo_branch_names: List[str]
+) -> List[str]:
     matching_branches = []
     for repo_branch_name in repo_branch_names:
-        if (any(fnmatch.fnmatch(repo_branch_name, pattern) for pattern in included_branch_patterns)):
+        if any(fnmatch.fnmatch(repo_branch_name, pattern) for pattern in included_branch_patterns):
             matching_branches.append(repo_branch_name)
     return matching_branches

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -83,7 +83,6 @@ def download_users(
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_fields(jira_connection, include_fields, exclude_fields):
-
     print('downloading jira fields... ', end='', flush=True)
 
     filters = []
@@ -156,7 +155,6 @@ def download_priorities(jira_connection):
 def download_projects_and_versions(
     jira_connection, include_projects, exclude_projects, include_categories, exclude_categories
 ):
-
     print('downloading jira projects... ', end='', flush=True)
 
     filters = []
@@ -343,7 +341,6 @@ def download_all_issue_metadata(
 
     all_issue_metadata: Dict[int, IssueMetadata] = {}
     for project_ids in project_ids_array:
-
         issue_jql = (
             f'project in ({",".join(project_ids)}) and updatedDate > '
             f'{"0" if not earliest_issue_dt else earliest_issue_dt.strftime("%Y-%m-%d")}'
@@ -805,7 +802,6 @@ def _search_all_users(jira_connection, gdpr_active):
 
     # different jira versions / different times, the way to list all users has changed. Try a few.
     for q in [None, '', '%', '@']:
-
         # iterate through pages of results
         while True:
             users = _search_users(
@@ -902,7 +898,6 @@ def _search_users(
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_missing_repos_found_by_jira(config, creds, issues_to_scan):
-
     from jf_agent.jf_jira import get_basic_jira_connection
     from jf_agent.git import get_git_client
 
@@ -936,7 +931,6 @@ def download_missing_repos_found_by_jira(config, creds, issues_to_scan):
 
 
 def _get_repos_list_in_jira(issues_to_scan, jira_connection):
-
     print('Scanning Jira issues for Git repos...')
     missing_repositories = {}
 
@@ -984,7 +978,6 @@ def _remove_repos_present_in_git_instance(git_connection, git_config, missing_re
 
 
 def _scan_jira_issue_for_repo_data(jira_connection, issue_id, application_type):
-
     params = {
         'issueId': issue_id,
         'dataType': 'repository',
@@ -1040,7 +1033,6 @@ def _remove_mismatched_repos(repos_found_by_jira, git_repos, config):
 
     ignore_repos = []
     for repo in list(repos_found_by_jira.values()):
-
         repo_name = repo['name']
         repo_url = repo['url']
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -147,7 +147,6 @@ def main():
             )
 
             if config.run_mode_is_print_apparently_missing_git_repos:
-
                 issues_to_scan = get_issues_to_scan_from_jellyfish(
                     config, creds, args.for_print_missing_repos_issues_updated_within_last_x_months,
                 )
@@ -264,8 +263,12 @@ def obtain_creds(config):
         git_config.git_instance_slug: _get_git_instance_to_creds(git_config)
         for git_config in config.git_configs
     }
-    if len(set(list(token.values())[0] for token in git_instance_to_creds.values())) < len(git_instance_to_creds):
-        print('ERROR: Token for each git instance must be unique even if they are for the same provider.')
+    if len(set(list(token.values())[0] for token in git_instance_to_creds.values())) < len(
+        git_instance_to_creds
+    ):
+        print(
+            'ERROR: Token for each git instance must be unique even if they are for the same provider.'
+        )
         raise BadConfigException()
 
     jira_username_pass_missing = bool(not (jira_username and jira_password))
@@ -370,10 +373,10 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
             print_all_jira_fields(config, jira_connection)
         download_data_status.append(load_and_dump_jira(config, endpoint_jira_info, jira_connection))
 
-    if len(config.git_configs) == 0: 
+    if len(config.git_configs) == 0:
         return download_data_status
 
-    # git downloading is parallelized by the number of configurations. 
+    # git downloading is parallelized by the number of configurations.
     futures = []
     with ThreadPoolExecutor(max_workers=config.git_max_concurrent) as executor:
         for git_config in config.git_configs:
@@ -381,7 +384,9 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                 logger,
                 logging.INFO,
                 f'Obtained {git_config.git_provider}:{git_config.git_instance_slug} configuration, attempting download '
-                + f'in parallel with {config.git_max_concurrent} workers' if len(config.git_configs) > 1 else "..."
+                + f'in parallel with {config.git_max_concurrent} workers'
+                if len(config.git_configs) > 1
+                else "...",
             )
             futures.append(
                 executor.submit(
@@ -400,7 +405,6 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 def _download_git_data(
     git_config, config, creds, endpoint_git_instances_info, is_multi_git_config
 ) -> dict:
-
     if is_multi_git_config:
         instance_slug = git_config.git_instance_slug
         instance_info = endpoint_git_instances_info.get(instance_slug)

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -128,7 +128,7 @@ def validate_git(config, creds):
                     " =============================================================================/n \033[91mERROR: No projects and repositories available to agent: Please Check Configuration\033[0m /n ============================================================================="
                 )
                 continue
-                 
+
             print("  All projects and repositories available to agent:")
             for project_name, repo_list in project_repo_dict.items():
                 print(f"  -- {project_name}")

--- a/tests/test_bitbucket_server.py
+++ b/tests/test_bitbucket_server.py
@@ -203,12 +203,12 @@ class TestBitbucketServer(TestCase):
             self.assertEqual(
                 result_commit['author']['email'],
                 test_commit['author']['emailAddress'],
-                "resulting author email does not match input"
+                "resulting author email does not match input",
             )
             self.assertEqual(
                 result_commit['author']['login'],
                 test_commit['author']['name'],
-                "resulting author login does not match input"
+                "resulting author login does not match input",
             )
             expected_url = test_repos[0]['links']['self'][0]['href'].replace(
                 'browse', f'commits/{test_commit["id"]}'
@@ -243,12 +243,12 @@ class TestBitbucketServer(TestCase):
             self.assertNotIn(
                 'emailAddress',
                 result_commit['author'].keys(),
-                "author field of commit was not normalized; 'emailAddress' not renamed to 'email'"
+                "author field of commit was not normalized; 'emailAddress' not renamed to 'email'",
             )
             self.assertIn(
                 'login',
                 result_commit['author'].keys(),
-                "author field of commit was not normalized; 'login' not present as username key"
+                "author field of commit was not normalized; 'login' not present as username key",
             )
 
     def test_get_pull_requests(self):

--- a/tests/test_gitlab_adapter.py
+++ b/tests/test_gitlab_adapter.py
@@ -279,9 +279,7 @@ class TestGitLabAdapter(TestCase):
 
         self.assertFalse(result_commit.is_merge)
 
-        self.assertEqual(
-            result_commit.repo.id, 1, "resulting commit repo id does not match input"
-        )
+        self.assertEqual(result_commit.repo.id, 1, "resulting commit repo id does not match input")
         self.assertEqual(
             result_commit.repo.name,
             "test_repo_name",


### PR DESCRIPTION
Add `black` formatting logic to the `jf_agent` repository, so that all code stays consistently formatted.

I opted to lock us into `black` version `19.10b0` to keep us in sync with other internal repositories. Locking us into that version required us to install a dependency on the `click` library, which I also locked into place to ensure we stay in sync with `black`. Additionally I need to install the `pre-commit` library. This is all contained within the python virtual env.