### PR TITLE
[OJ-26479] Log Error on Sprints 400

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -121,7 +121,7 @@ ERROR_MESSAGES = {
         'Please check that the appropriate permissions are set for the following repos... ({})'
     ),
     2202: "You do not have the required permissions in jira required to fetch boards for the project {}",
-    2203: "ERROR: Failed downloading sprints for Jira board: {}.\nReceived 400 response:\n{}",
+    2203: "ERROR: Failed downloading sprints for Jira board: {} with s_start_at={}.\nReceived 400 response:\n{}",
 }
 
 

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -121,7 +121,7 @@ ERROR_MESSAGES = {
         'Please check that the appropriate permissions are set for the following repos... ({})'
     ),
     2202: "You do not have the required permissions in jira required to fetch boards for the project {}",
-    2203: "ERROR: Failed downloading sprints for Jira board with ID {}, received 400 response:\n{}",
+    2203: "ERROR: Failed downloading sprints for Jira board: {}.\nReceived 400 response:\n{}",
 }
 
 

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -121,6 +121,7 @@ ERROR_MESSAGES = {
         'Please check that the appropriate permissions are set for the following repos... ({})'
     ),
     2202: "You do not have the required permissions in jira required to fetch boards for the project {}",
+    2203: "ERROR: Failed downloading sprints for Jira board with ID {}, received 400 response:\n{}",
 }
 
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -293,6 +293,9 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                     # skip and move on
                     if e.status_code == 500 or e.status_code == 404:
                         print(f"Couldn't get sprints for board {b['id']}.  Skipping...")
+                    elif e.status_code == 400:
+                        agent_logging.log_and_print_error_or_warning(
+                            logger, logging.ERROR, msg_args=[b['id'], str(e)], error_code=2203, exc_info=True)
                     else:
                         raise
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -295,7 +295,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                         print(f"Couldn't get sprints for board {b['id']}.  Skipping...")
                     elif e.status_code == 400:
                         agent_logging.log_and_print_error_or_warning(
-                            logger, logging.ERROR, msg_args=[b['id'], str(e)], error_code=2203, exc_info=True)
+                            logger, logging.ERROR, msg_args=[str(b), str(e)], error_code=2203, exc_info=True)
                     else:
                         raise
 

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -295,7 +295,8 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                         print(f"Couldn't get sprints for board {b['id']}.  Skipping...")
                     elif e.status_code == 400:
                         agent_logging.log_and_print_error_or_warning(
-                            logger, logging.ERROR, msg_args=[str(b), str(e)], error_code=2203, exc_info=True)
+                            logger, logging.ERROR, msg_args=[str(b), str(s_start_at), str(e)],
+                            error_code=2203, exc_info=True)
                     else:
                         raise
 


### PR DESCRIPTION
### Description
Log an error whenever we get a 400 back from the Jira sprints endpoint, rather than bombing out.