### PR TITLE
OJ-27619-reduce-scope-of-github-manifest-gen

### DIFF
--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -7,7 +7,6 @@ from jf_agent.data_manifests.git.manifest import (
     GitBranchManifest,
     GitPullRequestManifest,
     GitRepoManifest,
-    GitTeamManifest,
     GitUserManifest,
 )
 from jf_agent.data_manifests.manifest import ManifestSource
@@ -37,16 +36,12 @@ class GithubManifestGenerator(ManifestAdapter):
         # Session fields
         self.token = token
 
-        if not base_url:
-            self.base_url = 'https://api.github.com/graphql'
-        elif 'api/v3' in base_url:
-            # Github server can provide an API with a trailing '/api/v3'
+        if base_url and 'api/v3' in base_url:
+            # Github server provides an API with a trailing '/api/v3'
             # replace this with the graphql endpoint
             self.base_url = base_url.replace('api/v3', 'api/graphql')
         else:
-            # Assume all other cases we have a base_url like this:
-            #  https://api.github.com
-            self.base_url = f'{base_url}/api/graphql'
+            self.base_url = 'https://api.github.com/graphql'
 
         self.session = retry_session(**kwargs)
         self.session.verify = verify
@@ -68,20 +63,6 @@ class GithubManifestGenerator(ManifestAdapter):
             'totalCount'
         ]
 
