### PR TITLE
OJ-28908-rename-normalize-to-standardize

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -32,13 +32,13 @@ PROVIDERS = [GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER]
 
 '''
 
-    Normalized Structure
+    Standardized Structure
 
 '''
 
 
 @dataclass
-class NormalizedUser:
+class StandardizedUser:
     id: str
     name: str
     login: str
@@ -48,13 +48,13 @@ class NormalizedUser:
 
 
 @dataclass
-class NormalizedBranch:
+class StandardizedBranch:
     name: str
     sha: str
 
 
 @dataclass
-class NormalizedProject:
+class StandardizedProject:
     id: str
     name: str
     login: str
@@ -62,58 +62,58 @@ class NormalizedProject:
 
 
 @dataclass
-class NormalizedShortRepository:
+class StandardizedShortRepository:
     id: int
     name: str
     url: str
 
 
 @dataclass
-class NormalizedRepository:
+class StandardizedRepository:
     id: int
     name: str
     full_name: str
     url: str
     is_fork: bool
     default_branch_name: str
-    project: NormalizedProject
-    branches: List[NormalizedBranch]
+    project: StandardizedProject
+    branches: List[StandardizedBranch]
 
     def short(self):
-        # return the short form of Normalized Repository
-        return NormalizedShortRepository(id=self.id, name=self.name, url=self.url)
+        # return the short form of Standardized Repository
+        return StandardizedShortRepository(id=self.id, name=self.name, url=self.url)
 
 
 @dataclass
-class NormalizedCommit:
+class StandardizedRepository:
     hash: str
     url: str
     message: str
     commit_date: str
     author_date: str
-    author: NormalizedUser
-    repo: NormalizedShortRepository
+    author: StandardizedUser
+    repo: StandardizedShortRepository
     is_merge: bool
     branch_name: str = None
 
 
 @dataclass
-class NormalizedPullRequestComment:
-    user: NormalizedUser
+class StandardizedPullRequestComment:
+    user: StandardizedUser
     body: str
     created_at: str
     system_generated: bool = None
 
 
 @dataclass
-class NormalizedPullRequestReview:
-    user: NormalizedUser
+class StandardizedPullRequestComment:
+    user: StandardizedUser
     foreign_id: int
     review_state: str
 
 
 @dataclass
-class NormalizedPullRequest:
+class StandardizedPullRequest:
     id: any
     additions: int
     deletions: int
@@ -129,14 +129,14 @@ class NormalizedPullRequest:
     url: str
     base_branch: str
     head_branch: str
-    author: NormalizedUser
-    merged_by: NormalizedUser
-    commits: List[NormalizedCommit]
-    merge_commit: NormalizedCommit
-    comments: List[NormalizedPullRequestComment]
-    approvals: List[NormalizedPullRequestReview]
-    base_repo: NormalizedShortRepository
-    head_repo: NormalizedShortRepository
+    author: StandardizedUser
+    merged_by: StandardizedUser
+    commits: List[StandardizedRepository]
+    merge_commit: StandardizedRepository
+    comments: List[StandardizedPullRequestComment]
+    approvals: List[StandardizedPullRequestComment]
+    base_repo: StandardizedShortRepository
+    head_repo: StandardizedShortRepository
 
 
 class GitAdapter(ABC):
@@ -146,29 +146,31 @@ class GitAdapter(ABC):
         self.compress_output_files = compress_output_files
 
     @abstractmethod
-    def get_users(self) -> List[NormalizedUser]:
+    def get_users(self) -> List[StandardizedUser]:
         pass
 
     @abstractmethod
-    def get_projects(self) -> List[NormalizedProject]:
+    def get_projects(self) -> List[StandardizedProject]:
         pass
 
     @abstractmethod
-    def get_repos(self) -> List[NormalizedRepository]:
+    def get_repos(self) -> List[StandardizedRepository]:
         pass
 
     @abstractmethod
     def get_commits_for_included_branches(
         self, api_repos, server_git_instance_info
-    ) -> List[NormalizedCommit]:
+    ) -> List[StandardizedRepository]:
         pass
 
     @abstractmethod
