### PR TITLE
[OJ-21241] Add snyk monitor job to track vulns in dependencies

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,0 +1,18 @@
+
+name: Snyk monitor workflow for tracking third-party dependencies
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+jobs:
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/python@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+          args: --project-name=jf_agent --org=jellyfish-k9n

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -3,8 +3,6 @@ name: Snyk monitor workflow for tracking third-party dependencies
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 jobs:
   snyk-monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,9 +1,10 @@
 
 name: Snyk monitor workflow for tracking third-party dependencies
-push:
-  branches: [ "master" ]
-pull_request:
-  branches: [ "master" ]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 jobs:
   snyk-monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,9 +1,9 @@
 
 name: Snyk monitor workflow for tracking third-party dependencies
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+push:
+  branches: [ "master" ]
+pull_request:
+  branches: [ "master" ]
 jobs:
   snyk-monitor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new GitHub Action for running `snyk monitor` on pushes to the master branch.

This will be used to gather third-party dependencies and upload to Jellyfish's Snyk account for tracking. This will bring this repo into operational parity with our other repos.

I verified this by temporarily adding an `on:` rule that fires the `snyk monitor` workflow on PR (i.e., this PR) and examined the output of: https://github.com/Jellyfish-AI/jf_agent/actions/runs/4283820506/jobs/7459917268

You'll see a snapshot was properly created and upload:

```
...
Explore this snapshot at https://app.snyk.io/org/jellyfish-k9n/project/8e2b4e4a-ea2f-4ffc-9ee1-7b50fda7e46c/history/a5dfc3b2-0580-4453-b3b4-57983c88349c
...
```

I've also created a new Snyk service account and generated an access token that has been stored as a repo-level Actions secret here in the `SNYK_TOKEN` secret.

