### PR TITLE
OJ-27251-remove-sprint-counts-from-manifests

### DIFF
--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -86,7 +86,6 @@ def process_global_jira_data(manifest_adapter: JiraCloudManifestAdapter) -> Jira
     total_issue_link_types_count = manifest_adapter.get_issue_link_types_count()
     total_priorities_count = manifest_adapter.get_priorities_count()
     total_boards_count = manifest_adapter.get_boards_count()
-    total_sprints_count = manifest_adapter.get_sprints_count()
     project_data_dicts = manifest_adapter.get_project_data_dicts()
     project_versions_count = manifest_adapter.get_project_versions_count()
     issues_count = manifest_adapter.get_issues_count()
@@ -102,7 +101,6 @@ def process_global_jira_data(manifest_adapter: JiraCloudManifestAdapter) -> Jira
         priorities_count=total_priorities_count,
         projects_count=len(project_data_dicts),
         boards_count=total_boards_count,
-        sprints_count=total_sprints_count,
         project_versions_count=project_versions_count,
         issues_count=issues_count,
         # The following fields must be filled out after processing

--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -64,8 +64,6 @@ def create_manifest(company_slug, config, creds):
 
         _agent_log(f'Done processing {len(project_data_dicts)} Jira Projects!')
 
-        _agent_log('Processing Jira Global Values (this make take up to 15 more minutes)')
-
         # Load base Jira Manifest object from globals generator
         jira_manifest = generate_base_manifest_future.result()
         # Append additional manifests (only project manifests, for now)

--- a/jf_agent/data_manifests/jira/manifest.py
+++ b/jf_agent/data_manifests/jira/manifest.py
@@ -23,7 +23,6 @@ class JiraDataManifest(Manifest):
     projects_count: int
     project_versions_count: int
     boards_count: int
-    sprints_count: int
     issues_count: int
 
     # Drill down into each project with ProjectManifests


### PR DESCRIPTION
Remove sprints from Jira Manifest to expedite manifest generation