-    def get_pull_requests(self, api_repos, server_git_instance_info) -> List[NormalizedPullRequest]:
+    def get_pull_requests(
+        self, api_repos, server_git_instance_info
+    ) -> List[StandardizedPullRequest]:
         pass
 
     def load_and_dump_git(self, endpoint_git_instance_info):
-        nrm_projects: List[NormalizedProject] = self.get_projects()
+        nrm_projects: List[StandardizedProject] = self.get_projects()
         write_file(self.outdir, 'bb_projects', self.compress_output_files, nrm_projects)
 
         write_file(
@@ -487,7 +489,7 @@ def get_nested_repos_from_git(git_connection, config: GitConfig):
                 not in set([r.lower() for r in config.git_exclude_repos])
             )
 
-        for api_project, _normalized_project_dict in projects:
+        for api_project, _standardized_project_dict in projects:
             project_repos = []
             project = git_connection.projects[api_project['key']]
             for repo in project.repos.list():

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -4,15 +4,15 @@ from tqdm import tqdm
 
 from jf_agent.git import (
     GithubClient,
-    NormalizedBranch,
-    NormalizedCommit,
-    NormalizedProject,
-    NormalizedPullRequest,
-    NormalizedPullRequestComment,
-    NormalizedPullRequestReview,
-    NormalizedRepository,
-    NormalizedShortRepository,
-    NormalizedUser,
+    StandardizedBranch,
+    StandardizedRepository,
+    StandardizedProject,
+    StandardizedPullRequest,
+    StandardizedPullRequestComment,
+    StandardizedPullRequestComment,
+    StandardizedRepository,
+    StandardizedShortRepository,
+    StandardizedUser,
 )
 from jf_agent.git import pull_since_date_for_repo
 from jf_agent.git.utils import get_matching_branches
@@ -132,12 +132,12 @@ def _normalize_user(user):
 
     # raw user, just have email (e.g. from a commit)
     if 'id' not in user:
