### PR TITLE
OJ-27539-re-work-gh-graphql-base-url-for-manifests

### DIFF
--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -21,7 +21,14 @@ class GithubManifestGenerator(ManifestAdapter):
     '''
 
     def __init__(
-        self, token: str, company: str, org: str, instance: str, verify=True, **kwargs
+        self,
+        token: str,
+        base_url: str,
+        company: str,
+        org: str,
+        instance: str,
+        verify=True,
+        **kwargs,
     ) -> None:
         # Super class fields
         self.company = company
@@ -29,7 +36,13 @@ class GithubManifestGenerator(ManifestAdapter):
         self.instance = instance
         # Session fields
         self.token = token
-        self.base_url = 'https://api.github.com/graphql'
+
+        # potentially cleanup base url
+        base_url[:-1] if base_url and base_url.endswith('/') else base_url
+        if 'api/v3' in base_url:
+            self.base_url = base_url.replace('api/v3', 'graphql')
+        else:
+            self.base_url = f'{base_url}/graphql' or 'https://api.github.com/graphql'
 
         self.session = retry_session(**kwargs)
         self.session.verify = verify

--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -37,12 +37,16 @@ class GithubManifestGenerator(ManifestAdapter):
         # Session fields
         self.token = token
 
-        # potentially cleanup base url
-        base_url[:-1] if base_url and base_url.endswith('/') else base_url
-        if 'api/v3' in base_url:
+        if not base_url:
+            self.base_url = 'https://api.github.com/graphql'
+        elif 'api/v3' in base_url:
+            # Github server can provide an API with a trailing '/api/v3'
+            # replace this with the graphql endpoint
             self.base_url = base_url.replace('api/v3', 'graphql')
         else:
-            self.base_url = f'{base_url}/graphql' or 'https://api.github.com/graphql'
+            # Assume all other cases we have a base_url like this:
+            #  https://api.github.com
+            self.base_url = f'{base_url}/graphql'
 
         self.session = retry_session(**kwargs)
         self.session.verify = verify

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -163,5 +163,9 @@ def get_manifest_adapter(
             f'Currently only instances of source github are supported, cannot process instance {instance} which has git_provider type {git_config.git_provider}'
         )
     return GithubManifestGenerator(
-        token=git_creds['github_token'], company=company_slug, instance=instance, org=org
+        token=git_creds['github_token'],
+        base_url=git_config.git_url,
+        company=company_slug,
+        instance=instance,
+        org=org,
     )


### PR DESCRIPTION
Re work base URL for graphql base Manifests, which should allow Github Enterprise Server clients to generate manifests