### PR TITLE
OJ-27617-refactor-github-ingest-to-use-gql

### DIFF
--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -105,7 +105,7 @@ class GithubManifestGenerator(ManifestAdapter):
         """
         path_to_page_info = 'data.organization.repositories'
         for result in self._page_results(
-            query_body=query_body, path_to_page_info=path_to_page_info,
+            query_body=query_body, path_to_page_info=path_to_page_info
         ):
             for repo in result['data']['organization']['repositories']['repos']:
                 yield GitRepoManifest(
@@ -152,7 +152,7 @@ class GithubManifestGenerator(ManifestAdapter):
 
         path_to_page_info = 'data.organization.users'
         for result in self._page_results(
-            query_body=query_body, path_to_page_info=path_to_page_info,
+            query_body=query_body, path_to_page_info=path_to_page_info
         ):
             for user in result['data']['organization']['users']['user_details']:
                 yield GitUserManifest(
@@ -191,7 +191,7 @@ class GithubManifestGenerator(ManifestAdapter):
 
         path_to_page_info = 'data.organization.repository.branches_query'
         for result in self._page_results(
-            query_body=query_body, path_to_page_info=path_to_page_info,
+            query_body=query_body, path_to_page_info=path_to_page_info
         ):
             for branch in result['data']['organization']['repository']['branches_query'][
                 'branches'
@@ -234,7 +234,7 @@ class GithubManifestGenerator(ManifestAdapter):
 
         path_to_page_info = 'data.organization.repository.prs_query'
         for result in self._page_results(
-            query_body=query_body, path_to_page_info=path_to_page_info,
+            query_body=query_body, path_to_page_info=path_to_page_info
         ):
             for pr in result['data']['organization']['repository']['prs_query']['prs']:
                 yield GitPullRequestManifest(

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -245,7 +245,6 @@ def get_git_client(
             )
 
         if config.git_provider == GH_PROVIDER:
-            # TODO: Change this to hide behind new supports_graphql_endpoints flag
             if instance_info.get('supports_graphql_endpoints', False):
                 return GithubGqlClient(
                     base_url=config.git_url,
@@ -326,6 +325,7 @@ def load_and_dump_git(
                 ).load_and_dump_git(endpoint_git_instance_info)
             else:
                 # using old func method, todo: refactor to use GitAdapter
+                # NOTE: We can hopefully do this with the above githubGqlAdapter!
                 from jf_agent.git.github import load_and_dump as load_and_dump_gh
 
                 load_and_dump_gh(

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -318,21 +318,22 @@ def load_and_dump_git(
         elif config.git_provider == 'github':
             from jf_agent.git.github_gql_adapter import GithubGqlAdapter
 
-            GithubGqlAdapter(
-                config, outdir, compress_output_files, git_connection
-            ).load_and_dump_git(endpoint_git_instance_info)
-            """
-            # using old func method, todo: refactor to use GitAdapter
-            from jf_agent.git.github import load_and_dump as load_and_dump_gh
+            # TODO: replace this with the supports_graphql_endpoints flag
+            if True:
+                GithubGqlAdapter(
+                    config, outdir, compress_output_files, git_connection
+                ).load_and_dump_git(endpoint_git_instance_info)
+            else:
+                # using old func method, todo: refactor to use GitAdapter
+                from jf_agent.git.github import load_and_dump as load_and_dump_gh
 
