### PR TITLE
OJ-27616-add-compression-to-manifest-uploading

### DIFF
--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -37,16 +37,14 @@ class GithubManifestGenerator(ManifestAdapter):
         # Session fields
         self.token = token
 
-        if not base_url:
-            self.base_url = 'https://api.github.com/graphql'
-        elif 'api/v3' in base_url:
-            # Github server can provide an API with a trailing '/api/v3'
+        if base_url and 'api/v3' in base_url:
+            # Github server clients provide an API with a trailing '/api/v3'
             # replace this with the graphql endpoint
             self.base_url = base_url.replace('api/v3', 'api/graphql')
         else:
-            # Assume all other cases we have a base_url like this:
-            #  https://api.github.com
-            self.base_url = f'{base_url}/api/graphql'
+            # All non github enterprise server users should use the same
+            # github cloud API endpoint
+            self.base_url = 'https://api.github.com/graphql'
 
         self.session = retry_session(**kwargs)
         self.session.verify = verify

--- a/jf_agent/data_manifests/manifest.py
+++ b/jf_agent/data_manifests/manifest.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -102,7 +103,7 @@ class Manifest(ABC):
             f.write(self.to_json_str())
 
     def upload_to_s3(self, jellyfish_api_base: str, jellyfish_api_token: str) -> None:
-        headers = {'Jellyfish-API-Token': jellyfish_api_token}
+        headers = {'Jellyfish-API-Token': jellyfish_api_token, 'content-encoding': 'gzip'}
 
         agent_logging.log_and_print(
             logger, logging.INFO, f'Attempting to upload {self.get_unique_key()} manifest to s3...'
@@ -111,7 +112,7 @@ class Manifest(ABC):
         r = requests.post(
             f'{jellyfish_api_base}/endpoints/agent/upload_manifest',
             headers=headers,
-            json={'manifest': self.to_json_str()},
+            data=gzip.compress(bytes(self.to_json_str(), encoding='utf-8')),
         )
         r.raise_for_status()
 


### PR DESCRIPTION
GZIP compress all manifest uploads to make manifest uploading more efficient