### PR TITLE
OJ-25748-jira-project-manifests

### DIFF
--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -1,13 +1,20 @@
+from concurrent.futures import ThreadPoolExecutor
 import logging
+import traceback
 from jf_agent import agent_logging
 
 from jf_agent.data_manifests.jira.adapter import JiraCloudManifestAdapter
 
-from jf_agent.data_manifests.jira.manifest import JiraDataManifest
+from jf_agent.data_manifests.jira.manifest import JiraDataManifest, JiraProjectManifest
 from jf_agent.data_manifests.manifest import ManifestSource
+from jira import JIRAError
 
 
 logger = logging.getLogger(__name__)
+
+
+class ProjectManifestGenerationException(Exception):
+    pass
 
 
 class UnsupportedJiraProvider(Exception):
@@ -15,56 +22,127 @@ class UnsupportedJiraProvider(Exception):
 
 
 def create_manifest(company_slug, config, creds):
-    manifest_adapter = JiraCloudManifestAdapter(config=config, creds=creds)
+    manifest_adapter = JiraCloudManifestAdapter(
+        company_slug=company_slug, config=config, creds=creds
+    )
 
     def _agent_log(msg: str):
         agent_logging.log_and_print(logger, logging.INFO, msg)
 
-    _agent_log(f'Generating Jira Manifest data for {company_slug}...')
+    project_data_dicts = manifest_adapter.get_project_data_dicts()
 
-    _agent_log('Processing Users...')
-    users_count = manifest_adapter.get_users_count()
-    _agent_log('Processing Fields...')
-    fields_count = manifest_adapter.get_fields_count()
-    _agent_log('Processing Resolutions...')
-    resolutions_count = manifest_adapter.get_resolutions_count()
-    _agent_log('Processing Issue Types...')
-    issue_types_count = manifest_adapter.get_issue_types_count()
-    _agent_log('Processing Issue Link Types...')
-    issue_link_types_count = manifest_adapter.get_issue_link_types_count()
-    _agent_log('Processing Priorities...')
-    priorities_count = manifest_adapter.get_priorities_count()
-    _agent_log('Processing Projects count...')
-    projects_count = manifest_adapter.get_projects_count()
-    _agent_log('Processing Jira Project Key names...')
-    project_keys = manifest_adapter.get_project_keys()
-    _agent_log('Processing Project Versions...')
-    project_versions_count = manifest_adapter.get_project_versions_count()
-    _agent_log('Processing Boards...')
-    boards_count = manifest_adapter.get_boards_count()
-    _agent_log('Processing Sprints...')
-    sprints_count = manifest_adapter.get_sprints_count()
-    _agent_log('Processing Issues...')
-    issues_count = manifest_adapter.get_issues_count()
-    _agent_log('Processing Issue Data...')
-    issues_count = manifest_adapter.get_issues_data_count()
+    jira_manifest = None
+    # Total threads includes all potential project manifests
+    # plus one 'global' jira manifest thread that will get
+    # all totals (sprints, boards, issues, etc)
+    with ThreadPoolExecutor(max_workers=5) as executor:
 
-    _agent_log('Done generating manifest data!')
-    jira_manifest = JiraDataManifest(
-        company=company_slug,
-        data_source=ManifestSource.remote,
-        users_count=users_count,
-        fields_count=fields_count,
-        resolutions_count=resolutions_count,
-        issue_types_count=issue_types_count,
-        issue_link_types_count=issue_link_types_count,
-        priorities_count=priorities_count,
-        projects_count=projects_count,
-        project_versions_count=project_versions_count,
-        boards_count=boards_count,
-        sprints_count=sprints_count,
-        issues_count=issues_count,
-        project_keys=project_keys,
-    )
+        _agent_log(f'Processing {len(project_data_dicts)} Jira Projects...')
+
+        # Create future for global Jira Manifest. This will be our main JiraManifest,
+        # and we will add Project Manifests to it
+        generate_base_manifest_future = executor.submit(process_global_jira_data, manifest_adapter)
+
+        # generate futures for project manifests
+        project_future_to_project_key = {
+            executor.submit(
+                generate_project_manifest, manifest_adapter, project_data_dict
+            ): project_data_dict['key']
+            for project_data_dict in project_data_dicts
+        }
+
+        # Process future results and handle exceptions
+        project_keys_to_errors = {}
+        project_manifests: list[JiraProjectManifest] = []
+        for future in project_future_to_project_key.keys():
+            # Track exceptions and log them in a dictionary
+            # so we can map project keys to detected exceptions
+            if future.exception():
+                project_keys_to_errors[project_future_to_project_key[future]] = future.exception()
+            else:
+                project_manifests.append(future.result())
+
+        _agent_log(f'Done processing {len(project_data_dicts)} Jira Projects!')
+
+        _agent_log('Processing Jira Global Values (this make take up to 15 more minutes)')
+
+        # Load base Jira Manifest object from globals generator
+        jira_manifest = generate_base_manifest_future.result()
+        # Append additional manifests (only project manifests, for now)
+        jira_manifest.project_manifests = sorted(project_manifests, key=lambda p: p.project_key)
+        jira_manifest.encountered_errors_for_projects = project_keys_to_errors
+
+        _agent_log('Done processing Jira Manifest!')
 
     return jira_manifest
