### PR TITLE
OJ-26192-cleanup-manifest-logging

### DIFF
--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -213,9 +213,6 @@ class JiraCloudManifestAdapter:
     def get_issues_count_for_project(self, project_id: int) -> int:
         return self._get_jql_search(jql_search=f"project = {project_id}", max_results=0)['total']
 
-    def get_issues_data_count_for_project(self, project_id: int) -> int:
-        return self.get_issues_count_for_project(project_id=project_id)
-
     def _get_raw_result(self, url) -> dict:
         response = self.jira_connection._session.get(url)
         response.raise_for_status()

--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -76,10 +76,8 @@ class JiraCloudManifestAdapter:
     def _get_all_projects(self) -> list[dict]:
         if not self._projects_cache:
             self._projects_cache = [
-                project
-                for project in self._page_get_results(
-                    url=f'{self.jira_url}/rest/api/latest/project/search?startAt=%s&maxResults=500&status=archived&status=live'
-                )
+                self._get_raw_result(url=f'{self.jira_url}/rest/api/latest/project/{project}')
+                for project in self.config.jira_include_projects
             ]
 
         return self._projects_cache
@@ -118,12 +116,6 @@ class JiraCloudManifestAdapter:
             ]
         )
 
-    def get_board_ids(self, project_id: int):
-        result = self._get_raw_result(
-            url=f'{self.jira_url}/rest/agile/1.0/board?projectKeyOrId={project_id}&startAt=0&maxResults=100'
-        )
-        return [value['id'] for value in result['values']]
-
     def _get_all_boards(self):
         if not self._boards_cache:
             self._boards_cache = [
@@ -134,11 +126,6 @@ class JiraCloudManifestAdapter:
             ]
 
         return self._boards_cache
-
-    def get_projects_count(self) -> int:
-        url = f'{self.jira_url}/rest/api/latest/project/search?startAt=0&maxResults=0&status=archived&status=live'
-        result = self._get_raw_result(url=url)
-        return result['total']
 
     def get_project_versions_count(self) -> int:
         total_project_versions = 0


### PR DESCRIPTION
Rework Jira Manifest project generation to work with both Jira Cloud and Jira Server. Instead of only using the `GET /rest/api/latest/project/search` endpoint, which is only available in Jira Cloud instances, we now leverage Jira Server's "get all projects" API endpoint (`GET /rest/api/latest/project`). This API endpoint is technically available in Jira Cloud as well but it is marked as depreciated. For that reason I have introduced an if statement that will conditionally use either API endpoints depending on if GDPR is active or not.

[Jira Cloud API docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-search-get)
[Jira Server API docs](https://docs.atlassian.com/software/jira/docs/api/REST/9.9.0/#api/2/project-getAllProjects)


For more context on this issue, please check the comments in the related Jira Ticket