-        return NormalizedUser(
+        return StandardizedUser(
             id=user['email'], login=user['email'], name=user['name'], email=user['email']
         )
 
     # API user, where github matched to a known account
-    return NormalizedUser(
+    return StandardizedUser(
         id=user['id'], login=user['login'], name=user['name'], email=user['email']
     )
 
@@ -153,7 +153,7 @@ def get_users(client: GithubClient, include_orgs):
 
 
 def _normalize_project(api_org, redact_names_and_urls):
-    return NormalizedProject(
+    return StandardizedProject(
         id=api_org['id'],
         login=api_org['login'],
         name=(
@@ -183,7 +183,7 @@ def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
 
 
 def _normalize_repo(client: GithubClient, org_name, repo, redact_names_and_urls):
-    return NormalizedRepository(
+    return StandardizedRepository(
         id=repo['id'],
         name=(
             repo['name']
@@ -202,7 +202,7 @@ def _normalize_repo(client: GithubClient, org_name, repo, redact_names_and_urls)
             client.get_json(repo['organization']['url']), redact_names_and_urls
         ),
         branches=[
-            NormalizedBranch(
+            StandardizedBranch(
                 name=(
                     b['name']
                     if not redact_names_and_urls
@@ -247,7 +247,7 @@ def _normalize_commit(commit, repo, branch_name, strip_text_content, redact_name
         {'name': commit['commit']['author']['name'], 'email': commit['commit']['author']['email']}
     )
 
-    return NormalizedCommit(
+    return StandardizedRepository(
         hash=commit['sha'],
         url=commit['html_url'] if not redact_names_and_urls else None,
         message=sanitize_text(commit['commit']['message'], strip_text_content),
@@ -263,7 +263,7 @@ def _normalize_commit(commit, repo, branch_name, strip_text_content, redact_name
 
 
 def _normalize_pr_repo(repo, redact_names_and_urls):
-    return NormalizedShortRepository(
+    return StandardizedShortRepository(
         id=repo['id'],
         name=(
             repo['name'] if not redact_names_and_urls else _repo_redactor.redact_name(repo['name'])
@@ -288,8 +288,8 @@ def get_commits_for_included_branches(
 
             # Determine branches to pull commits from for this repo. If no branches are explicitly
             # provided in a config, only pull from the repo's default branch.
-            # We are working with the github api object rather than a NormalizedRepository here,
-            # so we can not use get_branches_for_normalized_repo as we do in bitbucket_cloud_adapter and gitlab_adapter.
+            # We are working with the github api object rather than a StandardizedRepository here,
+            # so we can not use get_branches_for_standardized_repo as we do in bitbucket_cloud_adapter and gitlab_adapter.
             branches_to_process = [repo['default_branch']]
             additional_branch_patterns = included_branches.get(repo['name'])
 
@@ -342,7 +342,7 @@ def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names
 
 
 def _normalize_pr(client: GithubClient, pr, strip_text_content, redact_names_and_urls):
-    return NormalizedPullRequest(
+    return StandardizedPullRequest(
         id=pr['number'],
         additions=pr['additions'],
         deletions=pr['deletions'],
@@ -383,7 +383,7 @@ def _normalize_pr(client: GithubClient, pr, strip_text_content, redact_names_and
         ],
         merge_commit=_get_merge_commit(client, pr, strip_text_content, redact_names_and_urls),
         comments=[
-            NormalizedPullRequestComment(
+            StandardizedPullRequestComment(
                 user=_normalize_user(client.get_json(c['user']['url'])),
                 body=sanitize_text(c['body'], strip_text_content),
                 created_at=c['created_at'],
@@ -391,7 +391,7 @@ def _normalize_pr(client: GithubClient, pr, strip_text_content, redact_names_and
             for c in client.get_pr_comments(pr['base']['repo']['full_name'], pr['number'])
         ],
         approvals=[
-            NormalizedPullRequestReview(
+            StandardizedPullRequestComment(
                 user=_normalize_user(client.get_json(r['user']['url'])),
                 foreign_id=r['id'],
                 review_state=r['state'],

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
-def get_branches_for_normalized_repo(repo: Any, included_branches: dict):
+def get_branches_for_standardized_repo(repo: Any, included_branches: dict):
     branches_to_process = [repo.default_branch_name] if repo.default_branch_name else []
     additional_branches_for_repo = included_branches.get(repo.name)
     if additional_branches_for_repo:

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_users(
-        jira_connection, gdpr_active, quiet=False, required_email_domains=None, is_email_required=False
+    jira_connection, gdpr_active, quiet=False, required_email_domains=None, is_email_required=False
 ):
     if not quiet:
         print('downloading jira users... ', end='', flush=True)
@@ -42,7 +42,7 @@ def download_users(
             logger=logger,
             level=logging.INFO,
             msg=f'Page limit reached with {len(jira_users)} users, '
-                'falling back to search by letter method.',
+            'falling back to search by letter method.',
         )
         jira_users = _users_by_letter(jira_connection, gdpr_active)
 
@@ -153,7 +153,7 @@ def download_priorities(jira_connection):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_projects_and_versions(
-        jira_connection, include_projects, exclude_projects, include_categories, exclude_categories
+    jira_connection, include_projects, exclude_projects, include_categories, exclude_categories
 ):
     print('downloading jira projects... ', end='', flush=True)
 
@@ -194,9 +194,9 @@ def download_projects_and_versions(
             # but are not actually accessible.  I don't know wtf Black
             # is doing with this formatting, but whatever.
             if (
-                    e.status_code == 400
-                    and e.text
-                    == f"A value with ID '{project_id}' does not exist for the field 'project'."
+                e.status_code == 400
+                and e.text
+                == f"A value with ID '{project_id}' does not exist for the field 'project'."
             ):
                 agent_logging.log_and_print_error_or_warning(
                     logger, logging.ERROR, msg_args=[project_id], error_code=2112,
@@ -295,8 +295,12 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                         print(f"Couldn't get sprints for board {b['id']}.  Skipping...")
                     elif e.status_code == 400:
                         agent_logging.log_and_print_error_or_warning(
-                            logger, logging.ERROR, msg_args=[str(b), str(s_start_at), str(e)],
-                            error_code=2203, exc_info=True)
+                            logger,
+                            logging.ERROR,
+                            msg_args=[str(b), str(s_start_at), str(e)],
+                            error_code=2203,
+                            exc_info=True,
+                        )
                     else:
                         raise
 
@@ -349,8 +353,12 @@ def get_issues(jira_connection, issue_jql, start_at, batch_size):
     # copied logic from jellyfish direct connect
     # don't bail, just skip
     # khardy 2023-03-16
-    agent_logging.log_and_print_error_or_warning(logger, logging.WARNING, msg_args=
-    [f"{type(error)}", issue_jql, start_at, original_batch_size], error_code=3092)
+    agent_logging.log_and_print_error_or_warning(
+        logger,
+        logging.WARNING,
+        msg_args=[f"{type(error)}", issue_jql, start_at, original_batch_size],
+        error_code=3092,
+    )
 
     return {}
 
@@ -358,7 +366,7 @@ def get_issues(jira_connection, issue_jql, start_at, batch_size):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_all_issue_metadata(
-        jira_connection, all_project_ids, earliest_issue_dt, num_parallel_threads, issue_filter
+    jira_connection, all_project_ids, earliest_issue_dt, num_parallel_threads, issue_filter
 ) -> Dict[int, IssueMetadata]:
     print('downloading issue metadata... ', end='', flush=True)
 
@@ -382,7 +390,7 @@ def download_all_issue_metadata(
     else:
         # Over 20K characters - break up project_ids evenly based on num_pulls
         n = len(all_project_ids) // num_pulls
-        project_ids_array = [all_project_ids[i: i + n] for i in range(0, len(all_project_ids), n)]
+        project_ids_array = [all_project_ids[i : i + n] for i in range(0, len(all_project_ids), n)]
 
     all_issue_metadata: Dict[int, IssueMetadata] = {}
     for project_ids in project_ids_array:
@@ -446,8 +454,8 @@ def download_all_issue_metadata(
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def detect_issues_needing_sync(
-        issue_metadata_from_jira: Dict[int, IssueMetadata],
-        issue_metadata_from_jellyfish: Dict[int, IssueMetadata],
+    issue_metadata_from_jira: Dict[int, IssueMetadata],
+    issue_metadata_from_jellyfish: Dict[int, IssueMetadata],
 ):
     missing_issue_ids = set()
     already_up_to_date_issue_ids = set()
@@ -469,7 +477,7 @@ def detect_issues_needing_sync(
 
 
 def detect_issues_needing_re_download(
-        downloaded_issue_info, issue_metadata_from_jellyfish, issue_metadata_addl_from_jellyfish
+    downloaded_issue_info, issue_metadata_from_jellyfish, issue_metadata_addl_from_jellyfish
 ):
     issue_keys_changed = []
     for issue_id_str, issue_key in downloaded_issue_info:
@@ -500,12 +508,12 @@ def detect_issues_needing_re_download(
 
 
 def download_necessary_issues(
-        jira_connection,
-        issue_ids_to_download,
-        include_fields,
-        exclude_fields,
-        suggested_batch_size,
-        num_parallel_threads,
+    jira_connection,
+    issue_ids_to_download,
+    include_fields,
+    exclude_fields,
+    suggested_batch_size,
+    num_parallel_threads,
 ):
     '''
     A generator that yields batches of issues, until we've downloaded all of the issues given by
@@ -552,7 +560,7 @@ def download_necessary_issues(
 
     encountered_issue_ids = set()
     with tqdm(
-            desc='downloading jira issues', total=len(issue_ids_to_download), file=sys.stdout
+        desc='downloading jira issues', total=len(issue_ids_to_download), file=sys.stdout
     ) as prog_bar:
         # Read batches from queue
         finished = 0
@@ -619,7 +627,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
 
 @agent_logging.log_entry_exit(logger)
 def _download_jira_issues_segment(
-        thread_num, jira_connection, jira_issue_ids_segment, field_spec, batch_size, q
+    thread_num, jira_connection, jira_issue_ids_segment, field_spec, batch_size, q
 ):
     '''
     Each thread's target function.  Downloads 1/nth of the issues necessary, where
@@ -657,7 +665,11 @@ def _split_id_list(jira_issue_ids_segment: list):
 
     # same logic as `download_all_issue_metadata` for splitting lists of ids
     max_length = 20000
-    len_issue_ids_string = len(','.join(str(x) for x in jira_issue_ids_segment)) + len(jira_issue_ids_segment) * 2 + 200
+    len_issue_ids_string = (
+        len(','.join(str(x) for x in jira_issue_ids_segment))
+        + len(jira_issue_ids_segment) * 2
+        + 200
+    )
     num_pulls = len_issue_ids_string // max_length + 1
 
     issue_ids_array = []
@@ -666,13 +678,15 @@ def _split_id_list(jira_issue_ids_segment: list):
     else:
         # Over 20K characters - break up issue_ids evenly based on num_pulls
         n = len(jira_issue_ids_segment) // num_pulls
-        issue_ids_array = [jira_issue_ids_segment[i: i + n] for i in range(0, len(jira_issue_ids_segment), n)]
+        issue_ids_array = [
+            jira_issue_ids_segment[i : i + n] for i in range(0, len(jira_issue_ids_segment), n)
+        ]
 
     return issue_ids_array
 
 
 def _download_jira_issues_page(
-        jira_connection, jira_issue_ids_segment, field_spec, start_at, batch_size
+    jira_connection, jira_issue_ids_segment, field_spec, start_at, batch_size
 ):
     '''
     Returns a tuple: (issues_downloaded, num_issues_apparently_deleted)
@@ -684,8 +698,9 @@ def _download_jira_issues_page(
         issue_ids_array = _split_id_list(jira_issue_ids_segment)
     except Exception as e:
         agent_logging.log_and_print(
-            logger, logging.WARNING,
-            f"got {e} trying to split up ids for jql 2500 character limit, moving on with normal id list"
+            logger,
+            logging.WARNING,
+            f"got {e} trying to split up ids for jql 2500 character limit, moving on with normal id list",
         )
         issue_ids_array.append(jira_issue_ids_segment)
 
@@ -717,7 +732,11 @@ def _download_jira_issues_page(
 
                 batch_size = int(batch_size / 2)
                 agent_logging.log_and_print_error_or_warning(
-                    logger, logging.WARNING, msg_args=[e, batch_size], error_code=3052, exc_info=True,
+                    logger,
+                    logging.WARNING,
+                    msg_args=[e, batch_size],
+                    error_code=3052,
+                    exc_info=True,
                 )
                 if batch_size == 0:
                     if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
@@ -834,7 +853,7 @@ def download_statuses(jira_connection):
 def _is_option_field(field_meta):
     schema = field_meta['schema']
     is_option_field = schema['type'] == 'option' or (
-            'items' in schema and schema['items'] == 'option'
+        'items' in schema and schema['items'] == 'option'
     )
     return is_option_field
 
@@ -877,37 +896,37 @@ def _users_by_letter(jira_connection, gdpr_active):
             {
                 _jira_user_key(u): u
                 for u in _search_users(
-                jira_connection,
-                gdpr_active,
-                query=f'{letter}.',
-                include_inactive=True,
-                include_active=False,
-            )
+                    jira_connection,
+                    gdpr_active,
+                    query=f'{letter}.',
+                    include_inactive=True,
+                    include_active=False,
+                )
             }
         )
         jira_users.update(
             {
                 _jira_user_key(u): u
                 for u in _search_users(
-                jira_connection,
-                gdpr_active,
-                query=f'{letter}.',
-                include_inactive=False,
-                include_active=True,
-            )
+                    jira_connection,
+                    gdpr_active,
+                    query=f'{letter}.',
+                    include_inactive=False,
+                    include_active=True,
+                )
             }
         )
     return list(jira_users.values())
 
 
 def _search_users(
-        jira_connection,
-        gdpr_active,
-        query,
-        start_at=0,
-        max_results=1000,
-        include_active=True,
-        include_inactive=False,
+    jira_connection,
+    gdpr_active,
+    query,
+    start_at=0,
+    max_results=1000,
+    include_active=True,
+    include_inactive=False,
 ):
     if query is None:
         # use new endpoint that doesn't take a query.  This may not exist in some instances.
@@ -1074,9 +1093,9 @@ def _remove_mismatched_repos(repos_found_by_jira, git_repos, config):
 
     git_repo_names = []
     git_repo_urls = []
-    for normalized_repo in git_repos:
-        git_repo_names.extend([normalized_repo.get('full_name'), normalized_repo.get('name')])
-        git_repo_urls.append(normalized_repo.get('url'))
+    for standardized_repo in git_repos:
+        git_repo_names.extend([standardized_repo.get('full_name'), standardized_repo.get('name')])
+        git_repo_urls.append(standardized_repo.get('url'))
 
     ignore_repos = []
     for repo in list(repos_found_by_jira.values()):

--- a/tests/test_bitbucket_cloud_adapter.py
+++ b/tests/test_bitbucket_cloud_adapter.py
@@ -5,7 +5,7 @@ from dateutil import parser
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from jf_agent.git import NormalizedShortRepository
+from jf_agent.git import StandardizedShortRepository
 from jf_agent.git.bitbucket_cloud_adapter import BitbucketCloudAdapter
 
 TEST_INPUT_FILE_PATH = 'tests/test_data/bitbucket_cloud/'
@@ -69,14 +69,14 @@ class TestBitbucketCloudAdapter(TestCase):
         test_repos = _get_test_data('test_repos.json')
         test_branches = _get_test_data('test_branches.json')
 
-        mock_normalized_project = MagicMock()
-        mock_normalized_projects = [mock_normalized_project]
+        mock_standardized_project = MagicMock()
+        mock_standardized_projects = [mock_standardized_project]
 
         self.mock_client.get_all_repos.return_value = test_repos
         self.mock_client.get_branches.return_value = test_branches
 
         # Act
-        resulting_repos = self.adapter.get_repos(mock_normalized_projects)
+        resulting_repos = self.adapter.get_repos(mock_standardized_projects)
 
         # Assert
         self.assertEqual(
@@ -110,7 +110,7 @@ class TestBitbucketCloudAdapter(TestCase):
         )
         self.assertEqual(
             resulting_repo.project,
-            mock_normalized_project,
+            mock_standardized_project,
             "Resulting repo project does not match input",
         )
 
@@ -136,11 +136,13 @@ class TestBitbucketCloudAdapter(TestCase):
         # Arrange
         test_commits = _get_test_data('test_commits.json')
 
-        mock_normalized_repo = MagicMock()
-        mock_normalized_repo.default_branch_name = 'default_branch_name'
-        test_short_repo = NormalizedShortRepository(id='test_id', name='test_name', url='test_url')
-        mock_normalized_repo.short.return_value = test_short_repo
-        mock_normalized_repos = [mock_normalized_repo]
+        mock_standardized_repo = MagicMock()
+        mock_standardized_repo.default_branch_name = 'default_branch_name'
+        test_short_repo = StandardizedShortRepository(
+            id='test_id', name='test_name', url='test_url'
+        )
+        mock_standardized_repo.short.return_value = test_short_repo
+        mock_standardized_repos = [mock_standardized_repo]
 
         self.mock_client.get_commits.return_value = test_commits
 
@@ -150,7 +152,7 @@ class TestBitbucketCloudAdapter(TestCase):
         # Act
         resulting_commits = list(
             self.adapter.get_commits_for_included_branches(
-                mock_normalized_repos, {'test_repo': ['test_branch_name']}, test_git_instance_info
+                mock_standardized_repos, {'test_repo': ['test_branch_name']}, test_git_instance_info
             )
         )
 
@@ -210,9 +212,9 @@ class TestBitbucketCloudAdapter(TestCase):
         test_prs = _get_test_data('test_prs.json')
         test_commits = _get_test_data('test_commits.json')
 
-        mock_normalized_repo = MagicMock()
-        mock_normalized_repo.default_branch_name = 'default_branch_name'
-        mock_normalized_repos = [mock_normalized_repo]
+        mock_standardized_repo = MagicMock()
+        mock_standardized_repo.default_branch_name = 'default_branch_name'
+        mock_standardized_repos = [mock_standardized_repo]
 
         self.mock_client.get_pullrequests.return_value = test_prs
         self.mock_client.pr_diff.return_value = ""
@@ -226,7 +228,7 @@ class TestBitbucketCloudAdapter(TestCase):
 
         # Act
         resulting_prs = list(
-            self.adapter.get_pull_requests(mock_normalized_repos, test_git_instance_info)
+            self.adapter.get_pull_requests(mock_standardized_repos, test_git_instance_info)
         )
 
         # Assert

--- a/tests/test_bitbucket_server.py
+++ b/tests/test_bitbucket_server.py
@@ -54,7 +54,7 @@ class TestBitbucketServer(TestCase):
             len(result_projects), len(test_projects), f"project size should be {len(test_projects)}"
         )
 
-        # get_projects returns a list of (api_object, normalized_project). Use the normalized version for verification.
+        # get_projects returns a list of (api_object, standardized_project). Use the standardized version for verification.
         result_project = result_projects[0][1]
         input_project = test_projects[0]
         self.assertEqual(
@@ -110,7 +110,7 @@ class TestBitbucketServer(TestCase):
             result_repos[0][0], mock_repo, "resulting tuple should have input mock as first element"
         )
 
-        # get_repos returns a list of (api_object, normalized_project). Use the normalized version for verification.
+        # get_repos returns a list of (api_object, standardized_project). Use the standardized version for verification.
         result_repo = result_repos[0][1]
         input_repo = test_repos[0]
         self.assertEqual(
@@ -243,12 +243,12 @@ class TestBitbucketServer(TestCase):
             self.assertNotIn(
                 'emailAddress',
                 result_commit['author'].keys(),
-                "author field of commit was not normalized; 'emailAddress' not renamed to 'email'",
+                "author field of commit was not standardized; 'emailAddress' not renamed to 'email'",
             )
             self.assertIn(
                 'login',
                 result_commit['author'].keys(),
-                "author field of commit was not normalized; 'login' not present as username key",
+                "author field of commit was not standardized; 'login' not present as username key",
             )
 
     def test_get_pull_requests(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -45,7 +45,7 @@ class TestGithub(TestCase):
         # Assert
         self.assertEqual(len(result_projects), 1, "project size should be 1")
 
-        # get_projects returns a list of (api_object, normalized_project). Use the normalized version for verification.
+        # get_projects returns a list of (api_object, standardized_project). Use the standardized version for verification.
         result_project = result_projects[0]
         input_project = test_projects[0]
         self.assertEqual(
@@ -84,7 +84,7 @@ class TestGithub(TestCase):
         # Assert
         self.assertEqual(len(result_repos), 1, "repo size should be 1")
 
-        # get_repos returns a list of (api_object, normalized_project). Use the normalized version for verification.
+        # get_repos returns a list of (api_object, standardized_project). Use the standardized version for verification.
         result_repo = result_repos[0][1]
         test_repo = test_repos[0]
         self.assertEqual(result_repo.id, test_repo['id'], "resulting repo id does not match input")

--- a/tests/test_gitlab_adapter.py
+++ b/tests/test_gitlab_adapter.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from jf_agent.git import NormalizedShortRepository
+from jf_agent.git import StandardizedShortRepository
 from jf_agent.git.gitlab_adapter import GitLabAdapter
 
 TEST_INPUT_FILE_PATH = 'tests/test_data/gitlab/'
@@ -232,7 +232,7 @@ class TestGitLabAdapter(TestCase):
         mock_repo.name = "test_repo_name"
         mock_repo.default_branch_name = mock_repo_default_branch
 
-        mock_short_repo = NormalizedShortRepository(
+        mock_short_repo = StandardizedShortRepository(
             id=1, name="test_repo_name", url="test_repo_url"
         )
         mock_repo.short.return_value = mock_short_repo


### PR DESCRIPTION
This PR deals with some clean up we need to do before unifying data classes between Agent and DC

In our internal code base, the `Normalized*` classes are called `Standardized*` classes. They function nearly the same, but the misaligned names will make the PR to unify them very messy. This initial PR is a low risk PR that renames a lot of variable and class names to scrub out the `Normalized*` data classes and replace them with `Standardized*` classes