-            load_and_dump_gh(
-                config=config,
-                outdir=outdir,
-                compress_output_files=compress_output_files,
-                endpoint_git_instance_info=endpoint_git_instance_info,
-                git_conn=git_connection,
-            )
-            """
+                load_and_dump_gh(
+                    config=config,
+                    outdir=outdir,
+                    compress_output_files=compress_output_files,
+                    endpoint_git_instance_info=endpoint_git_instance_info,
+                    git_conn=git_connection,
+                )
         elif config.git_provider == 'gitlab':
             from jf_agent.git.gitlab_adapter import GitLabAdapter
 

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -223,7 +223,9 @@ class GitAdapter(ABC):
 
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
-def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bool):
+def get_git_client(
+    config: GitConfig, git_creds: dict, skip_ssl_verification: bool, instance_info: dict = {}
+):
     try:
         if config.git_provider == BBS_PROVIDER:
             return Stash(
@@ -244,7 +246,7 @@ def get_git_client(config: GitConfig, git_creds: dict, skip_ssl_verification: bo
 
         if config.git_provider == GH_PROVIDER:
             # TODO: Change this to hide behind new supports_graphql_endpoints flag
-            if True:
+            if instance_info.get('supports_graphql_endpoints', False):
                 return GithubGqlClient(
                     base_url=config.git_url,
                     token=git_creds['github_token'],
@@ -318,8 +320,7 @@ def load_and_dump_git(
         elif config.git_provider == 'github':
             from jf_agent.git.github_gql_adapter import GithubGqlAdapter
 
-            # TODO: replace this with the supports_graphql_endpoints flag
-            if True:
+            if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
                 GithubGqlAdapter(
                     config, outdir, compress_output_files, git_connection
                 ).load_and_dump_git(endpoint_git_instance_info)

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -337,7 +337,7 @@ def _normalize_commit(
     strip_text_content: bool,
     redact_names_and_urls: bool,
 ):
-    author = _normalize_user(api_commit['author']['user'])
+    author = _normalize_user(api_commit['author'])
     commit_url = api_commit['url'] if not redact_names_and_urls else None
     return NormalizedCommit(
         hash=api_commit['sha'],
@@ -371,7 +371,7 @@ def _get_normalized_reviews(api_reviews: list[dict]):
     return [
         NormalizedPullRequestReview(
             user=_normalize_user(api_review['author']),
-            foreign_id=api_review['author']['id'],
+            foreign_id=api_review['id'],
             review_state=api_review['state'],
         )
         for api_review in api_reviews

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -137,10 +137,8 @@ class GithubGqlAdapter(GitAdapter):
                     server_git_instance_info, nrm_repo.project.login, nrm_repo.id, 'commits'
                 )
 
-                try:
-                    for branch_name in get_branches_for_normalized_repo(
-                        nrm_repo, included_branches
-                    ):
+                for branch_name in get_branches_for_normalized_repo(nrm_repo, included_branches):
+                    try:
                         for j, api_commit in enumerate(
                             tqdm(
                                 self.client.get_commits(
@@ -165,9 +163,9 @@ class GithubGqlAdapter(GitAdapter):
                                     self.config.git_redact_names_and_urls,
                                 )
 
-                except Exception as e:
-                    print(traceback.format_exc())
-                    print(f':WARN: Got exception for branch {branch_name}: {e}. Skipping...')
+                    except Exception as e:
+                        print(traceback.format_exc())
+                        print(f':WARN: Got exception for branch {branch_name}: {e}. Skipping...')
         print('✓')
 
     @diagnostics.capture_timing()

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -1,0 +1,429 @@
+import traceback
+from jf_agent.git.github_gql_client import GithubGqlClient
+from jf_agent.git.utils import get_branches_for_normalized_repo
+from tqdm import tqdm
+from dateutil import parser
+from typing import List
+import logging
+from jf_agent.git import (
+    GitAdapter,
+    NormalizedUser,
+    NormalizedProject,
+    NormalizedBranch,
+    NormalizedRepository,
+    NormalizedCommit,
+    NormalizedPullRequest,
+    NormalizedPullRequestComment,
+    NormalizedPullRequestReview,
+    NormalizedShortRepository,
+    pull_since_date_for_repo,
+)
+from jf_agent.git.utils import log_and_print_request_error
+from jf_agent import diagnostics, agent_logging
+from jf_agent.name_redactor import NameRedactor, sanitize_text
+from jf_agent.config_file_reader import GitConfig
+
+logger = logging.getLogger(__name__)
+
+_branch_redactor = NameRedactor(preserve_names=['master', 'develop'])
+_project_redactor = NameRedactor()
+_repo_redactor = NameRedactor()
+
+'''
+
+    Data Fetching
+
+'''
+
+
+class GithubGqlAdapter(GitAdapter):
+    def __init__(
+        self, config: GitConfig, outdir: str, compress_output_files: bool, client: GithubGqlClient
+    ):
+        super().__init__(config, outdir, compress_output_files)
+        self.client = client
+
+    @diagnostics.capture_timing()
+    @agent_logging.log_entry_exit(logger)
+    def get_projects(self) -> List[NormalizedProject]:
+        print('downloading github projects... ', end='', flush=True)
+        projects = []
+
+        # NOTE: For github, project equates to a Github organization here!
+        for project_id in self.config.git_include_projects:
+            organization = self.client.get_organization_by_login(project_id)
+
+            if organization is None:  # skip organizations that errored out when fetching data
+                continue
+
+            projects.append(
+                _normalize_project(organization, self.config.git_redact_names_and_urls,)
+            )
+        print('✓')
+
+        if not projects:
+            raise ValueError(
+                'No projects found.  Make sure your token has appropriate access to Github.'
+            )
+        return projects
+
+    @diagnostics.capture_timing()
+    @agent_logging.log_entry_exit(logger)
+    def get_users(self) -> List[NormalizedUser]:
+        print('downloading github users... ', end='', flush=True)
+        users = [
+            _normalize_user(user)
+            for project_id in self.config.git_include_projects
+            for user in self.client.get_users(project_id)
+        ]
+        print('✓')
+        return users
+
+    @diagnostics.capture_timing()
+    @agent_logging.log_entry_exit(logger)
+    def get_repos(
+        self, normalized_projects: List[NormalizedProject],
+    ) -> List[NormalizedRepository]:
+        print('downloading github repos... ', end='', flush=True)
+
+        nrm_repos: List[NormalizedRepository] = []
+
+        filters = []
+        if self.config.git_include_repos:
+            filters.append(
+                lambda r: r['name'].lower()
+                in set([r.lower() for r in self.config.git_include_repos])
+            )
+        if self.config.git_exclude_repos:
+            filters.append(
+                lambda r: r['name'].lower()
+                not in set([r.lower() for r in self.config.git_exclude_repos])
+            )
+
+        nrm_repos = [
+            _normalize_repo(api_repo, nrm_project, self.config.git_redact_names_and_urls)
+            for nrm_project in normalized_projects
+            for api_repo in tqdm(
+                self.client.get_repos(nrm_project.login),
+                desc=f'downloading repos for {nrm_project.login}',
+                unit='repos',
+            )
+            if all(filt(api_repo) for filt in filters)
+        ]
+
+        print('✓')
+        if not nrm_repos:
+            raise ValueError(
+                'No repos found. Make sure your token has appropriate access to Github and check your configuration of repos to pull.'
+            )
+        return nrm_repos
+
+    @diagnostics.capture_timing()
+    @agent_logging.log_entry_exit(logger)
+    def get_commits_for_included_branches(
+        self,
+        normalized_repos: List[NormalizedRepository],
+        included_branches: dict,
+        server_git_instance_info,
+    ) -> List[NormalizedCommit]:
+        print('downloading github commits on included branches... ', end='', flush=True)
+        for i, nrm_repo in enumerate(normalized_repos, start=1):
+            with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
+                pull_since = pull_since_date_for_repo(
+                    server_git_instance_info, nrm_repo.project.login, nrm_repo.id, 'commits'
+                )
+
+                try:
+                    for branch_name in get_branches_for_normalized_repo(
+                        nrm_repo, included_branches
+                    ):
+                        for j, api_commit in enumerate(
+                            tqdm(
+                                self.client.get_commits(
+                                    login=nrm_repo.project.login,
+                                    repo_name=nrm_repo.name,
+                                    branch_name=branch_name,
+                                    since=pull_since,
+                                ),
+                                desc=f'downloading commits for branch {branch_name} in repo {nrm_repo.name} ({nrm_repo.project.login})',
+                                unit='commits',
+                            ),
+                            start=1,
+                        ):
+                            with agent_logging.log_loop_iters(
+                                logger, 'branch commit inside repo', j, 100
+                            ):
+                                yield _normalize_commit(
+                                    api_commit,
+                                    nrm_repo,
+                                    branch_name,
+                                    self.config.git_strip_text_content,
+                                    self.config.git_redact_names_and_urls,
+                                )
+
+                except Exception as e:
+                    print(traceback.format_exc())
+                    print(f':WARN: Got exception for branch {branch_name}: {e}. Skipping...')
+        print('✓')
+
+    @diagnostics.capture_timing()
+    @agent_logging.log_entry_exit(logger)
+    def get_pull_requests(
+        self, normalized_repos: List[NormalizedRepository], server_git_instance_info,
+    ) -> List[NormalizedPullRequest]:
+        print('downloading github prs... ', end='', flush=True)
+
+        nrm_prs = []
+        for i, nrm_repo in enumerate(normalized_repos, start=1):
+            print(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')
+
+            with agent_logging.log_loop_iters(logger, 'repo for pull requests', i, 1):
+                try:
+                    pull_since = pull_since_date_for_repo(
+                        server_git_instance_info, nrm_repo.project.login, nrm_repo.id, 'prs'
+                    )
+
+                    api_prs = self.client.get_prs(
+                        login=nrm_repo.project.login, repo_name=nrm_repo.name
+                    )
+
+                    for api_pr in tqdm(
+                        api_prs,
+                        desc=f'processing prs for {nrm_repo.name} ({nrm_repo.id})',
+                        unit='prs',
+                    ):
+                        try:
+                            updated_at = parser.parse(api_pr['updatedAt'])
+
+                            # PRs are ordered newest to oldest
+                            # if this is too old, we're done with this repo
+                            if pull_since and updated_at < pull_since:
+                                break
+
+                            nrm_prs.append(
+                                _normalize_pr(
+                                    api_pr,
+                                    nrm_repo,
+                                    self.config.git_strip_text_content,
+                                    self.config.git_redact_names_and_urls,
+                                )
+                            )
+                        except Exception as e:
+                            # if something goes wrong with normalizing one of the prs - don't stop pulling. try
+                            # the next one.
+                            pr_id = f' {api_pr["id"]}' if api_pr else ''
+                            log_and_print_request_error(
+                                e,
+                                f'normalizing PR {pr_id} from repo {nrm_repo.name} ({nrm_repo.id}). Skipping...',
+                                log_as_exception=True,
+                            )
+
+                except Exception as e:
+                    # if something happens when pulling PRs for a repo, just keep going.
+                    log_and_print_request_error(
+                        e,
+                        f'getting PRs for repo {nrm_repo.name} ({nrm_repo.id}). Skipping...',
+                        log_as_exception=True,
+                    )
+        return nrm_prs
+
+    print('✓')
+
+
+'''
+
+    Massage Functions
+
+'''
+
+
+def _normalize_user(api_user) -> NormalizedUser:
+    if not api_user:
+        return None
+
+    # raw user, just have email (e.g. from a commit)
+    if 'id' not in api_user:
+        return NormalizedUser(
+            id=api_user['email'],
+            login=api_user['email'],
+            name=api_user['name'],
+            email=api_user['email'],
+        )
+
+    # API user, where github matched to a known account
+    return NormalizedUser(
+        id=api_user['id'], login=api_user['login'], name=api_user['name'], email=api_user['email']
+    )
+
+
+def _normalize_project(api_org: dict, redact_names_and_urls: bool) -> NormalizedProject:
+    return NormalizedProject(
+        id=api_org['id'],
+        login=api_org['login'],
+        name=api_org['name']
+        if not redact_names_and_urls
+        else _project_redactor.redact_name(api_org['name']),
+        url=api_org['url'] if not redact_names_and_urls else None,
+    )
+
+
+def _normalize_branch(api_branch, redact_names_and_urls: bool) -> NormalizedBranch:
+    return NormalizedBranch(
+        name=api_branch['name']
+        if not redact_names_and_urls
+        else _branch_redactor.redact_name(api_branch['name']),
+        sha=api_branch['target']['sha'],
+    )
+
+
+def _normalize_repo(
+    api_repo, normalized_project: NormalizedProject, redact_names_and_urls: bool,
+) -> NormalizedRepository:
+    repo_name = (
+        api_repo['name']
+        if not redact_names_and_urls
+        else _repo_redactor.redact_name(api_repo['name'])
+    )
+    url = api_repo['url'] if not redact_names_and_urls else None
+
+    normalized_branches = [
+        _normalize_branch(branch, redact_names_and_urls) for branch in api_repo['branches']
+    ]
+
+    return NormalizedRepository(
+        id=api_repo['id'],
+        name=repo_name,
+        full_name=repo_name,
+        url=url,
+        default_branch_name=api_repo['defaultBranch']['name'],
+        is_fork=api_repo['isFork'],
+        branches=normalized_branches,
+        project=normalized_project,
+    )
+
+
+def _normalize_short_form_repo(
+    api_repo: dict, redact_names_and_urls: dict
+) -> NormalizedShortRepository:
+    repo_name = (
+        api_repo['name']
+        if not redact_names_and_urls
+        else _repo_redactor.redact_name(api_repo['name'])
+    )
+    url = api_repo['url'] if not redact_names_and_urls else None
+
+    return NormalizedShortRepository(id=api_repo['id'], name=repo_name, url=url)
+
+
+def _normalize_commit(
+    api_commit: dict,
+    normalized_repo: NormalizedRepository,
+    branch_name: str,
+    strip_text_content: bool,
+    redact_names_and_urls: bool,
+):
+    author = _normalize_user(api_commit['author']['user'])
+    commit_url = api_commit['url'] if not redact_names_and_urls else None
+    return NormalizedCommit(
+        hash=api_commit['sha'],
+        author=author,
+        url=commit_url,
+        commit_date=api_commit['committedDate'],
+        author_date=api_commit['authoredDate'],
+        message=sanitize_text(api_commit['message'], strip_text_content),
+        is_merge=api_commit['parents']['totalCount'] > 1,
+        repo=normalized_repo.short(),  # use short form of repo
+        branch_name=branch_name
+        if not redact_names_and_urls
+        else _branch_redactor.redact_name(branch_name),
+    )
+
+
+def _get_normalized_pr_comments(
+    api_comments: list[dict], strip_text_content
+) -> List[NormalizedPullRequestComment]:
+    return [
+        NormalizedPullRequestComment(
+            user=_normalize_user(api_comment['author']),
+            body=sanitize_text(api_comment['body'], strip_text_content),
+            created_at=api_comment['createdAt'],
+        )
+        for api_comment in api_comments
+    ]
+
+
+def _get_normalized_reviews(api_reviews: list[dict]):
+    return [
+        NormalizedPullRequestReview(
+            user=_normalize_user(api_review['author']),
+            foreign_id=api_review['author']['id'],
+            review_state=api_review['state'],
+        )
+        for api_review in api_reviews
+    ]
+
+
+def _normalize_pr(
+    api_pr,
+    normalized_repo: NormalizedRepository,
+    strip_text_content: bool,
+    redact_names_and_urls: bool,
+):
+    base_branch_name = api_pr['baseRef']['name'] if api_pr['baseRef'] else None
+    head_branch_name = api_pr['headRef']['name'] if api_pr['headRef'] else None
+    normalized_merge_commit = (
+        _normalize_commit(
+            api_pr['mergeCommit'],
+            normalized_repo=normalized_repo,
+            branch_name=base_branch_name,
+            strip_text_content=strip_text_content,
+            redact_names_and_urls=redact_names_and_urls,
+        )
+        if api_pr['mergeCommit']
+        else None
+    )
+    return NormalizedPullRequest(
+        id=api_pr['id'],
+        additions=api_pr['additions'],
+        deletions=api_pr['deletions'],
+        changed_files=api_pr['changedFiles'],
+        created_at=api_pr['createdAt'],
+        updated_at=api_pr['updatedAt'],
+        merge_date=api_pr['mergedAt'],
+        closed_date=api_pr['closedAt'],
+        is_closed=api_pr['state'].lower() == 'closed',
+        is_merged=api_pr['merged'],
+        # redacted fields
+        url=api_pr['url'] if not redact_names_and_urls else None,
+        base_branch=(
+            base_branch_name
+            if not redact_names_and_urls
+            else _branch_redactor.redact_name(base_branch_name)
+        ),
+        head_branch=(
+            head_branch_name
+            if not redact_names_and_urls
+            else _branch_redactor.redact_name(head_branch_name)
+        ),
+        # sanitized fields
+        title=sanitize_text(api_pr['title'], strip_text_content),
+        body=sanitize_text(api_pr['body'], strip_text_content),
+        # normalized fields
+        commits=[
+            _normalize_commit(
+                api_commit=commit,
+                normalized_repo=normalized_repo,
+                branch_name=base_branch_name,
+                strip_text_content=strip_text_content,
+                redact_names_and_urls=redact_names_and_urls,
+            )
+            for commit in api_pr['commits']
+        ],
+        merge_commit=normalized_merge_commit,
+        author=_normalize_user(api_user=api_pr['author']),
+        merged_by=_normalize_user(api_user=api_pr['mergedBy']),
+        approvals=_get_normalized_reviews(api_pr['reviews']),
+        comments=_get_normalized_pr_comments(api_pr['comments'], strip_text_content),
+        base_repo=_normalize_short_form_repo(api_pr['baseRepository'], redact_names_and_urls),
+        head_repo=_normalize_short_form_repo(api_pr['baseRepository'], redact_names_and_urls),
+    )

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -1,0 +1,399 @@
+import inspect
+import logging
+from datetime import datetime
+from requests import Session
+from typing import Generator
+
+from jf_agent.git.github_gql_utils import (
+    get_github_gql_base_url,
+    get_github_gql_session,
+    get_raw_result,
+    page_results,
+)
+from jf_agent.git.utils import log_and_print_request_error
+
+logger = logging.getLogger(__name__)
+
+
+class GithubGqlClient:
+
+    GITHUB_GQL_USER_FRAGMENT = "... on User {id, login, email, name }"
+    GITHUB_GQL_PAGE_INFO_BLOCK = "pageInfo {hasNextPage, endCursor}"
+    GITHUB_GQL_COMMIT_FRAGMENT = f"""
+        ... on Commit {{
+            sha: oid
+            url
+            author {{
+                user {{
+                    {GITHUB_GQL_USER_FRAGMENT}
+                }}
+            }}
+            message
+            committedDate
+            authoredDate
+            parents {{totalCount}}
+        }}
+    """
+    GITHUB_GQL_SHORT_REPO_FRAGMENT = "... on Repository {name, id, url}"
+
+    def __init__(self, base_url: str, token: str, verify: bool, session: Session) -> None:
+        self.token = token
+        self.base_url = get_github_gql_base_url(base_url=base_url)
+
+        self.session = get_github_gql_session(token=token, verify=verify, session=session)
+
+    def _get_raw_result(self, query_body: str):
+        return get_raw_result(query_body=query_body, base_url=self.base_url, session=self.session)
+
+    def _page_results(self, query_body: str, path_to_page_info: str):
+        return page_results(
+            query_body=query_body,
+            path_to_page_info=path_to_page_info,
+            session=self.session,
+            base_url=self.base_url,
+        )
+
+    @staticmethod
+    def _to_git_timestamp(timestamp: datetime):
+        return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def get_organization_by_login(self, login: str):
+        query_body = f"""{{
+            organization(login: \"{login}\") {{
+                id
+                login
+                name
+                url
+            }}
+        }}
+        """
+        try:
+            return self._get_raw_result(query_body=query_body)['data']['organization']
+        except Exception as e:
+            log_and_print_request_error(
+                e, f'fetching source project {login}. ' f'Skipping...',
+            )
+            return None
+
+    def get_users(self, login: str) -> Generator[dict, None, None]:
+        query_body = f"""{{
+            organization(login: \"{login}\") {{
+                userQuery: membersWithRole(first: 100, after: %s) {{
+                    {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                    users: nodes {{
+                        {self.GITHUB_GQL_USER_FRAGMENT}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.userQuery'
+        ):
+            for user in page['data']['organization']['userQuery']['users']:
+                yield user
+
+    def get_repos(self, login: str) -> Generator[dict, None, None]:
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                # THIS IS NEEDED BY NORMALIZE_PROJECT
+                id
+                login
+                url
+                repoQuery: repositories(first: 100, after: null) {{
+                    {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                    repos: nodes {{
+                        ... on Repository {{
+                            id: databaseId
+                            name
+                            fullName: nameWithOwner
+                            url
+                            isFork
+                            defaultBranch: defaultBranchRef {{
+                                    name
+                            }}
+                            # This should be broken out into a separate query if 
+                            # hasNextPage is True.
+                            # We should cache all branch names and sha's, too
+                            branchQuery: refs(refPrefix:"refs/heads/", first: 100, after: %s) {{
+                                {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                                branches: nodes {{
+                                    ... on Ref {{
+                                        name
+                                        target {{sha: oid}}
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repoQuery'
+        ):
+            for api_repo in page['data']['organization']['repoQuery']['repos']:
+                if api_repo['branchQuery']['pageInfo']['hasNextPage']:
+                    # Page for all branches
+                    branches = [
+                        branch
+                        for branch in self.get_branches(login=login, repo_name=api_repo['name'])
+                    ]
+                else:
+                    branches = api_repo['branchQuery']['branches']
+
+                # Add new dict entry for branches
+                api_repo['branches'] = branches
+                yield api_repo
+
+    def get_branches(self, login: str, repo_name: str) -> Generator[dict, None, None]:
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repository(name: "{repo_name}") {{
+                    ... on Repository {{
+                        branchQuery: refs(refPrefix:"refs/heads/", first: 100, after: %s) {{
+                            {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                            branches: nodes {{
+                                ... on Ref {{
+                                    name
+                                    target {{sha: oid}}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repository.branchQuery'
+        ):
+            for api_branch in page['data']['organization']['repository']['branchQuery']['branches']:
+                yield api_branch
+
+    def get_commits(
+        self, login: str, repo_name: str, branch_name: str, since: datetime
+    ) -> Generator[dict, None, None]:
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repo: repository(name: "{repo_name}") {{
+                    ... on Repository {{
+                        branch: ref(qualifiedName: "{branch_name}") {{
+                            target {{
+                                ... on Commit {{
+                                    history(first: 100, since: "{self._to_git_timestamp(since)}", after: %s) {{
+                                        {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                                        commits: nodes {{
+                                            {self.GITHUB_GQL_COMMIT_FRAGMENT}
+                                        }}
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repo.branch.target.history'
+        ):
+            for api_commit in page['data']['organization']['repo']['branch']['target']['history'][
+                'commits'
+            ]:
+                yield api_commit
+
+    #
+    # PR Queries are HUGE, so pull out reusable blocks (comments, reviews, commits, etc)
+    #
+    GITHUB_GQL_PR_COMMENTS_QUERY_BLOCK = f"""
+        commentsQuery: comments(first: 50) {{
+            {GITHUB_GQL_PAGE_INFO_BLOCK}
+            
+            comments: nodes {{
+                ... on IssueComment {{
+                    author {{
+                        {GITHUB_GQL_USER_FRAGMENT}
+                    }}
+                    body
+                    createdAt
+                }}
+            }}
+        }}
+    """
+    GITHUB_GQL_PR_REVIEWS_QUERY_BLOCK = f"""
+        reviewsQuery: reviews(first: 50) {{
+            {GITHUB_GQL_PAGE_INFO_BLOCK}
+            
+            reviews: nodes {{
+                ... on PullRequestReview {{
+                    author {{
+                        {GITHUB_GQL_USER_FRAGMENT}
+                    }}
+                    id
+                    state
+                }}
+            }}
+        }}
+    """
+    GITHUB_GQL_PR_COMMITS_QUERY_BLOCK = f"""
+        commitsQuery: commits(first: 50) {{
+            {GITHUB_GQL_PAGE_INFO_BLOCK}
+            
+            commits: nodes {{
+                ... on PullRequestCommit {{
+                    commit {{
+                        {GITHUB_GQL_COMMIT_FRAGMENT}
+                    }}
+                }}
+            }}
+        }}
+    """
+    # PR query is HUGE, see above GITHUB_GQL_PR_* blocks for reused code
+    def get_prs(self, login: str, repo_name: str,) -> Generator[dict, None, None]:
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repo: repository(name: "{repo_name}") {{
+                    prQuery: pullRequests(first: 50, orderBy: {{direction: DESC, field: UPDATED_AT}}, after: %s) {{
+                        {self.GITHUB_GQL_PAGE_INFO_BLOCK}
+                        prs: nodes {{
+                            ... on PullRequest {{
+                                id: databaseId
+                                number
+                                updated_at: updatedAt
+                                additions
+                                deletions
+                                changedFiles
+                                state
+                                merged
+                                createdAt
+                                updatedAt
+                                mergedAt
+                                closedAt
+                                title
+                                body
+                                url
+                                baseRef {{
+                                    name
+                                }}
+                                headRef {{
+                                    name
+                                }}
+                                baseRepository {{ {self.GITHUB_GQL_SHORT_REPO_FRAGMENT} }}
+                                headRepository {{ {self.GITHUB_GQL_SHORT_REPO_FRAGMENT} }}
+                                author {{
+                                    {self.GITHUB_GQL_USER_FRAGMENT}
+                                }}
+                                mergedBy {{
+                                    {self.GITHUB_GQL_USER_FRAGMENT}
+                                }}
+                                mergeCommit {{
+                                    {self.GITHUB_GQL_COMMIT_FRAGMENT}
+                                }}
+                                {self.GITHUB_GQL_PR_COMMENTS_QUERY_BLOCK}
+                                {self.GITHUB_GQL_PR_REVIEWS_QUERY_BLOCK}
+                                {self.GITHUB_GQL_PR_COMMITS_QUERY_BLOCK}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repo.prQuery'
+        ):
+            for api_pr in page['data']['organization']['repo']['prQuery']['prs']:
+                # Process and add related PR data (comments, reviews, commits)
+                # This may require additional API calls
+                pr_number = api_pr['number']
+                api_pr['comments'] = (
+                    self.get_pr_comments(login, repo_name, pr_number=pr_number)
+                    if api_pr['commentsQuery']['pageInfo']['hasNextPage']
+                    else api_pr['commentsQuery']['comments']
+                )
+                api_pr['reviews'] = (
+                    self.get_pr_reviews(login, repo_name, pr_number=pr_number)
+                    if api_pr['reviewsQuery']['pageInfo']['hasNextPage']
+                    else api_pr['reviewsQuery']['reviews']
+                )
+                api_pr['commits'] = (
+                    self.get_pr_commits(login, repo_name, pr_number=pr_number)
+                    if api_pr['commitsQuery']['pageInfo']['hasNextPage']
+                    else [commit['commit'] for commit in api_pr['commitsQuery']['commits']]
+                )
+                yield api_pr
+
+    def get_pr_comments(
+        self, login: str, repo_name: str, pr_number: int
+    ) -> Generator[dict, None, None]:
+        print(f'{inspect.stack()[0][3]} for {login} {repo_name} {pr_number}')
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repo: repository(name: "{repo_name}") {{
+                    pr: pullRequest(number: {pr_number}) {{
+                        ... on PullRequest {{
+                            {self.GITHUB_GQL_PR_COMMENTS_QUERY_BLOCK}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repo.pr.commentsQuery'
+        ):
+            for api_pr_comment in page['data']['organization']['repo']['pr']['commentsQuery'][
+                'comments'
+            ]:
+                yield api_pr_comment
+
+    def get_pr_reviews(
+        self, login: str, repo_name: str, pr_number: int
+    ) -> Generator[dict, None, None]:
+        print(f'{inspect.stack()[0][3]} for {login} {repo_name} {pr_number}')
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repo: repository(name: "{repo_name}") {{
+                    pr: pullRequest(number: {pr_number}) {{
+                        ... on PullRequest {{
+                            {self.GITHUB_GQL_PR_REVIEWS_QUERY_BLOCK}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repo.pr.reviewsQuery'
+        ):
+            for api_pr_review in page['data']['organization']['repo']['pr']['reviewsQuery'][
+                'reviews'
+            ]:
+                yield api_pr_review
+
+    def get_pr_commits(
+        self, login: str, repo_name: str, pr_number: int
+    ) -> Generator[dict, None, None]:
+        print(f'{inspect.stack()[0][3]} for {login} {repo_name} {pr_number}')
+        query_body = f"""{{
+            organization(login: "{login}") {{
+                repo: repository(name: "{repo_name}") {{
+                    pr: pullRequest(number: {pr_number}) {{
+                        ... on PullRequest {{
+                            {self.GITHUB_GQL_PR_COMMITS_QUERY_BLOCK}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        """
+        for page in self._page_results(
+            query_body=query_body, path_to_page_info='data.organization.repo.pr.commitsQuery'
+        ):
+            for api_pr_commit in page['data']['organization']['repo']['pr']['commitsQuery'][
+                'commits'
+            ]:
+                # Commit blocks are nested within the 'commits' block
+                yield api_pr_commit['commit']

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -70,9 +70,10 @@ class GithubGqlClient:
     # the nested user object
     @staticmethod
     def _process_git_actor_author_gql_object(author: dict) -> dict:
+        user = author['user']
         return {
-            'id': author['user']['id'],
-            'login': author['user']['login'],
+            'id': author['user']['id'] if author['user'] else None,
+            'login': author['user']['login'] if author['user'] else None,
             'email': author['email'],
             'name': author['name'],
         }

--- a/jf_agent/git/github_gql_utils.py
+++ b/jf_agent/git/github_gql_utils.py
@@ -1,0 +1,64 @@
+import json
+from typing import Generator
+
+from requests import Session
+
+from jf_agent.session import retry_session
+
+
+def get_github_gql_base_url(base_url: str):
+    if base_url and 'api/v3' in base_url:
+        # Github server clients provide an API with a trailing '/api/v3'
+        # replace this with the graphql endpoint
+        return base_url.replace('api/v3', 'api/graphql')
+    else:
+        return 'https://api.github.com/graphql'
+
+
+def get_github_gql_session(token: str, verify: bool = True, session: Session = None):
+    if not session:
+        session = retry_session()
+
+    session.verify = verify
+    session.headers.update(
+        {'Authorization': f'token {token}', "Accept": "application/vnd.github+json",}
+    )
+    return session
+
+
+def page_results(
+    query_body: str, path_to_page_info: str, session: Session, base_url: str, cursor: str = 'null'
+) -> Generator[dict, None, None]:
+
+    # TODO: Write generalized paginator
+    hasNextPage = True
+    while hasNextPage:
+        # Fetch results
+        result = get_raw_result(
+            query_body=(query_body % cursor), base_url=base_url, session=session
+        )
+
+        yield result
+
+        # Get relevant data and yield it
+        path_tokens = path_to_page_info.split('.')
+        for token in path_tokens:
+            result = result[token]
+
+        page_info = result['pageInfo']
+        # Need to grab the cursor and wrap it in quotes
+        _cursor = page_info['endCursor']
+        cursor = f'"{_cursor}"'
+        hasNextPage = page_info['hasNextPage']
+
+
+def get_raw_result(query_body: str, base_url: str, session: Session) -> dict:
+    response = session.post(url=base_url, json={'query': query_body})
+    response.raise_for_status()
+    json_str = response.content.decode()
+    json_data = json.loads(json_str)
+    if 'errors' in json_data:
+        raise Exception(
+            f'Exception encountered when trying to query: {query_body}. Error: {json_data["errors"]}'
+        )
+    return json_data

--- a/jf_agent/git/github_gql_utils.py
+++ b/jf_agent/git/github_gql_utils.py
@@ -48,8 +48,9 @@ def page_results(
         page_info = result['pageInfo']
         # Need to grab the cursor and wrap it in quotes
         _cursor = page_info['endCursor']
+        # If endCursor returns null (None), break out of loop
+        hasNextPage = page_info['hasNextPage'] and _cursor
         cursor = f'"{_cursor}"'
-        hasNextPage = page_info['hasNextPage']
 
 
 def get_raw_result(query_body: str, base_url: str, session: Session) -> dict:

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -21,9 +21,9 @@ from jf_agent.git import (
 )
 from jf_agent.git.gitlab_client import (
     GitLabClient,
-    log_and_print_request_error,
     MissingSourceProjectException,
 )
+from jf_agent.git.utils import log_and_print_request_error
 from jf_agent import diagnostics, agent_logging
 from jf_agent.name_redactor import NameRedactor, sanitize_text
 from jf_agent.config_file_reader import GitConfig

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -3,35 +3,13 @@ import logging
 import requests
 
 from jf_agent import agent_logging
+from jf_agent.git.utils import log_and_print_request_error
 
 logger = logging.getLogger(__name__)
 
 
 class MissingSourceProjectException(Exception):
     pass
-
-
-def log_and_print_request_error(e, action='making request', log_as_exception=False):
-    try:
-        response_code = e.response_code
-    except AttributeError:
-        # if the request error is a retry error, we won't have the code
-        response_code = ''
-
-    error_name = type(e).__name__
-
-    if log_as_exception:
-        agent_logging.log_and_print_error_or_warning(
-            logger,
-            logging.ERROR,
-            msg_args=[error_name, response_code, action, e],
-            error_code=3131,
-            exc_info=True,
-        )
-    else:
-        agent_logging.log_and_print_error_or_warning(
-            logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3141
-        )
 
 
 class GitLabClient:

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -1,11 +1,12 @@
 import fnmatch
-from typing import List
-from jf_agent.git import NormalizedRepository
+import logging
+from typing import Any, List
 
+logger = logging.getLogger(__name__)
 
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
-def get_branches_for_normalized_repo(repo: NormalizedRepository, included_branches: dict):
+def get_branches_for_normalized_repo(repo: Any, included_branches: dict):
     branches_to_process = [repo.default_branch_name]
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:
@@ -27,3 +28,28 @@ def get_matching_branches(
         if any(fnmatch.fnmatch(repo_branch_name, pattern) for pattern in included_branch_patterns):
             matching_branches.append(repo_branch_name)
     return matching_branches
+
+
+def log_and_print_request_error(e, action='making request', log_as_exception=False):
+    from jf_agent import agent_logging
+
+    try:
+        response_code = e.response_code
+    except AttributeError:
+        # if the request error is a retry error, we won't have the code
+        response_code = ''
+
+    error_name = type(e).__name__
+
+    if log_as_exception:
+        agent_logging.log_and_print_error_or_warning(
+            logger,
+            logging.ERROR,
+            msg_args=[error_name, response_code, action, e],
+            error_code=3131,
+            exc_info=True,
+        )
+    else:
+        agent_logging.log_and_print_error_or_warning(
+            logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3141
+        )

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -1,6 +1,5 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 import gzip
 import logging
 import os
@@ -510,7 +509,6 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 def _download_git_data(
     git_config, config, creds, endpoint_git_instances_info, is_multi_git_config
 ) -> dict:
-    start_time = datetime.utcnow()
     if is_multi_git_config:
         instance_slug = git_config.git_instance_slug
         instance_info = endpoint_git_instances_info.get(instance_slug)
@@ -523,16 +521,13 @@ def _download_git_data(
     git_connection = get_git_client(
         git_config, instance_creds, skip_ssl_verification=config.skip_ssl_verification
     )
-    data = load_and_dump_git(
+    return load_and_dump_git(
         config=git_config,
         endpoint_git_instance_info=instance_info,
         outdir=config.outdir,
         compress_output_files=config.compress_output_files,
         git_connection=git_connection,
     )
-    end_time = datetime.utcnow()
-    print(f'GIT PULL ELAPSED TIME: {end_time - start_time}')
-    return data
 
 
 def send_data(config, creds):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -1,5 +1,6 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 import gzip
 import logging
 import os
@@ -509,6 +510,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 def _download_git_data(
     git_config, config, creds, endpoint_git_instances_info, is_multi_git_config
 ) -> dict:
+    start_time = datetime.utcnow()
     if is_multi_git_config:
         instance_slug = git_config.git_instance_slug
         instance_info = endpoint_git_instances_info.get(instance_slug)
@@ -521,13 +523,16 @@ def _download_git_data(
     git_connection = get_git_client(
         git_config, instance_creds, skip_ssl_verification=config.skip_ssl_verification
     )
-    return load_and_dump_git(
+    data = load_and_dump_git(
         config=git_config,
         endpoint_git_instance_info=instance_info,
         outdir=config.outdir,
         compress_output_files=config.compress_output_files,
         git_connection=git_connection,
     )
+    end_time = datetime.utcnow()
+    print(f'GIT PULL ELAPSED TIME: {end_time - start_time}')
+    return data
 
 
 def send_data(config, creds):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -519,7 +519,10 @@ def _download_git_data(
         instance_creds = list(creds.git_instance_to_creds.values())[0]
 
     git_connection = get_git_client(
-        git_config, instance_creds, skip_ssl_verification=config.skip_ssl_verification
+        git_config,
+        instance_creds,
+        skip_ssl_verification=config.skip_ssl_verification,
+        instance_info=instance_info,
     )
     return load_and_dump_git(
         config=git_config,


### PR DESCRIPTION
Introduce a new Github Adapter that leverages Graphql to greatly increase speed of data ingestion. The biggest gains here will be realized by speeding up our pull request ingesiton

See the related Jira Ticket for a more in-depth analysis of this change