-    def get_teams_count(self) -> int:
-        query_body = f"""{{
-            organization(login: "{self.org}"){{
-                    teams {{
-                        totalCount
-                    }}
-                }}
-            }}
-        """
-        # TODO: Maybe serialize the return results so that we don't have to do this crazy nested grabbing?
-        return self._get_raw_result(query_body=query_body)['data']['organization']['teams'][
-            'totalCount'
-        ]
-
     def get_repos_count(self) -> int:
         query_body = f"""{{
             organization(login: "{self.org}"){{
@@ -99,7 +80,6 @@ class GithubManifestGenerator(ManifestAdapter):
     def get_all_repo_data(self, page_size: int = 10) -> Generator[GitRepoManifest, None, None]:
         query_body = f"""{{
             organization(login: "{self.org}") {{
-                    name
                     repositories(first: {page_size}, after: %s) {{
                         pageInfo {{
                             endCursor
@@ -164,7 +144,6 @@ class GithubManifestGenerator(ManifestAdapter):
     def get_all_user_data(self, page_size: int = 10) -> Generator[GitUserManifest, None, None]:
         query_body = f"""{{
             organization(login: "{self.org}") {{
-                    name
                     users: membersWithRole(first: {page_size}, after: %s) {{
                         pageInfo {{
                             endCursor
@@ -199,50 +178,11 @@ class GithubManifestGenerator(ManifestAdapter):
                     email=user['email'],
                 )
 
-    def get_all_team_data(self, page_size=100) -> Generator[GitTeamManifest, None, None]:
-        query_body = f"""{{
-                organization(login: "{self.org}") {{
-                    name
-                    teams(first: {page_size}, after: %s) {{
-                        pageInfo {{
-                            endCursor
-                            hasNextPage
-                        }}
-                        team_details: nodes {{
-                            id: databaseId
-                            name
-                            slug
-                            members {{
-                                totalCount
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        """
-
-        path_to_page_info = 'data.organization.teams'
-        for result in self._page_results(
-            query_body=query_body, path_to_page_info=path_to_page_info
-        ):
-            for team in result['data']['organization']['teams']['team_details']:
-                yield GitTeamManifest(
-                    company=self.company,
-                    data_source=ManifestSource.remote,
-                    org=self.org,
-                    instance=self.instance,
-                    team_id=team['id'],
-                    slug=team['slug'],
-                    name=team['name'],
-                    member_count=team['members']['totalCount'],
-                )
-
     def get_all_branch_data(
         self, repo_name: str, page_size=100
     ) -> Generator[GitBranchManifest, None, None]:
         query_body = f"""{{
                 organization(login: "{self.org}") {{
-                        name
                         repository(name: "{repo_name}") {{
                             name
                             id: databaseId
@@ -282,7 +222,6 @@ class GithubManifestGenerator(ManifestAdapter):
     ) -> Generator[GitPullRequestManifest, None, None]:
         query_body = f"""{{
                 organization(login: "{self.org}") {{
-                        name
                         repository(name: "{repo_name}") {{
                             name
                             id: databaseId

--- a/jf_agent/data_manifests/git/adapters/manifest_adapter.py
+++ b/jf_agent/data_manifests/git/adapters/manifest_adapter.py
@@ -6,7 +6,6 @@ from jf_agent.data_manifests.git.manifest import (
     GitBranchManifest,
     GitPullRequestManifest,
     GitRepoManifest,
-    GitTeamManifest,
     GitUserManifest,
 )
 
@@ -26,10 +25,6 @@ class ManifestAdapter(ABC):
         pass
 
     @abstractmethod
-    def get_teams_count(self) -> int:
-        pass
-
-    @abstractmethod
     def get_repos_count(self) -> int:
         pass
 
@@ -39,10 +34,6 @@ class ManifestAdapter(ABC):
 
     @abstractmethod
     def get_all_user_data(self) -> Generator[GitUserManifest, None, None]:
-        pass
-
-    @abstractmethod
-    def get_all_team_data(self) -> Generator[GitTeamManifest, None, None]:
         pass
 
     @abstractmethod

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -8,7 +8,6 @@ from jf_agent.data_manifests.git.adapters.manifest_adapter import ManifestAdapte
 from jf_agent.data_manifests.git.manifest import (
     GitDataManifest,
     GitRepoManifest,
-    GitTeamManifest,
     GitUserManifest,
 )
 from jf_agent.data_manifests.git.adapters.github import GithubManifestGenerator
@@ -73,7 +72,6 @@ def create_manifests(
 
                 repo_manifests: list[GitRepoManifest] = []
                 user_manifests: list[GitUserManifest] = []
-                team_manifests: list[GitTeamManifest] = []
 
                 # Process Repos
                 repos_count = manifest_adapter.get_repos_count()
@@ -115,14 +113,6 @@ def create_manifests(
                 ]
                 agent_logging.log_and_print(logger, logging.INFO, 'Done processing Users')
 
-                # Process Teams
-                teams_count = manifest_adapter.get_teams_count()
-                agent_logging.log_and_print(logger, logging.INFO, f'Processing {teams_count} teams')
-                team_manifests += [
-                    team_manifest for team_manifest in manifest_adapter.get_all_team_data()
-                ]
-                agent_logging.log_and_print(logger, logging.INFO, 'Done processing Teams')
-
                 manifests.append(
                     GitDataManifest(
                         data_source=ManifestSource.remote,
@@ -130,11 +120,9 @@ def create_manifests(
                         instance=instance_slug,
                         org=org,
                         users_count=users_count,
-                        teams_count=teams_count,
                         repos_count=repos_count,
                         repo_manifests=repo_manifests,
                         user_manifests=user_manifests,
-                        team_manifests=team_manifests,
                     )
                 )
         except UnsupportedGitProvider as e:

--- a/jf_agent/data_manifests/git/manifest.py
+++ b/jf_agent/data_manifests/git/manifest.py
@@ -8,7 +8,6 @@ from jf_agent.data_manifests.manifest import Manifest, ManifestSource
 IGitDataManifest = TypeVar('IGitDataManifest', bound='GitDataManifest')
 IGitRepoManifest = TypeVar('IGitRepoManifest', bound='GitRepoManifest')
 IGitUserManifest = TypeVar('IGitUserManifest', bound='GitUserManifest')
-IGitTeamManifest = TypeVar('IGitTeamManifest', bound='GitTeamManifest')
 IGitPullRequestManifest = TypeVar('IGitPullRequestManifest', bound='GitPullRequestManifest')
 
 # This is the parent class for all GitManifest type classes. It inherits
@@ -32,11 +31,9 @@ class GitManifest(Manifest):
 @dataclass
 class GitDataManifest(GitManifest):
     users_count: int
-    teams_count: int
     repos_count: int
     repo_manifests: list[IGitRepoManifest]
     user_manifests: list[IGitUserManifest]
-    team_manifests: list[IGitTeamManifest]
 
     def _find_unique_manifests(
         self, minuend_list: list[Manifest], subtrahend_list: list[Manifest]
@@ -52,25 +49,6 @@ class GitDataManifest(GitManifest):
     # Function used for doing class comparisons
     def get_manifest_full_name(self):
         return super().get_manifest_full_name()
-
-
-@dataclass
-class GitTeamManifest(GitManifest):
-
-    team_id: str
-    slug: str
-    name: str
-    member_count: int
-
-    # Function used for doing class comparisons
-    def get_manifest_full_name(self):
-        return f'{super().get_manifest_full_name()}_{self.team_id}'
-
-    def __hash__(self):
-        return super().__hash__()
-
-    def __eq__(self, __o: IGitRepoManifest) -> bool:
-        return super().__eq__(__o)
 
 
 @dataclass


### PR DESCRIPTION
Reduce scope of GitDataManifest generation to not need `[read:org]`. This includes removing any reference to the `name` field when querying for a github `organization`, as well as removing the notion of `TeamManifests` from `GitDataManifests`

See OJ-27623 for internal side changes related to this PR