### PR TITLE
OJ-27539-adjust-graphql-endpoint-in-manifests

### DIFF
--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -42,11 +42,11 @@ class GithubManifestGenerator(ManifestAdapter):
         elif 'api/v3' in base_url:
             # Github server can provide an API with a trailing '/api/v3'
             # replace this with the graphql endpoint
-            self.base_url = base_url.replace('api/v3', 'graphql')
+            self.base_url = base_url.replace('api/v3', 'api/graphql')
         else:
             # Assume all other cases we have a base_url like this:
             #  https://api.github.com
-            self.base_url = f'{base_url}/graphql'
+            self.base_url = f'{base_url}/api/graphql'
 
         self.session = retry_session(**kwargs)
         self.session.verify = verify


### PR DESCRIPTION
Experimentally adjust graphql endpoint URL. Re-checking the docs, it looks like I forgot the base `/api` before the `/graphql` part