### PR TITLE
OJ-28550: add retry logic and reduce total API calls

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -321,7 +321,11 @@ def load_and_dump_git(
 
             if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
                 GithubGqlAdapter(
-                    config, outdir, compress_output_files, git_connection
+                    config,
+                    outdir,
+                    compress_output_files,
+                    git_connection,
+                    server_git_instance_info=endpoint_git_instance_info,
                 ).load_and_dump_git(endpoint_git_instance_info)
             else:
                 # using old func method, todo: refactor to use GitAdapter

--- a/jf_agent/git/github_gql_utils.py
+++ b/jf_agent/git/github_gql_utils.py
@@ -1,70 +1,9 @@
-import json
-from typing import Generator
-
-from requests import Session
-from requests.utils import default_user_agent
-
-from jf_agent.session import retry_session
+from datetime import datetime, timezone
 
 
-def get_github_gql_base_url(base_url: str):
-    if base_url and 'api/v3' in base_url:
-        # Github server clients provide an API with a trailing '/api/v3'
-        # replace this with the graphql endpoint
-        return base_url.replace('api/v3', 'api/graphql')
-    else:
-        return 'https://api.github.com/graphql'
+def github_gql_format_to_datetime(datetime_str: str) -> datetime:
+    return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
 
 
-def get_github_gql_session(token: str, verify: bool = True, session: Session = None):
-    if not session:
-        session = retry_session()
-
-    session.verify = verify
-    session.headers.update(
-        {
-            'Authorization': f'token {token}',
-            'Accept': 'application/vnd.github+json',
-            'User-Agent': f'jellyfish/1.0 ({default_user_agent()})',
-        }
-    )
-    return session
-
-
-def page_results(
-    query_body: str, path_to_page_info: str, session: Session, base_url: str, cursor: str = 'null'
-) -> Generator[dict, None, None]:
-
-    # TODO: Write generalized paginator
-    hasNextPage = True
-    while hasNextPage:
-        # Fetch results
-        result = get_raw_result(
-            query_body=(query_body % cursor), base_url=base_url, session=session
-        )
-
-        yield result
-
-        # Get relevant data and yield it
-        path_tokens = path_to_page_info.split('.')
-        for token in path_tokens:
-            result = result[token]
-
-        page_info = result['pageInfo']
-        # Need to grab the cursor and wrap it in quotes
-        _cursor = page_info['endCursor']
-        # If endCursor returns null (None), break out of loop
-        hasNextPage = page_info['hasNextPage'] and _cursor
-        cursor = f'"{_cursor}"'
-
-
-def get_raw_result(query_body: str, base_url: str, session: Session) -> dict:
-    response = session.post(url=base_url, json={'query': query_body})
-    response.raise_for_status()
-    json_str = response.content.decode()
-    json_data = json.loads(json_str)
-    if 'errors' in json_data:
-        raise Exception(
-            f'Exception encountered when trying to query: {query_body}. Error: {json_data["errors"]}'
-        )
-    return json_data
+def datetime_to_gql_str_format(_datetime: datetime) -> str:
+    return _datetime.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
### Description/Summary

Some of our extra large clients, that also implement threading, are running into secondary rate limiting when running git ingest with GQL. To get around this, I added retry logic to the `GithubGraphqlClient` class

I also made an effort to reduce the total number of calls made per git ingest. See the `get_repos` function, and how we are now caching whether or not the repo (and it's default branch) should pull from the API again

### Changes

- Move Graphql Client logic to `github_gql_client.py` and out of the `github_gql_utils.py` file
- Add in retry logic to the `GithubGqlAdapter.get_raw_result` function
- Reduce number of total API calls by caching the latest commit date and latest PR update time in memory

### Testing

To test, I modified my local environment to call the `api.github.com/graphql` endpoint against our own data (`orthogonal-networks`). To stress test throttling, I created an endless loop that calls the API concurrently 10 times with every loop. With every 20 or so loops I would hit the secondary rate limit. After I let it run for a while I hit the 'master' GQL rate limit
