### PR TITLE
Oj 28632 reduce number of api calls for prs

### DIFF
--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -253,33 +253,17 @@ class GithubGqlAdapter(GitAdapter):
 
             with agent_logging.log_loop_iters(logger, 'repo for pull requests', i, 1):
                 try:
+                    # Check if we flagged this repo as quiescent
+                    if self.repo_has_quiescent_prs_lookup[nrm_repo.id]:
+                        continue
+
                     pull_since = pull_since_date_for_repo(
                         server_git_instance_info, nrm_repo.project.login, nrm_repo.id, 'prs'
                     )
 
-                    if self.repo_has_quiescent_prs_lookup[nrm_repo.id]:
-                        continue
-
-                    # This will return a page size between 0 and 25 (upper bound set by GithubGqlClient.MAX_PAGE_SIZE_FOR_PR_QUERY)
-                    def _get_pagesize_for_prs() -> int:
-                        api_prs_updated_at_only = self.client.get_pr_last_update_dates(
-                            login=nrm_repo.project.login,
-                            repo_name=self.repo_id_to_name_lookup[nrm_repo.id],
-                            page_size=GithubGqlClient.MAX_PAGE_SIZE_FOR_PR_QUERY,
-                        )
-                        updated_at_values = [
-                            1
-                            for api_pr in api_prs_updated_at_only
-                            if pull_since and parser.parse(api_pr['updatedAt']) >= pull_since
-                        ]
-                        return len(updated_at_values)
-
-                    page_size = _get_pagesize_for_prs()
-
                     api_prs = self.client.get_prs(
                         login=nrm_repo.project.login,
                         repo_name=self.repo_id_to_name_lookup[nrm_repo.id],
-                        page_size=page_size,
                     )
 
                     for j, api_pr in enumerate(
@@ -295,8 +279,10 @@ class GithubGqlAdapter(GitAdapter):
                                 updated_at = parser.parse(api_pr['updatedAt'])
 
                                 # PRs are ordered newest to oldest
-                                # if this is too old, we're done with this repo
-                                if pull_since and updated_at < pull_since:
+                                # if this is too old, we're done with this repo.
+                                # This is an INCLUSIVE check, to stop us from grabbing
+                                # the last PR that is our marker for pull_since!
+                                if pull_since and pull_since >= updated_at:
                                     break
 
                                 nrm_prs.append(

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -425,33 +425,6 @@ class GithubGqlClient:
             }}
         """
 
-    # Generally, if we are running agent ingest daily, there aren't that many PRs
-    # day to day (for most repos). This function takes this assumption into account and
-    # is a cheap test to see if we should make a big query against PRs.
-    # I.e. it helps with determining the page size for get_prs(),
-    # as well as IF we should call get PRs at all!
-    def get_pr_last_update_dates(
-        self, login: str, repo_name: str, page_size: int = MAX_PAGE_SIZE_FOR_PR_QUERY
-    ) -> list[dict]:
-        query_body = f"""{{
-            organization(login: "{login}") {{
-                repo: repository(name: "{repo_name}") {{
-                    prQuery: pullRequests(first: {page_size}, orderBy: {{direction: DESC, field: UPDATED_AT}}, after: null) {{
-                        {self.GITHUB_GQL_PAGE_INFO_BLOCK}
-                        prs: nodes {{
-                            ... on PullRequest {{
-                                updatedAt
-                            }}
-                        }}
-                    }}
-                }}
-            }}
-        }}
-        """
-        return self.get_raw_result(query_body=query_body)['data']['organization']['repo'][
-            'prQuery'
-        ]['prs']
-
     # PR query is HUGE, see above GITHUB_GQL_PR_* blocks for reused code
     # page_size is optimally variable. Most repos only have a 0 to a few PRs day to day,
     # so sometimes the optimal page_size is 0. Generally, we should never go over 25


### PR DESCRIPTION
This pull requests gets rid of the function that is used to determine the page size when pulling repos. This page size function was initially introduced to help us quickly see if there are no PRs that we need to pull, but it has since been replace by the `reop_has_quiescent_prs_lookup` look up table. Getting rid of this superfluous page size checking will help reduce our total number of calls and fly lower under the GQL API rate limiter