### PR TITLE
OJ-22882-file-upload-logging-improvement

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -71,7 +71,7 @@ def log_loop_iters(
 ERROR_MESSAGES = {
     0000: 'An unknown error has occurred. Error message: {}',
     3000: 'Failed to upload file {} to S3 bucket',
-    3001: 'Connection to bucket was disconnected while uploading: {}. Retrying...',
+    3001: 'Connection to bucket was disconnected while uploading: {} with the following error: {}. Retrying...',
     3010: 'Rate limiter: thought we were operating within our limit (made {}/{} calls for {}), but got HTTP 429 anyway!',
     3020: 'Next available time to make call is after the timeout of {} seconds. Giving up.',
     3030: 'ERROR: Could not parse response with status code {}. Contact an administrator for help.',

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -471,18 +471,31 @@ def send_data(config, creds):
                         files={'file': (path_to_obj, f)},
                     )
                     upload_resp.raise_for_status()
-                    break
+                    agent_logging.log_and_print(
+                        logger, logging.INFO, msg=f'Successfully uploaded {filename}',
+                    )
+                    return
             # For large file uploads, we run into intermittent 104 errors where the 'peer' (jellyfish)
             # will appear to shut down the session connection.
             # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
             # Attempt to catch and retry the 104 type error here
-            except requests.exceptions.ConnectionError:
+            except requests.exceptions.ConnectionError as e:
                 agent_logging.log_and_print_error_or_warning(
-                    logger, logging.WARNING, msg_args=[filename], error_code=3001, exc_info=True,
+                    logger,
+                    logging.WARNING,
+                    msg_args=[filename, repr(e)],
+                    error_code=3001,
+                    exc_info=True,
                 )
                 retry_count += 1
                 # Back off logic
                 sleep(1 * retry_count)
+
+        # If we make it out of the while loop without breaking, that means
+        # we failed to upload the file.
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
+        )
 
     # Compress any not yet compressed files before sending
     for fname in glob(f'{config.outdir}/*.json'):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -491,7 +491,7 @@ def send_data(config, creds):
                 # Back off logic
                 sleep(1 * retry_count)
 
-        # If we make it out of the while loop without breaking, that means
+        # If we make it out of the while loop without returning, that means
         # we failed to upload the file.
         agent_logging.log_and_print_error_or_warning(
             logger, logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,


### PR DESCRIPTION
Improve logging when uploading files.

- Logging statement is made when a file is successful uploaded
- Logging message on retry logs with the error message in it's actual message
- If we fail to upload after all our retry attempts, log an error