### PR TITLE
OJ-28629-disable-top-level-comments-from-getting-pulled

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -290,6 +290,7 @@ def load_and_dump_git(
     outdir: str,
     compress_output_files: bool,
     git_connection,
+    jf_options: dict,
 ):
     # use the unique git instance agent key to collate files
     instance_slug = endpoint_git_instance_info['slug']
@@ -326,6 +327,7 @@ def load_and_dump_git(
                     compress_output_files,
                     git_connection,
                     server_git_instance_info=endpoint_git_instance_info,
+                    jf_options=jf_options,
                 ).load_and_dump_git(endpoint_git_instance_info)
             else:
                 # using old func method, todo: refactor to use GitAdapter

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -22,6 +22,7 @@ from jf_agent.git import (
 )
 from jf_agent.git.utils import log_and_print_request_error
 from jf_agent import diagnostics, agent_logging
+from jf_agent.main import JellyfishEndpointInfo
 from jf_agent.name_redactor import NameRedactor, sanitize_text
 from jf_agent.config_file_reader import GitConfig
 
@@ -46,11 +47,13 @@ class GithubGqlAdapter(GitAdapter):
         compress_output_files: bool,
         client: GithubGqlClient,
         server_git_instance_info: dict,
+        jf_options: dict,
     ):
         super().__init__(config, outdir, compress_output_files)
         self.client = client
 
         self.server_git_instance_info = server_git_instance_info
+        self.jf_options = jf_options
 
         self.repo_id_to_name_lookup: dict = {}
         self.repo_to_branch_is_quiescent_lookups: dict = {}
@@ -280,6 +283,9 @@ class GithubGqlAdapter(GitAdapter):
                         login=nrm_repo.project.login,
                         repo_name=self.repo_id_to_name_lookup[nrm_repo.id],
                         page_size=page_size,
+                        include_top_level_comments=self.jf_options.get(
+                            'get_all_issue_comments', False
+                        ),
                     )
 
                     for j, api_pr in enumerate(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -140,7 +140,7 @@ def main():
             agent_logging.log_and_print(
                 logger,
                 logging.WARNING,
-                msg=f"Could not validate client/org creds, moving on. Got {e}"
+                msg=f"Could not validate client/org creds, moving on. Got {e}",
             )
 
         print(f'Will write output files into {config.outdir}')
@@ -185,6 +185,7 @@ def main():
                     creds,
                     jellyfish_endpoint_info.jira_info,
                     jellyfish_endpoint_info.git_instance_info,
+                    jellyfish_endpoint_info.jf_options,
                 )
 
                 success = all(s['status'] == 'success' for s in download_data_status)
@@ -225,7 +226,9 @@ UserProvidedCreds = namedtuple(
     ],
 )
 
-JellyfishEndpointInfo = namedtuple('JellyfishEndpointInfo', ['jira_info', 'git_instance_info', 'jf_options'])
+JellyfishEndpointInfo = namedtuple(
+    'JellyfishEndpointInfo', ['jira_info', 'git_instance_info', 'jf_options']
+)
 
 required_jira_fields = [
     'issuekey',
@@ -327,7 +330,6 @@ def obtain_jellyfish_endpoint_info(config, creds):
     jira_info = agent_config_from_api.get('jira_info')
     git_instance_info = agent_config_from_api.get('git_instance_info')
     jf_options = agent_config_from_api.get("jf_options", {})
-
 
     # if no git info has returned from the endpoint, then an instance may not have been provisioned
     if len(config.git_configs) > 0 and not len(git_instance_info.values()):
@@ -478,7 +480,7 @@ def generate_manifests(config, creds, jellyfish_endpoint_info):
 
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
-def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info):
+def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info, jf_options):
     download_data_status = []
 
     if config.jira_url:
@@ -513,6 +515,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                     creds,
                     endpoint_git_instances_info,
                     len(config.git_configs) > 1,
+                    jf_options,
                 )
             )
 
@@ -520,7 +523,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 
 
 def _download_git_data(
-    git_config, config, creds, endpoint_git_instances_info, is_multi_git_config
+    git_config, config, creds, endpoint_git_instances_info, is_multi_git_config, jf_options
 ) -> dict:
     if is_multi_git_config:
         instance_slug = git_config.git_instance_slug
@@ -543,6 +546,7 @@ def _download_git_data(
         outdir=config.outdir,
         compress_output_files=config.compress_output_files,
         git_connection=git_connection,
+        jf_options=jf_options,
     )
 
 


### PR DESCRIPTION
Disable 'Top Level' comments on reviews, akak 'IssueComments' vs 'PullRequestReviewComments' in the GQL schema

This is inline with how we are doing comments in the 'legacy' github ingest, and better reflects how comments are tracked by our metrics