+
+
+def process_global_jira_data(manifest_adapter: JiraCloudManifestAdapter) -> JiraDataManifest:
+
+    total_users_count = manifest_adapter.get_users_count()
+    total_fields_count = manifest_adapter.get_fields_count()
+    total_resolutions_count = manifest_adapter.get_resolutions_count()
+    total_issue_types_count = manifest_adapter.get_issue_types_count()
+    total_issue_link_types_count = manifest_adapter.get_issue_link_types_count()
+    total_priorities_count = manifest_adapter.get_priorities_count()
+    total_boards_count = manifest_adapter.get_boards_count()
+    total_sprints_count = manifest_adapter.get_sprints_count()
+    project_data_dicts = manifest_adapter.get_project_data_dicts()
+    project_versions_count = manifest_adapter.get_project_versions_count()
+    issues_count = manifest_adapter.get_issues_count()
+
+    return JiraDataManifest(
+        company=manifest_adapter.company_slug,
+        data_source=ManifestSource.remote,
+        users_count=total_users_count,
+        fields_count=total_fields_count,
+        resolutions_count=total_resolutions_count,
+        issue_types_count=total_issue_types_count,
+        issue_link_types_count=total_issue_link_types_count,
+        priorities_count=total_priorities_count,
+        projects_count=len(project_data_dicts),
+        boards_count=total_boards_count,
+        sprints_count=total_sprints_count,
+        project_versions_count=project_versions_count,
+        issues_count=issues_count,
+        # The following fields must be filled out after processing
+        # all ProjectManifests
+        project_manifests=[],
+        encountered_errors_for_projects={},
+    )
+
+
+def generate_project_manifest(
+    manifest_adapter: JiraCloudManifestAdapter, project_data_dict: dict
+) -> JiraProjectManifest:
+
+    project_key = project_data_dict['key']
+    project_id = int(project_data_dict['id'])
+    try:
+
+        # FIRST, DO A BASIC TEST TO SEE IF WE HAVE THE PROPER PERMISSIONS
+        # TO SEE ANY DATA IN THIS PROJECT
+        if not manifest_adapter.test_basic_auth_for_project(project_id=project_id):
+            raise ProjectManifestGenerationException(
+                f'Exception encountered when trying to do basic auth test against Jira Project {project_key}. It is very likely that we do not have permissions to this Project.'
+            )
+
+        board_count = manifest_adapter.get_boards_count_for_project(project_id=project_id)
+        issues_count = manifest_adapter.get_issues_count_for_project(project_id=project_id)
+        version_count = manifest_adapter.get_project_versions_count_for_project(
+            project_id=project_id
+        )
+
+        return JiraProjectManifest(
+            company=manifest_adapter.company_slug,
+            data_source=ManifestSource.remote,
+            project_id=project_id,
+            project_key=project_key,
+            issues_count=issues_count,
+            board_count=board_count,
+            version_count=version_count,
+        )
+    except JIRAError as e:
+        raise ProjectManifestGenerationException(e.text)
+    except Exception as e:
+        raise ProjectManifestGenerationException(str(e))

--- a/jf_agent/data_manifests/jira/manifest.py
+++ b/jf_agent/data_manifests/jira/manifest.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
-from jf_agent.data_manifests.manifest import Manifest, ManifestSource
-
+from jf_agent.data_manifests.manifest import Manifest
 
 IJiraDataManifest = TypeVar('IJiraDataManifest', bound='JiraDataManifest')
+IJiraProjectManifest = TypeVar('IJiraProjectManifest', bound='JiraProjectManifest')
 
 
 def _get_jira_manifest_full_name(manifest: Manifest):
@@ -25,10 +25,27 @@ class JiraDataManifest(Manifest):
     boards_count: int
     sprints_count: int
     issues_count: int
-    project_keys: list[str]
+
+    # Drill down into each project with ProjectManifests
+    project_manifests: list[IJiraProjectManifest]
+
+    # For debug purposes. We may want to optionally exclude this when serializing
+    encountered_errors_for_projects: Any
 
     def get_manifest_full_name(self):
         return _get_jira_manifest_full_name(self)
 
-    def __eq__(self, __o: Manifest) -> bool:
-        return super().__eq__(__o)
+
+@dataclass
+class JiraProjectManifest(Manifest):
+    project_id: str
+    project_key: str
+    issues_count: int
+    board_count: int
+    version_count: int
+
+    def get_manifest_full_name(self):
+        return f'{_get_jira_manifest_full_name(self)}_{self.project_key}'
+
+    def __hash__(self):
+        return hash(self.get_manifest_full_name())


### PR DESCRIPTION
Add Project Manifests to Jira Manifest Uploads

This code has been tested against my localhost of our Jellyfish API, and I have confirmed that we can successfully deserialize the uploaded manifest and that the deserialized manifest contains the proper values.