### PR TITLE
OJ-22785-add-104-retry-logic-to-file-upload

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -71,6 +71,7 @@ def log_loop_iters(
 ERROR_MESSAGES = {
     0000: 'An unknown error has occurred. Error message: {}',
     3000: 'Failed to upload file {} to S3 bucket',
+    3001: 'Connection to bucket was disconnected while uploading: {}. Retrying...',
     3010: 'Rate limiter: thought we were operating within our limit (made {}/{} calls for {}), but got HTTP 429 anyway!',
     3020: 'Next available time to make call is after the timeout of {} seconds. Giving up.',
     3030: 'ERROR: Could not parse response with status code {}. Contact an administrator for help.',

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -268,7 +268,7 @@ def obtain_creds(config):
     ):
         print(
             'WARNING: Tokens for each git instance provided are not unique. You will see better performance by configuring '
-            'git instances for the same provider with separate tokens that have independent rate-limits.' 
+            'git instances for the same provider with separate tokens that have independent rate-limits.'
         )
 
     jira_username_pass_missing = bool(not (jira_username and jira_password))
@@ -457,13 +457,31 @@ def send_data(config, creds):
     def upload_file(filename, path_to_obj, signed_url, local=False):
         filepath = filename if local else f'{config.outdir}/{filename}'
 
-        with open(filepath, 'rb') as f:
-            # If successful, returns HTTP status code 204
-            session = retry_session()
-            upload_resp = session.post(
-                signed_url['url'], data=signed_url['fields'], files={'file': (path_to_obj, f)}
-            )
-            upload_resp.raise_for_status()
+        total_retries = 5
+        retry_count = 0
+        while total_retries >= retry_count:
+            try:
+                with open(filepath, 'rb') as f:
+                    # If successful, returns HTTP status code 204
+                    session = retry_session()
+                    upload_resp = session.post(
+                        signed_url['url'],
+                        data=signed_url['fields'],
+                        files={'file': (path_to_obj, f)},
+                    )
+                    upload_resp.raise_for_status()
+                    break
+            # For large file uploads, we run into intermittent 104 errors where the 'peer' (jellyfish)
+            # will appear to shut down the session connection.
+            # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
+            # Attempt to catch and retry the 104 type error here
+            except requests.exceptions.ConnectionError:
+                agent_logging.log_and_print_error_or_warning(
+                    logger, logging.WARNING, msg_args=[filename], error_code=3001, exc_info=True,
+                )
+                retry_count += 1
+                # Back off logic
+                sleep(1 * retry_count)
 
     # Compress any not yet compressed files before sending
     for fname in glob(f'{config.outdir}/*.json'):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from glob import glob
 from pathlib import Path
 import sys
+from time import sleep
 
 import requests
 import json


### PR DESCRIPTION
Some agent clients have been seeing issues when uploading files from their agent containers to S3. The specific issues have to do with `104 - Connection Reset` errors being thrown intermittently. This PR contains some retry logic to make our file uploads more robust