### PR TITLE
OJ-28494-introduce-user-agent-header-to-gql-client

### DIFF
--- a/jf_agent/git/github_gql_utils.py
+++ b/jf_agent/git/github_gql_utils.py
@@ -2,6 +2,7 @@ import json
 from typing import Generator
 
 from requests import Session
+from requests.utils import default_user_agent
 
 from jf_agent.session import retry_session
 
@@ -21,7 +22,11 @@ def get_github_gql_session(token: str, verify: bool = True, session: Session = N
 
     session.verify = verify
     session.headers.update(
-        {'Authorization': f'token {token}', "Accept": "application/vnd.github+json",}
+        {
+            'Authorization': f'token {token}',
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': f'jellyfish/1.0 ({default_user_agent()})',
+        }
     )
     return session
 


### PR DESCRIPTION
Add the `User-Agent` header to the Graphql Github Client. This should resolve some issues that clients are seeing when fetching Pull Requests. We are getting `403` errors that I believe have to do with WAF rules when pulling data, and setting this header may get us around those problems