### PR TITLE
[OJ-23618] Add precommit and CI job to detect secrets in PRs or commits

### DIFF
--- a/.github/workflows/secrets-detect.yml
+++ b/.github/workflows/secrets-detect.yml
@@ -1,0 +1,17 @@
+
+name: Secrets detection using detect-secrets
+on:
+  pull_request:
+    branches: [ "master" ]
+jobs:
+  secrets-detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Install detect-secrets
+        run: pip install detect-secrets
+      - name: Run detect secrets.
+        run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -v 'Pipfile.lock' | xargs detect-secrets-hook
+

--- a/.github/workflows/secrets-detect.yml
+++ b/.github/workflows/secrets-detect.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Install detect-secrets
         run: pip install detect-secrets
       - name: Run detect secrets.
-        run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -v 'Pipfile.lock' | xargs detect-secrets-hook
+        run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -v '.secrets.baseline' | grep -v 'Pipfile.lock' | xargs detect-secrets-hook
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,9 @@ repos:
       - id: black
         language_version: python3.9
         additional_dependencies: ["click==8.0.4"]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: Pipfile.lock

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,245 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "tests/test_data/bitbucket_cloud/test_branches.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_branches.json",
+        "hashed_secret": "722f6f1cbfd63fb34b9ab6609bf641a8924738d6",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_branches.json",
+        "hashed_secret": "7f1432f0bd47c736562dedcbcbc031674b922673",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "tests/test_data/bitbucket_cloud/test_commits.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_commits.json",
+        "hashed_secret": "996693e960428585ef66375c2f192746b9846c16",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_commits.json",
+        "hashed_secret": "6850d57f43a6cabd0a822a3eb6daa00f2c21e6b2",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "tests/test_data/bitbucket_cloud/test_prs.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_prs.json",
+        "hashed_secret": "2ca7fda562a4f22627d0db2d18e3c803f7a1389f",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_cloud/test_prs.json",
+        "hashed_secret": "4800183535ae2f9c63a8d601db34610e91fc7207",
+        "is_verified": false,
+        "line_number": 115
+      }
+    ],
+    "tests/test_data/bitbucket_server/test_branches.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_server/test_branches.json",
+        "hashed_secret": "e242b7710beaed41d057e2443ca1dfd3137edd0e",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/bitbucket_server/test_branches.json",
+        "hashed_secret": "1c3ede43c27a429611971d760b26991402499134",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "tests/test_data/github/test_branches.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/github/test_branches.json",
+        "hashed_secret": "abc8d0af31d200a20afb34871c95b273ba2a4709",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "tests/test_data/github/test_commits.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/github/test_commits.json",
+        "hashed_secret": "31f3f550542ae5f97361c1a28d2e03d5f8b3ed57",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "tests/test_data/github/test_prs.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/github/test_prs.json",
+        "hashed_secret": "5d2095be8ec1394b8b0495fafcdde2129ad95d1e",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/github/test_prs.json",
+        "hashed_secret": "31f3f550542ae5f97361c1a28d2e03d5f8b3ed57",
+        "is_verified": false,
+        "line_number": 176
+      }
+    ],
+    "tests/test_data/gitlab/test_branches.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/gitlab/test_branches.json",
+        "hashed_secret": "1abc31e230ccca36fe922ca68413ebd9cb3f63cd",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/gitlab/test_branches.json",
+        "hashed_secret": "f2ca7c040445d80d25c0cbb548bf07326b2eb8d8",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "tests/test_data/gitlab/test_commits.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_data/gitlab/test_commits.json",
+        "hashed_secret": "6444ede2dc8dcafb0cdd9ee3e624cd4a797c6b3b",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "tests/test_jira_download.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_jira_download.py",
+        "hashed_secret": "63041c5e9ea8c576c8f9d88a41f3973a9c20ad3e",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ]
+  },
+  "generated_at": "2023-04-14T14:06:36Z"
+}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -241,5 +245,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-14T14:06:36Z"
+  "generated_at": "2023-04-14T14:20:39Z"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jf_agent
-API_KEY = 'Test'
+
 An agent that can run on-premise to download and send data to [Jellyfish](https://jellyfish.co/).
 
 See the documentation [here](https://jf-public.s3.amazonaws.com/Jellyfish+Agent+Guide.pdf)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jf_agent
-
+API_KEY = 'Test'
 An agent that can run on-premise to download and send data to [Jellyfish](https://jellyfish.co/).
 
 See the documentation [here](https://jf-public.s3.amazonaws.com/Jellyfish+Agent+Guide.pdf)


### PR DESCRIPTION
This PR adds a new pre-commit hook and GitHub actions job to detect accidental inclusion of sensitive data (private keys, slack webhooks, etc.)

A "baseline" file is included which will prevent detect-secrets from reporting on findings in those data files in the future. I audited all those findings and they were not actual issues (they were git commit hashes).

**Testing:**

1. Commit and push change locally (when your change does not have any secrets included in it).
2. Note pre-commit does not flag any issues
3. Note CI passes cleanly
4. Now create fake change which includes a "suspicious" value. i.e. include `API_KEY = 'Test'` somewhere.
5. Commit and push
6. Note pre-commit fails
7. Push with `--no-verify` to skip pre-commit hooks
8. Note that CI Job fails.

**Screenshots:**

Example of pre-commit failure:
![Screenshot 2023-04-14 at 10 36 44 AM](https://user-images.githubusercontent.com/2743835/232074909-8960dd30-c61a-4884-9ebf-782e7bf564a8.png)

Example of CI failure:
<img width="645" alt="Screenshot 2023-04-14 at 10 38 18 AM" src="https://user-images.githubusercontent.com/2743835/232075185-dff2300a-de6a-42db-a623-4809b2161280.png">
