### PR TITLE
OJ-26362-cleanup-board-counts

### DIFF
--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -117,23 +117,6 @@ class JiraCloudManifestAdapter:
         result = self._get_jql_search(jql_search="", max_results=0)
         return result['total']
 
-    def get_boards_count_for_project(self, project_id: int) -> int:
-        return sum(
-            [
-                1
-                for board in self._get_all_boards()
-                # Boards can come from a ew different places and thus
-                # a few different formats. We only care about project
-                # boards, though, which have the 'location' dict
-                # and the 'projectId' key within that dict
-                if (
-                    'location' in board
-                    and 'projectId' in board['location']
-                    and board['location']['projectId'] == project_id
-                )
-            ]
-        )
-
     def _get_all_boards(self):
         if not self._boards_cache:
             self._boards_cache = [

--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -127,7 +127,6 @@ def generate_project_manifest(
                 f'Exception encountered when trying to do basic auth test against Jira Project {project_key}. It is very likely that we do not have permissions to this Project.'
             )
 
-        board_count = manifest_adapter.get_boards_count_for_project(project_id=project_id)
         issues_count = manifest_adapter.get_issues_count_for_project(project_id=project_id)
         version_count = manifest_adapter.get_project_versions_count_for_project(
             project_id=project_id
@@ -139,7 +138,6 @@ def generate_project_manifest(
             project_id=project_id,
             project_key=project_key,
             issues_count=issues_count,
-            board_count=board_count,
             version_count=version_count,
         )
     except JIRAError as e:

--- a/jf_agent/data_manifests/jira/manifest.py
+++ b/jf_agent/data_manifests/jira/manifest.py
@@ -41,7 +41,6 @@ class JiraProjectManifest(Manifest):
     project_id: str
     project_key: str
     issues_count: int
-    board_count: int
     version_count: int
 
     def get_manifest_full_name(self):


### PR DESCRIPTION
Remove board_count from Jira Project Manifests. This field is no longer used internally