### PR TITLE
OJ-28347-api-scopes-investigation

### DIFF
--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -34,8 +34,21 @@ def load_and_dump(
     outdir: str,
     compress_output_files: bool,
     endpoint_git_instance_info: dict,
-    git_conn,
+    git_conn: GithubClient,
 ):
+    # Logic to help with debugging the scopes that clients have with their API key
+    try:
+        scopes: dict[str:str] = {
+            org: git_conn.get_scopes_of_api_token(org) for org in config.git_include_projects
+        }
+        print(
+            f'Attempting to run github ingest using an API key with the following scopes: {scopes}'
+        )
+    except Exception as e:
+        print(
+            f'Problem finding scopes. This should not affect your github agent processing. Error: {e}'
+        )
+
     write_file(
         outdir, 'bb_users', compress_output_files, get_users(git_conn, config.git_include_projects),
     )

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import logging
 import pytz
 import requests
-from requests import HTTPError
+from requests import HTTPError, Response
 from requests.utils import default_user_agent
 import time
 
@@ -27,6 +27,11 @@ class GithubClient:
                 'Authorization': f'token {token}',
             }
         )
+
+    def get_scopes_of_api_token(self, org):
+        url = f'{self.base_url}/orgs/{org}'
+        result: Response = self.get_raw_result(url)
+        return result.headers.get('X-OAuth-Scopes')
 
     def get_organization_by_name(self, org):
         url = f'{self.base_url}/orgs/{org}'

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -261,20 +261,16 @@ def _normalize_user(api_user) -> NormalizedUser:
     if not api_user:
         return None
 
-    # Backwards compatability paranoia.
-    # rest returns blank emails as null, vs ""
-    if api_user['email'] == '':
-        email = None
-    else:
-        email = api_user['email']
+    id = api_user.get('id')
+    name = api_user.get('name')
+    login = api_user.get('login')
+    email = api_user.get('email')
     # raw user, just have email (e.g. from a commit)
-    if not api_user.get('id', None):
-        return NormalizedUser(id=email, login=email, name=api_user['name'], email=email,)
+    if not id:
+        return NormalizedUser(id=email, login=email, name=name, email=email,)
 
     # API user, where github matched to a known account
-    return NormalizedUser(
-        id=api_user['id'], login=api_user['login'], name=api_user['name'], email=email
-    )
+    return NormalizedUser(id=id, login=login, name=name, email=email)
 
 
 def _normalize_project(api_org: dict, redact_names_and_urls: bool) -> NormalizedProject:


### PR DESCRIPTION
For GA:
Print out API scopes as a debugging tool in the logs

For `supports_graphql_endpoints` feature flag:
Add more null referencing when getting user data from commits
Re work the organization call to use the legacy method for fetching org data (doesn't need `read:org` scope)