### PR TITLE
[OJ-28830] Fix snyk-monitor after change to pdm

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Install pdm
+        run: pip install --user pdm
+      - name: Convert pdm.lock to requirements.txt
+        run: pdm export -o requirements.txt 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/python@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --project-name=jf_agent --org=jellyfish-k9n
+          args: --project-name=jf_agent --org=jellyfish-k9n --file=requirements.txt

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -3,6 +3,9 @@ name: Snyk monitor workflow for tracking third-party dependencies
 on:
   push:
     branches: [ "master" ]
+  pull_request:
+    types: [ "opened", "synchronize", "reopened" ]
+
 jobs:
   snyk-monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -3,8 +3,6 @@ name: Snyk monitor workflow for tracking third-party dependencies
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    types: [ "opened", "synchronize", "reopened" ]
 
 jobs:
   snyk-monitor:


### PR DESCRIPTION
This PR fixes up our Snyk CI so that we can monitor jf_agent dependencies for vulnerabilities following the switch to pdm.

Evidence monitor now works:

<img width="1086" alt="Screenshot 2023-08-24 at 1 37 45 PM" src="https://github.com/Jellyfish-AI/jf_agent/assets/2743835/acc7005f-d6ed-464b-946e-cc0e11b46ae9">
