### PR TITLE
OJ-28319-gql-edge-case-cleanup

### DIFF
--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -214,7 +214,7 @@ def get_repos(
     repos = [
         (r, _normalize_repo(client, org, r, redact_names_and_urls))
         for org in include_orgs
-        for r in client.get_all_repos(org)
+        for r in tqdm(client.get_all_repos(org), desc=f'downloading repos', unit='repos',)
         if all(filt(r) for filt in filters)
     ]
     print('✓')

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -214,7 +214,7 @@ def get_repos(
     repos = [
         (r, _normalize_repo(client, org, r, redact_names_and_urls))
         for org in include_orgs
-        for r in tqdm(client.get_all_repos(org), desc=f'downloading repos', unit='repos',)
+        for r in client.get_all_repos(org)
         if all(filt(r) for filt in filters)
     ]
     print('✓')

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -334,12 +334,8 @@ class GithubGqlClient:
                                 title
                                 body
                                 url
-                                baseRef {{
-                                    name
-                                }}
-                                headRef {{
-                                    name
-                                }}
+                                baseRefName
+                                headRefName
                                 baseRepository {{ {self.GITHUB_GQL_SHORT_REPO_FRAGMENT} }}
                                 headRepository {{ {self.GITHUB_GQL_SHORT_REPO_FRAGMENT} }}
                                 author {{

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -7,10 +7,10 @@ logger = logging.getLogger(__name__)
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
 def get_branches_for_normalized_repo(repo: Any, included_branches: dict):
-    branches_to_process = [repo.default_branch_name]
+    branches_to_process = [repo.default_branch_name] if repo.default_branch_name else []
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:
-        repo_branch_names = [b.name for b in repo.branches]
+        repo_branch_names = [b.name for b in repo.branches if b]
         branches_to_process.extend(
             get_matching_branches(additional_branches_for_repo, repo_branch_names)
         )


### PR DESCRIPTION
Clean up potential edge cases, notably around empty repositories not having default branches.

Additionally clean up null serialization to play nicer with our `git_import` logic