### PR TITLE
OJ-29421-normalize-agent-logging

### DIFF
--- a/jf_agent/__init__.py
+++ b/jf_agent/__init__.py
@@ -48,7 +48,7 @@ def download_and_write_streaming(
     generator_func_args,
     item_id_dict_key,
     addl_info_dict_key=None,
-    batch_size=None   # batch size implies that we are being given a list of list (e.g. jira issue, nothing else)
+    batch_size=None,  # batch size implies that we are being given a list of list (e.g. jira issue, nothing else)
 ):
     batch_num = 0
     item_infos = set()
@@ -79,7 +79,7 @@ def download_and_write_streaming(
                             _get_item_by_key(item, addl_info_dict_key),
                         )
                     )
-            logger.info(f'File: {filepath}, Size: {round(outfile.tell() / 1000000, 1)}MB')
+            logger.debug(f'File: {filepath}, Size: {round(outfile.tell() / 1000000, 1)}MB')
 
         outfile.close()
         batch_num += 1

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -29,7 +29,7 @@ def _emit_helper(_self: logging.Handler, record: logging.LogRecord, always_use_n
         special_code = '[!n]'
 
         if _self.stream is None:
-            if _self.mode != 'w' or not _self._closed:
+            if isinstance(_self, logging.FileHandler) and (_self.mode != 'w' or not _self._closed):
                 _self.stream = _self._open()
 
         msg = _self.format(record)

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -1,50 +1,86 @@
-from datetime import datetime
 from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
-import traceback
+import sys
 
 '''
 Guidance on logging/printing in the agent:
 
-stdout (e.g., print() output) is for the customer/operator; it should include
- - info on run progress: tqdm output, etc.
- - errors/warnings encountered
+stdout (e.g., print() output) is for the customer/operator; it should be used when
+we have customer sensitive data that they do not want to submit to jellyfish (i.e. passwords)
 
-logger output is for Jellyfish; it should include
+logger output is for Jellyfish and customers; it should include:
  - function entry/exit timings
  - loop iteration timings/liveness indicators
  - errors/warnings encountered
 
 logger output is submitted to Jellyfish, so should only contain non-sensitive data:
 e.g., function names, iteration counts
-
-Since we generally want errors/warnings to go to BOTH stdout and the logger, we
-should generally use log_and_print() instead of logger.whatever().
 '''
 
 LOG_FILE_NAME = 'jf_agent.log'
 
+# For styling in log files, I think it's best to always use new lines even when we use
+# the special character to ignore them. Leverage always_use_newlines for this
+def _emit_helper(_self: logging.Handler, record: logging.LogRecord, always_use_newlines=False):
+    special_code = '[!n]'
+
+    msg = _self.format(record)
+    if special_code in msg:
+        msg = msg.replace('[!n]', '')
+        if always_use_newlines:
+            msg += '\n'
+    else:
+        msg += '\n'
+
+    _self.stream.write(msg)
+    _self.flush()
+
+
+class CustomStreamHandler(logging.StreamHandler):
+    """Handler that controls the writing of the newline character"""
+
+    def emit(self, record) -> None:
+        _emit_helper(self, record)
+
+
+class CustomFileHandler(logging.FileHandler):
+    """Handler that controls the writing of the newline character"""
+
+    def emit(self, record) -> None:
+        _emit_helper(self, record, always_use_newlines=True)
+
 
 def configure(outdir):
+
+    # Send log messages to std using a stream handler
+    # All INFO level and above errors will go to STDOUT
+    stdout_handler = CustomStreamHandler(stream=sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(fmt='%(message)s'))
+    stdout_handler.setLevel(logging.INFO)
+
+    # Send log messages to logger, using more structured format
+    # All DEBUG level and above errors will go to the log file
+    logfile_handler = CustomFileHandler(os.path.join(outdir, LOG_FILE_NAME), mode='a')
+    logfile_handler.setFormatter(
+        logging.Formatter(fmt='%(asctime)s %(threadName)s %(levelname)s %(name)s %(message)s')
+    )
+    logfile_handler.setLevel(logging.DEBUG)
+
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s %(threadName)s %(levelname)s %(name)s %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        filename=os.path.join(outdir, LOG_FILE_NAME),
-        filemode='a',  # May be adding to a file created in a previous run
+        level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S', handlers=[logfile_handler, stdout_handler]
     )
 
 
-def log_entry_exit(logger, *args, **kwargs):
+def log_entry_exit(logger: logging.Logger, *args, **kwargs):
     def actual_decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             func_name = func.__name__
-            logger.info(f'{func_name}: Starting')
+            logger.debug(f'{func_name}: Starting')
             ret = func(*args, **kwargs)
-            logger.info(f'{func_name}: Ending')
+            logger.debug(f'{func_name}: Ending')
             return ret
 
         return wrapper
@@ -58,10 +94,10 @@ def log_loop_iters(
 ):
     if (this_iternum - 1) % log_every_n_iters == 0:
         if log_entry:
-            logger.info(f'Loop "{loop_desc}", iter {this_iternum}: Starting')
+            logger.debug(f'Loop "{loop_desc}", iter {this_iternum}: Starting')
         yield
         if log_exit:
-            logger.info(f'Loop "{loop_desc}", iter {this_iternum}: Ending')
+            logger.debug(f'Loop "{loop_desc}", iter {this_iternum}: Ending')
     else:
         yield
 
@@ -125,13 +161,8 @@ ERROR_MESSAGES = {
 }
 
 
-def log_and_print(logger, level, msg):
-    '''
-    For an info-level message that should be sent to the logger, and also written
-    to stdout (for user visibility)
-    '''
-    logger.log(level, msg)
-    print(msg, flush=True)
+def generate_standard_error_msg(error_code, msg_args=[]):
+    return f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}'
 
 
 def log_and_print_error_or_warning(logger, level, error_code, msg_args=[], exc_info=False):
@@ -140,14 +171,12 @@ def log_and_print_error_or_warning(logger, level, error_code, msg_args=[], exc_i
     to stdout (for user visibility)
     '''
     assert level >= logging.WARNING
-    msg = f'[{error_code}] {ERROR_MESSAGES.get(error_code).format(*msg_args)}'
-    logger.log(level, msg, exc_info=exc_info)
-    print(msg, flush=True)
-    if exc_info:
-        print(traceback.format_exc())
-
-
-# TODO(asm,2021-08-12): This is sloppy, we should figure out a way to
-# get Python's native logging to behave the way we want.
-def verbose(msg):
-    print(f"[{datetime.now().isoformat()}] {msg}")
+    msg = generate_standard_error_msg(error_code=error_code, msg_args=msg_args)
+    if level == logging.WARNING or level == logging.WARN:
+        logger.warn(msg=msg, exc_info=exc_info)
+    elif level == logging.ERROR:
+        logger.error(msg=msg, exc_info=exc_info)
+    elif level == logging.CRITICAL:
+        logger.critical(msg=msg, exc_info=exc_info)
+    else:
+        logger.info(msg=msg, exc_info=exc_info)

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -154,13 +154,13 @@ def obtain_config(args) -> ValidatedConfig:
     if jira_include_fields:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARNING, msg_args=[list(missing_required_fields)], error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARNING, msg_args=[list(excluded_required_fields)], error_code=2142,
             )
 

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -46,20 +46,14 @@ def create_manifests(
         try:
             # If the git config doesn't have a git instance, do not generate a manifest
             if not instance_slug:
-                agent_logging.log_and_print(
-                    logger,
-                    logging.WARNING,
-                    f'Git instance for company {company_slug} was detected as NONE. The manifest for this instance will not be processed or uploaded. This should NOT affect your agent upload',
+                logger.debug(
+                    f'Git instance for company {company_slug} was detected as NONE. The manifest for this instance will not be processed or uploaded',
                 )
                 continue
 
-            agent_logging.log_and_print(
-                logger, logging.INFO, f'Generating manifest for instance {instance_slug}'
-            )
+            logger.info(f'Generating manifest for instance {instance_slug}')
             for org in git_config.git_include_projects:
-                agent_logging.log_and_print(
-                    logger,
-                    logging.INFO,
+                logger.info(
                     f'Processing git instance {instance_slug} for company {company_slug} under github org {org}',
                 )
                 manifest_adapter: ManifestAdapter = get_manifest_adapter(
@@ -75,9 +69,7 @@ def create_manifests(
 
                 # Process Repos
                 repos_count = manifest_adapter.get_repos_count()
-                agent_logging.log_and_print(
-                    logger,
-                    logging.INFO,
+                logger.info(
                     f'Processing {repos_count} repos {"including Branches and Pull Request" if verbose else ""}',
                 )
                 for repo_manifest in manifest_adapter.get_all_repo_data():
@@ -103,15 +95,15 @@ def create_manifests(
 
                     repo_manifests.append(repo_manifest)
 
-                agent_logging.log_and_print(logger, logging.INFO, 'Done processing Repos')
+                logger.info('Done processing Repos')
 
                 # Process Users
                 users_count = manifest_adapter.get_users_count()
-                agent_logging.log_and_print(logger, logging.INFO, f'Processing {users_count} users')
+                logger.info(f'Processing {users_count} users')
                 user_manifests += [
                     user_manifest for user_manifest in manifest_adapter.get_all_user_data()
                 ]
-                agent_logging.log_and_print(logger, logging.INFO, 'Done processing Users')
+                logger.info('Done processing Users')
 
                 manifests.append(
                     GitDataManifest(
@@ -126,16 +118,12 @@ def create_manifests(
                     )
                 )
         except UnsupportedGitProvider as e:
-            agent_logging.log_and_print(
-                logger,
-                logging.WARNING,
+            logger.warning(
                 'Unsupported Git Provider exception encountered. '
                 f'This shouldn\'t affect your agent upload. Error: {e}',
             )
         except Exception as e:
-            agent_logging.log_and_print(
-                logger,
-                logging.WARNING,
+            logger.warning(
                 'An exception happened when creating manifest. This shouldn\'t affect your agent upload. '
                 f'Exception: {e}',
             )

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -1,6 +1,4 @@
 import logging
-import traceback
-from jf_agent import agent_logging
 from jf_agent.config_file_reader import GitConfig
 
 from jf_agent.data_manifests.git.adapters.manifest_adapter import ManifestAdapter

--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 import json
-
+import logging
 from dataclasses import dataclass
 from functools import partial
 import traceback
@@ -9,6 +9,8 @@ from jf_agent import agent_logging
 from jf_agent.jf_jira import get_basic_jira_connection
 from jf_agent.jf_jira.jira_download import download_users
 from jira import JIRAError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -155,10 +157,11 @@ class JiraCloudManifestAdapter:
         except Exception as e:
             # This is unexpected behavior and it should never happen, log the error
             # before returning
-            agent_logging.log_and_print(
+            logger.debug(
                 'Unusual exception encountered when testing auth. '
                 'This should not affect agent uploading. '
-                f'JIRAError was expected but the following error was raised: {e}'
+                f'JIRAError was expected but the following error was raised: {e}',
+                exc_info=True,
             )
             return False
 

--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from functools import partial
 import traceback
 from typing import Callable, Generator
-from jf_agent import agent_logging
 from jf_agent.jf_jira import get_basic_jira_connection
 from jf_agent.jf_jira.jira_download import download_users
 from jira import JIRAError

--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -1,7 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
-import traceback
-from jf_agent import agent_logging
 
 from jf_agent.data_manifests.jira.adapter import JiraCloudManifestAdapter
 

--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -27,7 +27,7 @@ def create_manifest(company_slug, config, creds):
     )
 
     def _agent_log(msg: str):
-        agent_logging.log_and_print(logger, logging.INFO, msg)
+        logger.info(msg)
 
     project_data_dicts = manifest_adapter.get_project_data_dicts()
 

--- a/jf_agent/data_manifests/manifest.py
+++ b/jf_agent/data_manifests/manifest.py
@@ -98,16 +98,14 @@ class Manifest(ABC):
     ) -> None:
         file_name = file_name or f'./{self.get_unique_key()}.json'
         if verbose_logging:
-            agent_logging.log_and_print(logger, logging.INFO, f'Writing file data to {file_name}')
+            logger.info(f'Writing file data to {file_name}')
         with open(file_name, 'w') as f:
             f.write(self.to_json_str())
 
     def upload_to_s3(self, jellyfish_api_base: str, jellyfish_api_token: str) -> None:
         headers = {'Jellyfish-API-Token': jellyfish_api_token, 'content-encoding': 'gzip'}
 
-        agent_logging.log_and_print(
-            logger, logging.INFO, f'Attempting to upload {self.get_unique_key()} manifest to s3...'
-        )
+        logger.info(f'Attempting to upload {self.get_unique_key()} manifest to s3...')
 
         r = requests.post(
             f'{jellyfish_api_base}/endpoints/agent/upload_manifest',
@@ -116,6 +114,4 @@ class Manifest(ABC):
         )
         r.raise_for_status()
 
-        agent_logging.log_and_print(
-            logger, logging.INFO, f'Successfully uploaded {self.get_unique_key()} manifest to s3!'
-        )
+        logger.info(f'Successfully uploaded {self.get_unique_key()} manifest to s3!')

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -271,7 +271,7 @@ def get_git_client(
             )
 
     except Exception as e:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger,
             logging.ERROR,
             msg_args=[config.git_provider, e],
@@ -353,7 +353,7 @@ def load_and_dump_git(
             raise ValueError(f'unsupported git provider {config.git_provider}')
 
     except Exception as e:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger,
             logging.ERROR,
             msg_args=[config.git_provider, e],

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -56,12 +56,12 @@ class BitbucketCloudAdapter(GitAdapter):
     def get_projects(self) -> List[StandardizedProject]:
         # Bitbucket Cloud API doesn't have a way to fetch all top-level projects;
         # instead, need to configure the agent with a specific set of projects to pull
-        logger.info('downloading bitbucket projects... [!n]')
+        logger.info('downloading bitbucket projects...')
         projects = [
             _standardize_project(p, self.config.git_redact_names_and_urls)
             for p in self.config.git_include_projects
         ]
-        logger.info('✓')
+        logger.info('Done downloading Projects!')
 
         return projects
 
@@ -70,7 +70,7 @@ class BitbucketCloudAdapter(GitAdapter):
     def get_repos(
         self, standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
-        logger.info('downloading bitbucket repos... [!n]')
+        logger.info('downloading bitbucket repos...')
 
         repos = []
         for p in standardized_projects:
@@ -144,7 +144,7 @@ class BitbucketCloudAdapter(GitAdapter):
                     _standardize_repo(api_repo, branches, p, self.config.git_redact_names_and_urls)
                 )
 
-        logger.info('✓')
+        logger.info('Done downloading repos!')
         if not repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Bitbucket and check your configuration of repos to pull.'
@@ -160,7 +160,7 @@ class BitbucketCloudAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        logger.info('downloading bitbucket commits on included branches... [!n]')
+        logger.info('downloading bitbucket commits on included branches...')
         for i, repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
@@ -192,14 +192,14 @@ class BitbucketCloudAdapter(GitAdapter):
                             if commit.commit_date < pull_since:
                                 break
 
-        logger.info('✓')
+        logger.info('Done downloading commits on included branches!')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        logger.info('downloading bitbucket prs... [!n]')
+        logger.info('downloading bitbucket prs...')
         for i, repo in enumerate(
             tqdm(standardized_repos, desc='downloading prs for repos', unit='repos'), start=1
         ):
@@ -263,7 +263,7 @@ class BitbucketCloudAdapter(GitAdapter):
                         logger, logging.ERROR, msg_args=[repo.id], error_code=3021, exc_info=True,
                     )
 
-        logger.info('✓')
+        logger.info('Done downloading PRs!')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -226,7 +226,7 @@ class BitbucketCloudAdapter(GitAdapter):
                                 or 'repository' not in api_pr['destination']
                                 or not api_pr['destination']['repository']
                             ):
-                                agent_logging.log_and_print_error_or_warning(
+                                agent_logging.log_standard_error(
                                     logger, logging.WARN, msg_args=[api_pr['id']], error_code=3030
                                 )
                                 continue
@@ -249,7 +249,7 @@ class BitbucketCloudAdapter(GitAdapter):
 
                         except Exception:
                             # if something happens when normalizing a PR, just keep going with the rest
-                            agent_logging.log_and_print_error_or_warning(
+                            agent_logging.log_standard_error(
                                 logger,
                                 logging.ERROR,
                                 msg_args=[api_pr["id"], repo.id],
@@ -259,7 +259,7 @@ class BitbucketCloudAdapter(GitAdapter):
 
                 except Exception:
                     # if something happens when pulling PRs for a repo, just keep going.
-                    agent_logging.log_and_print_error_or_warning(
+                    agent_logging.log_standard_error(
                         logger, logging.ERROR, msg_args=[repo.id], error_code=3021, exc_info=True,
                     )
 
@@ -389,7 +389,7 @@ def _standardize_pr(
         diff_str = client.pr_diff(repo.project.id, repo.id, api_pr['id'])
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3031,
             )
     except requests.exceptions.RetryError:
@@ -403,7 +403,7 @@ def _standardize_pr(
             pass
         elif e.response.status_code == 401:
             # Server threw a 401 on the request for the diff; not sure why this would be, but it seems rare
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3041,
             )
         else:
@@ -411,7 +411,7 @@ def _standardize_pr(
             raise
     except UnicodeDecodeError:
         # Occasional diffs seem to be invalid UTF-8
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3051,
         )
 

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -56,12 +56,12 @@ class BitbucketCloudAdapter(GitAdapter):
     def get_projects(self) -> List[StandardizedProject]:
         # Bitbucket Cloud API doesn't have a way to fetch all top-level projects;
         # instead, need to configure the agent with a specific set of projects to pull
-        logger.info('downloading bitbucket projects...')
+        logger.info('downloading bitbucket projects... [!n]')
         projects = [
             _standardize_project(p, self.config.git_redact_names_and_urls)
             for p in self.config.git_include_projects
         ]
-        logger.info('Done downloading Projects!')
+        logger.info('✓')
 
         return projects
 
@@ -227,7 +227,10 @@ class BitbucketCloudAdapter(GitAdapter):
                                 or not api_pr['destination']['repository']
                             ):
                                 agent_logging.log_standard_error(
-                                    logger, logging.WARN, msg_args=[api_pr['id']], error_code=3030
+                                    logger,
+                                    logging.WARNING,
+                                    msg_args=[api_pr['id']],
+                                    error_code=3030,
                                 )
                                 continue
 
@@ -390,7 +393,7 @@ def _standardize_pr(
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
             agent_logging.log_standard_error(
-                logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3031,
+                logger, logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3031,
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -404,7 +407,7 @@ def _standardize_pr(
         elif e.response.status_code == 401:
             # Server threw a 401 on the request for the diff; not sure why this would be, but it seems rare
             agent_logging.log_standard_error(
-                logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3041,
+                logger, logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3041,
             )
         else:
             # Some other HTTP error happened; Re-raise
@@ -412,7 +415,7 @@ def _standardize_pr(
     except UnicodeDecodeError:
         # Occasional diffs seem to be invalid UTF-8
         agent_logging.log_standard_error(
-            logger, logging.WARN, msg_args=[api_pr["id"], repo.id], error_code=3051,
+            logger, logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3051,
         )
 
     # Comments

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -117,7 +117,7 @@ class BitbucketCloudClient:
                 if e.response.status_code == 429:
                     if hasattr(e.response, 'headers') and 'Retry-After' in e.response.headers:
                         wait_time = int(e.response.headers["Retry-After"]) + wait_extra
-                        logger.log(f'Retrying in {wait_time} seconds...')
+                        logger.info(f'Retrying in {wait_time} seconds...')
                         time.sleep(wait_time)
                         continue
                     # rate-limited in spite of trying to throttle
@@ -145,7 +145,8 @@ class BitbucketCloudClient:
                     page = self.get_json(url, rate_limit_realm)
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
-                        logger.log(f'Caught a 404 for {url} - ignoring',)
+                        # URLs are potentially sensitive data, so print instead of log!
+                        print(f'Caught a 404 for {url} - ignoring',)
                         return
                     raise
 

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -117,9 +117,7 @@ class BitbucketCloudClient:
                 if e.response.status_code == 429:
                     if hasattr(e.response, 'headers') and 'Retry-After' in e.response.headers:
                         wait_time = int(e.response.headers["Retry-After"]) + wait_extra
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, f'Retrying in {wait_time} seconds...'
-                        )
+                        logger.log(f'Retrying in {wait_time} seconds...')
                         time.sleep(wait_time)
                         continue
                     # rate-limited in spite of trying to throttle
@@ -151,9 +149,7 @@ class BitbucketCloudClient:
                     page = self.get_json(url, rate_limit_realm)
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, f'Caught a 404 for {url} - ignoring',
-                        )
+                        logger.log(f'Caught a 404 for {url} - ignoring',)
                         return
                     raise
 

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -126,15 +126,11 @@ class BitbucketCloudClient:
                     # so just try in 30 seconds, unless it's already
                     # been too long
                     elif (datetime.utcnow() - start) < timedelta(hours=1):
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, 'Retrying in 30 seconds...',
-                        )
+                        logger.info('Retrying in 30 seconds...')
                         time.sleep(30)
                         continue
                     else:
-                        agent_logging.log_and_print_error_or_warning(
-                            logger, logging.ERROR, error_code=3151
-                        )
+                        agent_logging.log_standard_error(logger, logging.ERROR, error_code=3151)
                 raise
 
     # Handle pagination

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -126,9 +126,9 @@ def _standardize_user(user):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_users(client):
-    logger.info(f'downloading bitbucket users... [!n]')
+    logger.info(f'downloading bitbucket users...')
     users = [_standardize_user(user) for user in client.admin.users]
-    logger.info('✓')
+    logger.info('Done downloading users!')
     return users
 
 
@@ -148,7 +148,7 @@ def _standardize_project(api_project, redact_names_and_urls):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_projects(client, include_projects, exclude_projects, redact_names_and_urls):
-    logger.info(f'downloading bitbucket projects... [!n]')
+    logger.info(f'downloading bitbucket projects...')
 
     filters = []
     if include_projects:
@@ -161,7 +161,7 @@ def get_projects(client, include_projects, exclude_projects, redact_names_and_ur
         for p in client.projects.list()
         if all(filt(p) for filt in filters)
     ]
-    logger.info('✓')
+    logger.info('Done downloading projects!')
     return projects
 
 
@@ -205,7 +205,7 @@ def _standardize_repo(api_project, api_repo, redact_names_and_urls):
 
 @agent_logging.log_entry_exit(logger)
 def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_and_urls):
-    logger.info(f'downloading bitbucket repositories... [!n]')
+    logger.info(f'downloading bitbucket repositories...')
 
     filters = []
     if include_repos:
@@ -220,7 +220,7 @@ def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_a
                 api_repo = project.repos[repo['name']]
                 yield api_repo, _standardize_repo(api_project, api_repo, redact_names_and_urls)
 
-    logger.info('✓')
+    logger.info('Done downloading repositories!')
 
 
 def _standardize_commit(commit, repo, branch_name, strip_text_content, redact_names_and_urls):

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -126,9 +126,9 @@ def _standardize_user(user):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_users(client):
-    logger.info(f'downloading bitbucket users...')
+    logger.info(f'downloading bitbucket users... [!n]')
     users = [_standardize_user(user) for user in client.admin.users]
-    logger.info('Done downloading users!')
+    logger.info('✓')
     return users
 
 
@@ -148,7 +148,7 @@ def _standardize_project(api_project, redact_names_and_urls):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_projects(client, include_projects, exclude_projects, redact_names_and_urls):
-    logger.info(f'downloading bitbucket projects...')
+    logger.info(f'downloading bitbucket projects... [!n]')
 
     filters = []
     if include_projects:
@@ -161,7 +161,7 @@ def get_projects(client, include_projects, exclude_projects, redact_names_and_ur
         for p in client.projects.list()
         if all(filt(p) for filt in filters)
     ]
-    logger.info('Done downloading projects!')
+    logger.info('✓')
     return projects
 
 
@@ -205,7 +205,7 @@ def _standardize_repo(api_project, api_repo, redact_names_and_urls):
 
 @agent_logging.log_entry_exit(logger)
 def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_and_urls):
-    logger.info(f'downloading bitbucket repositories...')
+    logger.info(f'downloading bitbucket repositories... [!n]')
 
     filters = []
     if include_repos:
@@ -220,7 +220,7 @@ def get_repos(client, api_projects, include_repos, exclude_repos, redact_names_a
                 api_repo = project.repos[repo['name']]
                 yield api_repo, _standardize_repo(api_project, api_repo, redact_names_and_urls)
 
-    logger.info('Done downloading repositories!')
+    logger.info('✓')
 
 
 def _standardize_commit(commit, repo, branch_name, strip_text_content, redact_names_and_urls):

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -139,9 +139,9 @@ def _standardize_user(user):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_users(client: GithubClient, include_orgs):
-    logger.info('downloading github users...')
+    logger.info('downloading github users... [!n]')
     users = [_standardize_user(user) for org in include_orgs for user in client.get_all_users(org)]
-    logger.info('Done downloading github users!')
+    logger.info('✓')
 
     return users
 
@@ -162,12 +162,12 @@ def _standardize_project(api_org, redact_names_and_urls):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
-    logger.info('downloading github projects...')
+    logger.info('downloading github projects... [!n]')
     projects = [
         _standardize_project(client.get_organization_by_name(org), redact_names_and_urls)
         for org in include_orgs
     ]
-    logger.info('Done downloading github projects')
+    logger.info('✓')
 
     if not projects:
         raise ValueError(
@@ -213,7 +213,7 @@ def _standardize_repo(client: GithubClient, org_name, repo, redact_names_and_url
 def get_repos(
     client: GithubClient, include_orgs, include_repos, exclude_repos, redact_names_and_urls
 ):
-    logger.info('downloading github repos...')
+    logger.info('downloading github repos... [!n]')
 
     filters = []
     if include_repos:
@@ -227,7 +227,7 @@ def get_repos(
         for r in client.get_all_repos(org)
         if all(filt(r) for filt in filters)
     ]
-    logger.info('Done downloading github repos!')
+    logger.info('✓')
     if not repos:
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
@@ -313,7 +313,7 @@ def get_commits_for_included_branches(
                             )
 
                 except Exception as e:
-                    logger.info(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
+                    logger.warning(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
 
 
 def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names_and_urls):
@@ -429,6 +429,6 @@ def get_pull_requests(
                         yield _standardize_pr(client, pr, strip_text_content, redact_names_and_urls)
 
             except Exception as e:
-                logger.info(
+                logger.warning(
                     f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...'
                 )

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -139,9 +139,9 @@ def _standardize_user(user):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_users(client: GithubClient, include_orgs):
-    logger.info('downloading github users... [!n]')
+    logger.info('downloading github users...')
     users = [_standardize_user(user) for org in include_orgs for user in client.get_all_users(org)]
-    logger.info('✓')
+    logger.info('Done downloading github users!')
 
     return users
 
@@ -162,12 +162,12 @@ def _standardize_project(api_org, redact_names_and_urls):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
-    logger.info('downloading github projects... [!n]')
+    logger.info('downloading github projects...')
     projects = [
         _standardize_project(client.get_organization_by_name(org), redact_names_and_urls)
         for org in include_orgs
     ]
-    logger.info('✓')
+    logger.info('Done downloading github projects')
 
     if not projects:
         raise ValueError(
@@ -213,7 +213,7 @@ def _standardize_repo(client: GithubClient, org_name, repo, redact_names_and_url
 def get_repos(
     client: GithubClient, include_orgs, include_repos, exclude_repos, redact_names_and_urls
 ):
-    logger.info('downloading github repos... [!n]')
+    logger.info('downloading github repos...')
 
     filters = []
     if include_repos:
@@ -227,7 +227,7 @@ def get_repos(
         for r in client.get_all_repos(org)
         if all(filt(r) for filt in filters)
     ]
-    logger.info('✓')
+    logger.info('Done downloading github repos!')
     if not repos:
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -39,18 +39,12 @@ def load_and_dump(
     # Logic to help with debugging the scopes that clients have with their API key
     try:
         scopes = git_conn.get_scopes_of_api_token()
-        agent_logging.log_and_print(
-            logger,
-            logging.INFO,
+        logger.debug(
             'Attempting to ingest github data with the following '
             f'scopes for {config.git_instance_slug}: {scopes}',
         )
     except Exception as e:
-        agent_logging.log_and_print(
-            logger,
-            logging.INFO,
-            f'Problem finding scopes for your API key. This should not affect your github agent processing. Error: {e}',
-        )
+        logger.debug(f'Problem finding scopes for your API key. Error: {e}', exc_info=True)
 
     write_file(
         outdir, 'bb_users', compress_output_files, get_users(git_conn, config.git_include_projects),
@@ -145,9 +139,9 @@ def _standardize_user(user):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_users(client: GithubClient, include_orgs):
-    print('downloading github users... ', end='', flush=True)
+    logger.info('downloading github users... [!n]')
     users = [_standardize_user(user) for org in include_orgs for user in client.get_all_users(org)]
-    print('✓')
+    logger.info('✓')
 
     return users
 
@@ -168,12 +162,12 @@ def _standardize_project(api_org, redact_names_and_urls):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def get_projects(client: GithubClient, include_orgs, redact_names_and_urls):
-    print('downloading github projects... ', end='', flush=True)
+    logger.info('downloading github projects... [!n]')
     projects = [
         _standardize_project(client.get_organization_by_name(org), redact_names_and_urls)
         for org in include_orgs
     ]
-    print('✓')
+    logger.info('✓')
 
     if not projects:
         raise ValueError(
@@ -219,7 +213,7 @@ def _standardize_repo(client: GithubClient, org_name, repo, redact_names_and_url
 def get_repos(
     client: GithubClient, include_orgs, include_repos, exclude_repos, redact_names_and_urls
 ):
-    print('downloading github repos... ', end='', flush=True)
+    logger.info('downloading github repos... [!n]')
 
     filters = []
     if include_repos:
@@ -233,7 +227,7 @@ def get_repos(
         for r in client.get_all_repos(org)
         if all(filt(r) for filt in filters)
     ]
-    print('✓')
+    logger.info('✓')
     if not repos:
         raise ValueError(
             'No repos found. Make sure your token has appropriate access to GitHub and check your configuration of repos to pull.'
@@ -319,7 +313,7 @@ def get_commits_for_included_branches(
                             )
 
                 except Exception as e:
-                    print(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
+                    logger.info(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
 
 
 def _get_merge_commit(client: GithubClient, pr, strip_text_content, redact_names_and_urls):
@@ -435,5 +429,6 @@ def get_pull_requests(
                         yield _standardize_pr(client, pr, strip_text_content, redact_names_and_urls)
 
             except Exception as e:
-                print(f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...')
-    print()
+                logger.info(
+                    f':WARN: Exception getting PRs for repo {repo["name"]}: {e}. Skipping...'
+                )

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -49,7 +49,7 @@ class GithubClient:
                 if e.response.status_code not in (403, 404):
                     raise
 
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger,
                     logging.WARNING,
                     msg_args=[m["url"], e.response.status_code],
@@ -68,7 +68,7 @@ class GithubClient:
 
                 # we've seen some strange behavior with ghe, where we can get a 403 for
                 # a repo that comes back in the list.  SKip them.
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger, logging.WARNING, msg_args=[m["url"]], error_code=3081,
                 )
 
@@ -107,7 +107,7 @@ class GithubClient:
             return raw.json()
         except HTTPError as e:
             if e.response.status_code in (422,):
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger,
                     logging.WARNING,
                     msg_args=[e.response.status_code, ref, full_repo_name],
@@ -144,7 +144,7 @@ class GithubClient:
                     raise
 
                 if i >= max_retries:
-                    agent_logging.log_and_print_error_or_warning(
+                    agent_logging.log_standard_error(
                         logger, logging.ERROR, msg_args=[url, i], error_code=3101,
                     )
                     raise
@@ -166,7 +166,7 @@ class GithubClient:
                 # wait longer than that
                 reset_wait_in_seconds = min(reset_wait_in_seconds, 3600)
                 reset_wait_str = str(timedelta(seconds=reset_wait_in_seconds))
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger, logging.WARNING, msg_args=[reset_wait_str], error_code=3091,
                 )
                 # often the GH reset time is off by <1 second, causing another rate-limit. 2 seconds buffer added.

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -62,7 +62,7 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        print('downloading github projects... ', end='', flush=True)
+        logger.info('downloading github projects... [!n]')
         projects = []
 
         # NOTE: For github, project equates to a Github organization here!
@@ -75,7 +75,7 @@ class GithubGqlAdapter(GitAdapter):
             projects.append(
                 _standardize_project(organization, self.config.git_redact_names_and_urls,)
             )
-        print('✓')
+        logger.info('✓')
 
         if not projects:
             raise ValueError(
@@ -86,13 +86,13 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        print('downloading github users... ', end='', flush=True)
+        logger.info('downloading github users... [!n]')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.get_users(project_id)
         ]
-        print('✓')
+        logger.info('✓')
         return users
 
     @diagnostics.capture_timing()
@@ -100,7 +100,7 @@ class GithubGqlAdapter(GitAdapter):
     def get_repos(
         self, standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
-        print('downloading github repos... ', end='', flush=True)
+        logger.info('downloading github repos... [!n]')
 
         nrm_repos: List[StandardizedRepository] = []
 
@@ -184,7 +184,7 @@ class GithubGqlAdapter(GitAdapter):
                     _standardize_repo(api_repo, nrm_project, self.config.git_redact_names_and_urls)
                 )
 
-        print('✓')
+        logger.info('✓')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Github and check your configuration of repos to pull.'
@@ -199,7 +199,7 @@ class GithubGqlAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        print('downloading github commits on included branches... ', end='', flush=True)
+        logger.info('downloading github commits on included branches... [!n]')
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = (
@@ -240,16 +240,18 @@ class GithubGqlAdapter(GitAdapter):
                                 )
 
                     except Exception as e:
-                        print(traceback.format_exc())
-                        print(f':WARN: Got exception for branch {branch_name}: {e}. Skipping...')
-        print('✓')
+                        logger.info(traceback.format_exc())
+                        logger.info(
+                            f':WARN: Got exception for branch {branch_name}: {e}. Skipping...'
+                        )
+        logger.info('✓')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        print('downloading github prs... ', end='', flush=True)
+        logger.info('downloading github prs... [!n]')
 
         nrm_prs = []
         for i, nrm_repo in enumerate(standardized_repos, start=1):
@@ -316,9 +318,9 @@ class GithubGqlAdapter(GitAdapter):
                         f'getting PRs for repo {nrm_repo.name} ({nrm_repo.id}). Skipping...',
                         log_as_exception=True,
                     )
-        return nrm_prs
 
-    print('✓')
+        logger.info('✓')
+        return nrm_prs
 
 
 '''

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -62,7 +62,7 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        logger.info('downloading github projects...')
+        logger.info('downloading github projects... [!n]')
         projects = []
 
         # NOTE: For github, project equates to a Github organization here!
@@ -75,7 +75,7 @@ class GithubGqlAdapter(GitAdapter):
             projects.append(
                 _standardize_project(organization, self.config.git_redact_names_and_urls,)
             )
-        logger.info('Downloading github projects!')
+        logger.info('✓')
 
         if not projects:
             raise ValueError(
@@ -86,13 +86,13 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        logger.info('downloading github users...')
+        logger.info('downloading github users... [!n]')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.get_users(project_id)
         ]
-        logger.info('Downloading github users!')
+        logger.info('✓')
         return users
 
     @diagnostics.capture_timing()
@@ -240,8 +240,8 @@ class GithubGqlAdapter(GitAdapter):
                                 )
 
                     except Exception as e:
-                        logger.info(traceback.format_exc())
-                        logger.info(
+                        logger.debug(traceback.format_exc())
+                        logger.warning(
                             f':WARN: Got exception for branch {branch_name}: {e}. Skipping...'
                         )
         logger.info('Done downloading commits for included branches!')

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -62,7 +62,7 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        logger.info('downloading github projects... [!n]')
+        logger.info('downloading github projects...')
         projects = []
 
         # NOTE: For github, project equates to a Github organization here!
@@ -75,7 +75,7 @@ class GithubGqlAdapter(GitAdapter):
             projects.append(
                 _standardize_project(organization, self.config.git_redact_names_and_urls,)
             )
-        logger.info('✓')
+        logger.info('Downloading github projects!')
 
         if not projects:
             raise ValueError(
@@ -86,13 +86,13 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        logger.info('downloading github users... [!n]')
+        logger.info('downloading github users...')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.get_users(project_id)
         ]
-        logger.info('✓')
+        logger.info('Downloading github users!')
         return users
 
     @diagnostics.capture_timing()
@@ -100,7 +100,7 @@ class GithubGqlAdapter(GitAdapter):
     def get_repos(
         self, standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
-        logger.info('downloading github repos... [!n]')
+        logger.info('downloading github repos...')
 
         nrm_repos: List[StandardizedRepository] = []
 
@@ -184,7 +184,7 @@ class GithubGqlAdapter(GitAdapter):
                     _standardize_repo(api_repo, nrm_project, self.config.git_redact_names_and_urls)
                 )
 
-        logger.info('✓')
+        logger.info('Done downloading repos!')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to Github and check your configuration of repos to pull.'
@@ -199,7 +199,7 @@ class GithubGqlAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        logger.info('downloading github commits on included branches... [!n]')
+        logger.info('downloading github commits on included branches...')
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = (
@@ -244,14 +244,14 @@ class GithubGqlAdapter(GitAdapter):
                         logger.info(
                             f':WARN: Got exception for branch {branch_name}: {e}. Skipping...'
                         )
-        logger.info('✓')
+        logger.info('Done downloading commits for included branches!')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        logger.info('downloading github prs... [!n]')
+        logger.info('downloading github prs...')
 
         nrm_prs = []
         for i, nrm_repo in enumerate(standardized_repos, start=1):
@@ -319,7 +319,7 @@ class GithubGqlAdapter(GitAdapter):
                         log_as_exception=True,
                     )
 
-        logger.info('✓')
+        logger.info('Done downloading github PRs!')
         return nrm_prs
 
 

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -163,9 +163,7 @@ class GithubGqlClient:
                         # Add three seconds for gracetime
                         sleep_time = retry_after + 3
 
-                agent_logging.log_and_print(
-                    logger,
-                    logging.WARNING,
+                logger.warning(
                     f'A secondary rate limit was hit. Sleeping for {sleep_time} seconds. (attempt {attempt_number}/{max_attempts})',
                 )
                 time.sleep(sleep_time)
@@ -189,11 +187,7 @@ class GithubGqlClient:
                 # past. In that case, wait for 5 mins just in case.
                 if sleep_time <= 0:
                     sleep_time = 300
-                agent_logging.log_and_print(
-                    logger,
-                    logging.WARNING,
-                    f'GQL Rate Limit hit. Sleeping for {sleep_time} seconds',
-                )
+                logger.warning(f'GQL Rate Limit hit. Sleeping for {sleep_time} seconds',)
                 time.sleep(sleep_time)
             finally:
                 attempt_number += 1

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -1,12 +1,11 @@
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 import time
 from requests import Session
 import requests
 from requests.utils import default_user_agent
 from typing import Generator
-from jf_agent import agent_logging
 from jf_agent.git.github_gql_utils import datetime_to_gql_str_format, github_gql_format_to_datetime
 
 from jf_agent.session import retry_session

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -137,7 +137,7 @@ class GitLabAdapter(GitAdapter):
                 )
                 total_failed = len(repos_that_failed_to_download)
 
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger,
                     logging.WARNING,
                     msg_args=[total_failed, nrm_project.id, repos_failed_string],
@@ -154,7 +154,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_branches(self, api_repo) -> List[StandardizedBranch]:
-        logger.info('downloading gitlab branches... ')
+        logger.info('downloading gitlab branches... [!n]')
         try:
             branches = [
                 _standardize_branch(api_branch, self.config.git_redact_names_and_urls)
@@ -178,7 +178,7 @@ class GitLabAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        logger.info('downloading gitlab commits on included branches... ')
+        logger.info('downloading gitlab commits on included branches... [!n]')
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
@@ -215,7 +215,7 @@ class GitLabAdapter(GitAdapter):
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        logger.info('downloading gitlab prs... ')
+        logger.info('downloading gitlab prs... [!n]')
 
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             logger.info(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -51,7 +51,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        logger.info('downloading gitlab projects...')
+        logger.info('downloading gitlab projects... [!n]')
         projects = []
 
         for project_id in self.config.git_include_projects:
@@ -63,7 +63,7 @@ class GitLabAdapter(GitAdapter):
             projects.append(
                 _standardize_project(group, self.config.git_redact_names_and_urls,)  # are group_ids
             )
-        logger.info('Done downloading gitlab projects!')
+        logger.info('✓')
 
         if not projects:
             raise ValueError(
@@ -74,13 +74,13 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        logger.info('downloading gitlab users...')
+        logger.info('downloading gitlab users... [!n]')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.list_group_members(project_id)
         ]
-        logger.info('Done downloading gitlab users!')
+        logger.info('✓')
         return users
 
     @diagnostics.capture_timing()
@@ -154,7 +154,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_branches(self, api_repo) -> List[StandardizedBranch]:
-        logger.info('downloading gitlab branches...')
+        logger.info('downloading gitlab branches... [!n]')
         try:
             branches = [
                 _standardize_branch(api_branch, self.config.git_redact_names_and_urls)
@@ -167,7 +167,7 @@ class GitLabAdapter(GitAdapter):
                 'This is most likely because no repo was in the GitlabProject -- will treat like there are no branches',
             )
             branches = []
-        logger.info('Done downloading gitlab branches!')
+        logger.info('✓')
         return branches
 
     @diagnostics.capture_timing()
@@ -603,7 +603,6 @@ def _should_fetch_repo_data(api_repo: GroupProject, config: GitConfig) -> bool:
     if include_rules_defined and not included:
         if config.git_verbose:
             logger.info(
-                logging.INFO,
                 f"skipping repo {api_repo.id} because it is not included explicitly or implicitly, "
                 f"while include rules are defined...",
             )

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -51,7 +51,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        logger.info('downloading gitlab projects... [!n]')
+        logger.info('downloading gitlab projects...')
         projects = []
 
         for project_id in self.config.git_include_projects:
@@ -63,7 +63,7 @@ class GitLabAdapter(GitAdapter):
             projects.append(
                 _standardize_project(group, self.config.git_redact_names_and_urls,)  # are group_ids
             )
-        logger.info('✓')
+        logger.info('Done downloading gitlab projects!')
 
         if not projects:
             raise ValueError(
@@ -74,13 +74,13 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        logger.info('downloading gitlab users... [!n]')
+        logger.info('downloading gitlab users...')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.list_group_members(project_id)
         ]
-        logger.info('✓')
+        logger.info('Done downloading gitlab users!')
         return users
 
     @diagnostics.capture_timing()
@@ -88,7 +88,7 @@ class GitLabAdapter(GitAdapter):
     def get_repos(
         self, standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
-        logger.info('downloading gitlab repos... [!n]')
+        logger.info('downloading gitlab repos...')
 
         nrm_repos: List[StandardizedRepository] = []
         for nrm_project in standardized_projects:
@@ -144,7 +144,7 @@ class GitLabAdapter(GitAdapter):
                     error_code=2201,
                 )
 
-        logger.info('✓')
+        logger.info('Done downloading gitlab repos!')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
@@ -154,7 +154,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_branches(self, api_repo) -> List[StandardizedBranch]:
-        logger.info('downloading gitlab branches... [!n]')
+        logger.info('downloading gitlab branches...')
         try:
             branches = [
                 _standardize_branch(api_branch, self.config.git_redact_names_and_urls)
@@ -167,7 +167,7 @@ class GitLabAdapter(GitAdapter):
                 'This is most likely because no repo was in the GitlabProject -- will treat like there are no branches',
             )
             branches = []
-        logger.info('✓')
+        logger.info('Done downloading gitlab branches!')
         return branches
 
     @diagnostics.capture_timing()
@@ -178,7 +178,7 @@ class GitLabAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        logger.info('downloading gitlab commits on included branches... [!n]')
+        logger.info('downloading gitlab commits on included branches...')
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
@@ -208,14 +208,14 @@ class GitLabAdapter(GitAdapter):
 
                 except Exception as e:
                     logger.info(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
-        logger.info('✓')
+        logger.info('Done downloading gitlab commits on included branches!')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        logger.info('downloading gitlab prs... [!n]')
+        logger.info('downloading gitlab prs...')
 
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             logger.info(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')
@@ -303,7 +303,7 @@ class GitLabAdapter(GitAdapter):
                         log_as_exception=True,
                     )
 
-    logger.info('✓')
+    logger.info('Done downloading gitlab PRs!')
 
 
 '''

--- a/jf_agent/git/gitlab_adapter.py
+++ b/jf_agent/git/gitlab_adapter.py
@@ -51,7 +51,7 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_projects(self) -> List[StandardizedProject]:
-        print('downloading gitlab projects... ', end='', flush=True)
+        logger.info('downloading gitlab projects... [!n]')
         projects = []
 
         for project_id in self.config.git_include_projects:
@@ -63,7 +63,7 @@ class GitLabAdapter(GitAdapter):
             projects.append(
                 _standardize_project(group, self.config.git_redact_names_and_urls,)  # are group_ids
             )
-        print('✓')
+        logger.info('✓')
 
         if not projects:
             raise ValueError(
@@ -74,13 +74,13 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_users(self) -> List[StandardizedUser]:
-        print('downloading gitlab users... ', end='', flush=True)
+        logger.info('downloading gitlab users... [!n]')
         users = [
             _standardize_user(user)
             for project_id in self.config.git_include_projects
             for user in self.client.list_group_members(project_id)
         ]
-        print('✓')
+        logger.info('✓')
         return users
 
     @diagnostics.capture_timing()
@@ -88,7 +88,7 @@ class GitLabAdapter(GitAdapter):
     def get_repos(
         self, standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
-        print('downloading gitlab repos... ', end='', flush=True)
+        logger.info('downloading gitlab repos... [!n]')
 
         nrm_repos: List[StandardizedRepository] = []
         for nrm_project in standardized_projects:
@@ -144,7 +144,7 @@ class GitLabAdapter(GitAdapter):
                     error_code=2201,
                 )
 
-        print('✓')
+        logger.info('✓')
         if not nrm_repos:
             raise ValueError(
                 'No repos found. Make sure your token has appropriate access to GitLab and check your configuration of repos to pull.'
@@ -154,9 +154,9 @@ class GitLabAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_branches(self, api_repo) -> List[StandardizedBranch]:
-        print('downloading gitlab branches... ', end='', flush=True)
+        logger.info('downloading gitlab branches... ')
         try:
-            return [
+            branches = [
                 _standardize_branch(api_branch, self.config.git_redact_names_and_urls)
                 for api_branch in self.client.list_project_branches(api_repo.id)
             ]
@@ -166,7 +166,9 @@ class GitLabAdapter(GitAdapter):
                 f'pulling branches from repo {api_repo.id}'
                 'This is most likely because no repo was in the GitlabProject -- will treat like there are no branches',
             )
-            return []
+            branches = []
+        logger.info('✓')
+        return branches
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
@@ -176,7 +178,7 @@ class GitLabAdapter(GitAdapter):
         included_branches: dict,
         server_git_instance_info,
     ) -> List[StandardizedCommit]:
-        print('downloading gitlab commits on included branches... ', end='', flush=True)
+        logger.info('downloading gitlab commits on included branches... ')
         for i, nrm_repo in enumerate(standardized_repos, start=1):
             with agent_logging.log_loop_iters(logger, 'repo for branch commits', i, 1):
                 pull_since = pull_since_date_for_repo(
@@ -205,18 +207,18 @@ class GitLabAdapter(GitAdapter):
                                 )
 
                 except Exception as e:
-                    print(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
-        print('✓')
+                    logger.info(f':WARN: Got exception for branch {branch}: {e}. Skipping...')
+        logger.info('✓')
 
     @diagnostics.capture_timing()
     @agent_logging.log_entry_exit(logger)
     def get_pull_requests(
         self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
-        print('downloading gitlab prs... ', end='', flush=True)
+        logger.info('downloading gitlab prs... ')
 
         for i, nrm_repo in enumerate(standardized_repos, start=1):
-            print(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')
+            logger.info(f'downloading prs for repo {nrm_repo.name} ({nrm_repo.id})')
 
             with agent_logging.log_loop_iters(logger, 'repo for pull requests', i, 1):
                 try:
@@ -301,7 +303,7 @@ class GitLabAdapter(GitAdapter):
                         log_as_exception=True,
                     )
 
-    print('✓')
+    logger.info('✓')
 
 
 '''
@@ -600,8 +602,7 @@ def _should_fetch_repo_data(api_repo: GroupProject, config: GitConfig) -> bool:
 
     if include_rules_defined and not included:
         if config.git_verbose:
-            agent_logging.log_and_print(
-                logger,
+            logger.info(
                 logging.INFO,
                 f"skipping repo {api_repo.id} because it is not included explicitly or implicitly, "
                 f"while include rules are defined...",
@@ -610,9 +611,7 @@ def _should_fetch_repo_data(api_repo: GroupProject, config: GitConfig) -> bool:
 
     if exclude_rules_defined and excluded:
         if config.git_verbose:
-            agent_logging.log_and_print(
-                logger,
-                logging.INFO,
+            logger.info(
                 f'skipping repo {api_repo.id} because it is excluded explicitly or implicitly,'
                 f'while exclude rules are defined...',
             )

--- a/jf_agent/git/gitlab_client.py
+++ b/jf_agent/git/gitlab_client.py
@@ -2,7 +2,6 @@ import gitlab
 import logging
 import requests
 
-from jf_agent import agent_logging
 from jf_agent.git.utils import log_and_print_request_error
 
 logger = logging.getLogger(__name__)

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -42,7 +42,7 @@ def log_and_print_request_error(e, action='making request', log_as_exception=Fal
     error_name = type(e).__name__
 
     if log_as_exception:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger,
             logging.ERROR,
             msg_args=[error_name, response_code, action, e],
@@ -50,6 +50,6 @@ def log_and_print_request_error(e, action='making request', log_as_exception=Fal
             exc_info=True,
         )
     else:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.WARNING, msg_args=[error_name, response_code, action], error_code=3141
         )

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -84,6 +84,7 @@ def print_all_jira_fields(config, jira_connection):
     for f in download_fields(
         jira_connection, config.jira_include_fields, config.jira_exclude_fields
     ):
+        # This could potential data that clients do not exposed. Print instead of logging here
         print(f"{f['key']:30}\t{f['name']}")
 
 
@@ -91,6 +92,7 @@ def print_all_jira_fields(config, jira_connection):
 @agent_logging.log_entry_exit(logger)
 def print_missing_repos_found_by_jira(config, creds, issues_to_scan):
     missing_repos = download_missing_repos_found_by_jira(config, creds, issues_to_scan)
+    # This could potential data that clients do not exposed. Print instead of logging here
     print(
         f'\nScanning the "Development" field on the Jira issues revealed {len(missing_repos)} Git repos apparently missing from Jellyfish'
     )
@@ -227,7 +229,7 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
                 ),
                 item_id_dict_key='id',
                 addl_info_dict_key='key',
-                batch_size=2000
+                batch_size=2000,
             )
 
         downloaded_issue_info = download_and_write_issues()
@@ -256,7 +258,7 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
                 ),
                 item_id_dict_key='id',
                 addl_info_dict_key='key',
-                batch_size=2000
+                batch_size=2000,
             )
 
         re_downloaded_issue_info = download_and_write_issues_needing_re_download()

--- a/jf_agent/jf_jira/__init__.py
+++ b/jf_agent/jf_jira/__init__.py
@@ -73,7 +73,7 @@ def get_basic_jira_connection(config, creds):
     try:
         return _get_raw_jira_connection(config, creds)
     except Exception as e:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.ERROR, msg_args=[e], error_code=2102, exc_info=True
         )
 
@@ -305,7 +305,7 @@ def load_and_dump_jira(config, endpoint_jira_info, jira_connection):
         return {'type': 'Jira', 'status': 'success'}
 
     except Exception as e:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.ERROR, msg_args=[e], error_code=3002, exc_info=True
         )
         return {'type': 'Jira', 'status': 'failed'}

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -198,7 +198,7 @@ def download_projects_and_versions(
                 and e.text
                 == f"A value with ID '{project_id}' does not exist for the field 'project'."
             ):
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger, logging.ERROR, msg_args=[project_id], error_code=2112,
                 )
                 return False
@@ -259,7 +259,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                 ).json()['values']
             except JIRAError as e:
                 if e.status_code == 400:
-                    agent_logging.log_and_print_error_or_warning(
+                    agent_logging.log_standard_error(
                         logger, logging.ERROR, msg_args=[project_id], error_code=2202,
                     )
                     break
@@ -294,7 +294,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                     if e.status_code == 500 or e.status_code == 404:
                         logger.info(f"Couldn't get sprints for board {b['id']}.  Skipping...")
                     elif e.status_code == 400:
-                        agent_logging.log_and_print_error_or_warning(
+                        agent_logging.log_standard_error(
                             logger,
                             logging.ERROR,
                             msg_args=[str(b), str(s_start_at), str(e)],
@@ -346,14 +346,14 @@ def get_issues(jira_connection, issue_jql, start_at, batch_size):
             # a smaller ask will prevent the server from choking.
             batch_size = int(batch_size / 2)
             error = e
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARNING, msg_args=[batch_size], error_code=3012,
             )
 
     # copied logic from jellyfish direct connect
     # don't bail, just skip
     # khardy 2023-03-16
-    agent_logging.log_and_print_error_or_warning(
+    agent_logging.log_standard_error(
         logger,
         logging.WARNING,
         msg_args=[f"{type(error)}", issue_jql, start_at, original_batch_size],
@@ -423,7 +423,7 @@ def download_all_issue_metadata(
 
             except Exception as e:
                 thread_exceptions[thread_num] = e
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger,
                     logging.ERROR,
                     msg_args=[thread_num, traceback.format_exc()],
@@ -595,7 +595,7 @@ def _filter_changelogs(issues, include_fields, exclude_fields):
         for i in items:
             field_id_field = _get_field_identifier(i)
             if not field_id_field:
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger=logger, level=logging.WARNING, error_code=3082, msg_args=[i.keys()],
                 )
             if include_fields and i.get(field_id_field) not in include_fields:
@@ -654,7 +654,7 @@ def _download_jira_issues_segment(
         q.put(None)
 
     except BaseException as e:
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.ERROR, msg_args=[thread_num], error_code=3042, exc_info=True,
         )
         q.put(e)
@@ -745,7 +745,7 @@ def _download_jira_issues_page(
                     if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
                         return [], 1
                     elif not get_changelog:
-                        agent_logging.log_and_print_error_or_warning(
+                        agent_logging.log_standard_error(
                             logger, logging.WARNING, msg_args=[search_params], error_code=3062,
                         )
                         return [], 0
@@ -820,7 +820,7 @@ def download_customfieldoptions(jira_connection, project_ids):
                 projectIds=[project_id], expand='projects.issuetypes.fields'
             )
         except JIRAError:
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.WARNING, error_code=3072, exc_info=False
             )
             return []
@@ -1012,7 +1012,7 @@ def _get_repos_list_in_jira(issues_to_scan, jira_connection):
                 )
             except JIRAError as e:
                 if e.status_code == 403:
-                    agent_logging.log_and_print_error_or_warning(
+                    agent_logging.log_standard_error(
                         logger, logging.ERROR, error_code=2122,
                     )
                     return []

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -31,7 +31,7 @@ def download_users(
     jira_connection, gdpr_active, quiet=False, required_email_domains=None, is_email_required=False
 ):
     if not quiet:
-        print('downloading jira users... ', end='', flush=True)
+        logger.info('downloading jira users...  [!n]')
 
     jira_users = _search_all_users(jira_connection, gdpr_active)
 
@@ -39,8 +39,7 @@ def download_users(
     # results.  If we have seen approximately 1000 results, try
     # searching a different way
     if 950 <= len(jira_users) <= 1000:
-        agent_logging.log_and_print(
-            logger=logger,
+        logger.info(
             level=logging.INFO,
             msg=f'Page limit reached with {len(jira_users)} users, '
             'falling back to search by letter method.',
@@ -76,7 +75,7 @@ def download_users(
         jira_users = filtered_users
 
     if not quiet:
-        print('✓')
+        logger.info('✓')
     return jira_users
 
 
@@ -84,7 +83,7 @@ def download_users(
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_fields(jira_connection, include_fields, exclude_fields):
-    print('downloading jira fields... ', end='', flush=True)
+    logger.info('downloading jira fields... [!n]')
 
     filters = []
     if include_fields:
@@ -94,7 +93,7 @@ def download_fields(jira_connection, include_fields, exclude_fields):
 
     fields = [field for field in jira_connection.fields() if all(filt(field) for filt in filters)]
 
-    print('✓')
+    logger.info('✓')
     return fields
 
 
@@ -102,9 +101,9 @@ def download_fields(jira_connection, include_fields, exclude_fields):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_resolutions(jira_connection):
-    print('downloading jira resolutions... ', end='', flush=True)
+    logger.info('downloading jira resolutions... [!n]')
     result = [r.raw for r in jira_connection.resolutions()]
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -117,7 +116,7 @@ def download_issuetypes(jira_connection, project_ids):
     For issue types that are scoped to projects, only extract the ones
     in the extracted projects.
     '''
-    print('downloading jira issue types... ', end='', flush=True)
+    logger.info('downloading jira issue types...  [!n]',)
     result = []
     for it in jira_connection.issue_types():
         if 'scope' in it.raw and it.raw['scope']['type'] == 'PROJECT':
@@ -125,7 +124,7 @@ def download_issuetypes(jira_connection, project_ids):
                 result.append(it.raw)
         else:
             result.append(it.raw)
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -133,9 +132,9 @@ def download_issuetypes(jira_connection, project_ids):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_issuelinktypes(jira_connection):
-    print('downloading jira issue link types... ', end='', flush=True)
+    logger.info('downloading jira issue link types... [!n]')
     result = [lt.raw for lt in jira_connection.issue_link_types()]
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -143,9 +142,9 @@ def download_issuelinktypes(jira_connection):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_priorities(jira_connection):
-    print('downloading jira priorities... ', end='', flush=True)
+    logger.info('downloading jira priorities... [!n]')
     result = [p.raw for p in jira_connection.priorities()]
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -156,7 +155,7 @@ def download_priorities(jira_connection):
 def download_projects_and_versions(
     jira_connection, include_projects, exclude_projects, include_categories, exclude_categories
 ):
-    print('downloading jira projects... ', end='', flush=True)
+    logger.info('downloading jira projects... [!n]')
 
     filters = []
     if include_projects:
@@ -218,19 +217,19 @@ def download_projects_and_versions(
             'No Jira projects found that meet all the provided filters for project and project category. Aborting... '
         )
 
-    print('✓')
+    logger.info('✓')
 
-    print('downloading jira project components... ', end='', flush=True)
+    logger.info('downloading jira project components... [!n]')
     for p in projects:
         p.raw.update({'components': [c.raw for c in jira_connection.project_components(p)]})
-    print('✓')
+    logger.info('✓')
 
-    print('downloading jira versions... ', end='', flush=True)
+    logger.info('downloading jira versions... [!n]')
     result = [
         p.raw.update({'versions': [v.raw for v in jira_connection.project_versions(p)]}) or p.raw
         for p in projects
     ]
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -293,7 +292,7 @@ def download_boards_and_sprints(jira_connection, project_ids, download_sprints):
                     # misconfigured; "falied to execute search"; etc.  Just
                     # skip and move on
                     if e.status_code == 500 or e.status_code == 404:
-                        print(f"Couldn't get sprints for board {b['id']}.  Skipping...")
+                        logger.info(f"Couldn't get sprints for board {b['id']}.  Skipping...")
                     elif e.status_code == 400:
                         agent_logging.log_and_print_error_or_warning(
                             logger,
@@ -369,7 +368,7 @@ def get_issues(jira_connection, issue_jql, start_at, batch_size):
 def download_all_issue_metadata(
     jira_connection, all_project_ids, earliest_issue_dt, num_parallel_threads, issue_filter
 ) -> Dict[int, IssueMetadata]:
-    print('downloading issue metadata... ', end='', flush=True)
+    logger.info('downloading issue metadata... [!n]')
 
     # all_project_ids is passed in as a set - need it to be a list so it can be split
     all_project_ids = list(all_project_ids)
@@ -447,7 +446,7 @@ def download_all_issue_metadata(
             any_exception = [e for e in thread_exceptions if e][0]
             raise Exception('Some thread(s) threw exceptions') from any_exception
 
-    print('✓')
+    logger.info('✓')
 
     return all_issue_metadata
 
@@ -484,9 +483,7 @@ def detect_issues_needing_re_download(
     for issue_id_str, issue_key in downloaded_issue_info:
         existing_metadata = issue_metadata_from_jellyfish.get(int(issue_id_str))
         if existing_metadata and issue_key != existing_metadata.key:
-            agent_logging.log_and_print(
-                logger,
-                logging.INFO,
+            logger.info(
                 f'Detected a key change for issue {issue_id_str} ({existing_metadata.key} -> {issue_key})',
             )
             issue_keys_changed.append(existing_metadata.key)
@@ -636,7 +633,7 @@ def _download_jira_issues_segment(
     download onto the shared queue.
     '''
     start_at = 0
-    agent_logging.log_and_print(logger, logging.INFO, f"Beginning to download jira issues in segment of {len(jira_issue_ids_segment)}")
+    logger.debug(f"Beginning to download jira issues in segment of {len(jira_issue_ids_segment)}")
     try:
         while start_at < len(jira_issue_ids_segment):
             issues, num_apparently_deleted = _download_jira_issues_page(
@@ -673,7 +670,7 @@ def _split_id_list(jira_issue_ids_segment: list):
         + 200
     )
     num_pulls = len_issue_ids_string // max_length + 1
-    agent_logging.log_and_print(logger, logging.INFO, f"Splitting the list of issue ids into {num_pulls} portions for server safety")
+    logger.debug(f"Splitting the list of issue ids into {num_pulls} portions for server safety")
 
     issue_ids_array = []
     if num_pulls == 1:
@@ -700,9 +697,7 @@ def _download_jira_issues_page(
     try:
         issue_ids_array = _split_id_list(jira_issue_ids_segment)
     except Exception as e:
-        agent_logging.log_and_print(
-            logger,
-            logging.WARNING,
+        logger.warning(
             f"got {e} trying to split up ids for jql 2500 character limit, moving on with normal id list",
         )
         issue_ids_array.append(jira_issue_ids_segment)
@@ -732,25 +727,19 @@ def _download_jira_issues_page(
             except Exception as e:
                 if hasattr(e, 'status_code') and e.status_code == 429:
                     if tries >= 5:
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, f'exhausted 5 tries of ratelmiting'
-                        )
+                        logger.info(f'exhausted 5 tries of ratelmiting')
                         raise
                     if hasattr(e.response, 'headers') and 'Retry-After' in e.response.headers:
                         wait_time = int(e.response.headers["Retry-After"])
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, f'Retrying in {wait_time} seconds...'
-                        )
+                        logger.info(f'Retrying in {wait_time} seconds...')
                         time.sleep(wait_time)
                     else:
                         tries += 1
-                        agent_logging.log_and_print(
-                            logger, logging.INFO, f'No retry-after header, retrying in 30 seconds...'
-                        )
+                        logger.info(f'No retry-after header, retrying in 30 seconds...')
                         time.sleep(30)
 
                 batch_size = int(batch_size / 2)
-                agent_logging.log_and_print(logger, logging.WARNING, f"Got {e}, reducing batch size")
+                logger.warning(f"Got {e}, reducing batch size")
                 time.sleep(30)
                 if batch_size == 0:
                     if re.match(r"A value with ID .* does not exist for the field 'id'", e.text):
@@ -792,7 +781,7 @@ def _expand_changelog(jira_issues, jira_connection):
 # TODO make this happen incrementally -- only pull down the worklogs that have been updated
 # more recently than we've already stored
 def download_worklogs(jira_connection, issue_ids):
-    print('downloading jira worklogs... ', end='', flush=True)
+    logger.info('downloading jira worklogs...  [!n]')
     updated = []
     since = 0
     while True:
@@ -806,7 +795,7 @@ def download_worklogs(jira_connection, issue_ids):
         try:
             worklog_list_json = json_loads(resp)
         except ValueError:
-            print("Couldn't parse JIRA response as JSON: %s", resp.text)
+            logger.info("Couldn't parse JIRA response as JSON: %s", resp.text)
             raise
 
         updated.extend([wl for wl in worklog_list_json if int(wl['issueId']) in issue_ids])
@@ -814,7 +803,7 @@ def download_worklogs(jira_connection, issue_ids):
             break
         since = worklog_ids_json['until']
 
-    print('✓')
+    logger.info('✓')
 
     return {'existing': updated, 'deleted': []}
 
@@ -823,7 +812,7 @@ def download_worklogs(jira_connection, issue_ids):
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_customfieldoptions(jira_connection, project_ids):
-    print('downloading jira custom field options... ', end='', flush=True)
+    logger.info('downloading jira custom field options... [!n]')
     optionvalues = {}
     for project_id in project_ids:
         try:
@@ -849,17 +838,17 @@ def download_customfieldoptions(jira_connection, project_ids):
                         optionvalues[field_key] = field['allowedValues']
 
     result = [{'field_key': k, 'raw_json': v} for k, v in optionvalues.items()]
-    print('✓')
+    logger.info('✓')
     return result
 
 
 @diagnostics.capture_timing()
 @agent_logging.log_entry_exit(logger)
 def download_statuses(jira_connection):
-    print('downloading jira statuses... ', end='', flush=True)
+    logger.info('downloading jira statuses... [!n]')
     statuses = jira_connection.statuses()
     result = [{'status_id': status.id, 'raw_json': status.raw} for status in statuses]
-    print('✓')
+    logger.info('✓')
     return result
 
 
@@ -989,7 +978,7 @@ def download_missing_repos_found_by_jira(config, creds, issues_to_scan):
     # cross-reference them with git sources
     is_multi_git_config = len(config.git_configs) > 1
     for git_config in config.git_configs:
-        print(
+        logger.info(
             f'Checking against the {git_config.git_provider} instance {git_config.git_instance_slug} ..'
         )
         if is_multi_git_config:
@@ -1012,7 +1001,7 @@ def download_missing_repos_found_by_jira(config, creds, issues_to_scan):
 
 
 def _get_repos_list_in_jira(issues_to_scan, jira_connection):
-    print('Scanning Jira issues for Git repos...')
+    logger.info('Scanning Jira issues for Git repos...')
     missing_repositories = {}
 
     for issue_id, instance_types in issues_to_scan.items():
@@ -1051,7 +1040,7 @@ def _remove_repos_present_in_git_instance(git_connection, git_config, missing_re
             missing_repositories, get_repos_from_git(git_connection, git_config), git_config
         )
     except Exception as e:
-        print(
+        logger.info(
             f'WARNING: Got an error when trying to cross-reference repos discovered by '
             f'Jira with Git repos: {e}\nSkipping this process and returning all repos '
             f'discovered by Jira...'
@@ -1071,27 +1060,27 @@ def _scan_jira_issue_for_repo_data(jira_connection, issue_id, application_type):
         )
     except JIRAError as e:
         if e.status_code == 400:
-            print(
+            logger.info(
                 f"WARNING: received a 400 when requesting development details for issue {issue_id}, "
                 f"likely because it doesn't exist anymore -- skipping"
             )
             return []
         raise
     except Exception as e:
-        print(
+        logger.info(
             f'WARNING: caught {type(e)} exception requesting development details for '
             f'{issue_id} -- skipping'
         )
         return []
 
     if response.get('errors'):
-        print(
+        logger.info(
             f"WARNING: received an error when requesting development details for {issue_id}: {response['errors']}"
         )
 
     detail = response.get('detail', [])
     if not detail:
-        print(f'found no development details for {issue_id}')
+        logger.info(f'found no development details for {issue_id}')
         return []
 
     return detail[0]['repositories']
@@ -1104,7 +1093,7 @@ def _remove_mismatched_repos(repos_found_by_jira, git_repos, config):
     if not (repos_found_by_jira and git_repos):
         return
 
-    print('comparing repos found by Jira against Git repos to find missing ones...')
+    logger.info('comparing repos found by Jira against Git repos to find missing ones...')
 
     git_repo_names = []
     git_repo_urls = []
@@ -1136,8 +1125,8 @@ def _remove_mismatched_repos(repos_found_by_jira, git_repos, config):
             del repos_found_by_jira[repo['name']]
 
     if len(ignore_repos):
-        print(
+        logger.info(
             '\nJira found the following repos but per your config file, Jellyfish already has access:'
         )
         for repo in ignore_repos:
-            print(f"* {repo[0]:30}\t{repo[1]}")
+            logger.info(f"* {repo[0]:30}\t{repo[1]}")

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -170,6 +170,7 @@ def main():
                     'Exception encountered when trying to generate manifests. '
                     f'This should not affect your agent upload. Exception: {e}',
                 )
+                logger.debug(f'Manifest generation bug: {e}', exc_info=True)
 
             if config.run_mode_is_print_apparently_missing_git_repos:
                 issues_to_scan = get_issues_to_scan_from_jellyfish(
@@ -631,7 +632,7 @@ def send_data(config, creds):
             upload_file(filename, path_to_obj, signed_url)
         except Exception as e:
             thread_exceptions.append(e)
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
             )
 
@@ -658,7 +659,7 @@ def send_data(config, creds):
             # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
             # Attempt to catch and retry the 104 type error here
             except requests.exceptions.ConnectionError as e:
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger,
                     logging.WARNING,
                     msg_args=[filename, repr(e)],
@@ -671,7 +672,7 @@ def send_data(config, creds):
 
         # If we make it out of the while loop without returning, that means
         # we failed to upload the file.
-        agent_logging.log_and_print_error_or_warning(
+        agent_logging.log_standard_error(
             logger, logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
         )
 
@@ -721,7 +722,7 @@ def send_data(config, creds):
     if any(thread_exceptions):
         # Run through exceptions and inject them into the agent log
         for exception in thread_exceptions:
-            agent_logging.log_and_print_error_or_warning(
+            agent_logging.log_standard_error(
                 logger, logging.ERROR, error_code=0000, msg_args=[exception], exc_info=True
             )
         logger.info(

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -54,7 +54,7 @@ class RateLimiter(object):
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 429:
                         # Got rate limited anyway!
-                        agent_logging.log_and_print_error_or_warning(
+                        agent_logging.log_standard_error(
                             logger,
                             logging.ERROR,
                             msg_args=[calls_made, max_calls, realm],
@@ -66,7 +66,7 @@ class RateLimiter(object):
                 f'Rate limiter: exceeded {max_calls} calls in {period_secs} seconds for {realm}!',
             )
             if (sleep_until - start) >= timedelta(seconds=self.timeout_secs):
-                agent_logging.log_and_print_error_or_warning(
+                agent_logging.log_standard_error(
                     logger, logging.ERROR, msg_args=[self.timeout_secs], error_code=3020
                 )
                 raise Exception('Rate limit timeout')

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -62,9 +62,7 @@ class RateLimiter(object):
                         )
                     raise
 
-            agent_logging.log_and_print(
-                logger,
-                logging.INFO,
+            logger.info(
                 f'Rate limiter: exceeded {max_calls} calls in {period_secs} seconds for {realm}!',
             )
             if (sleep_until - start) >= timedelta(seconds=self.timeout_secs):
@@ -75,8 +73,7 @@ class RateLimiter(object):
 
             sleep_period_secs = (sleep_until - datetime.utcnow()).total_seconds()
             if sleep_period_secs > 0:  # it's possible that sleep_until was a couple ms ago
-                agent_logging.log_and_print(
-                    logger,
+                logger.info(
                     logging.INFO,
                     f'Sleeping for {sleep_period_secs:.1f} secs ({sleep_period_secs / 60.0:.1f} mins)',
                 )

--- a/jf_agent/session.py
+++ b/jf_agent/session.py
@@ -11,6 +11,7 @@ class ReauthSession(requests.Session):
         # If we get HTTP 401, re-authenticate and try again
         response = super().request(method, url, **kwargs)
         if response.status_code == 401:
+            # Use print instead of logger.log, as URL could be considered sensitive data
             print(f'WARN: received 401 for the request [{method}] {url} - resetting client session')
 
             # Clear cookies and re-auth

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -14,6 +14,12 @@ from jf_agent.git import get_git_client, get_nested_repos_from_git, GithubGqlCli
 logger = logging.getLogger(__name__)
 
 
+# NOTE: Pretty much all 'logging' calls here should use PRINT
+# and not logger.info. Logger.info will log to stdout AND
+# to our log file. We do NOT want to log any passwords or usernames.
+# To be extra safe, use print instead of logger.log within validation
+
+
 class ProjectMetadata:
     project_name = ""
     valid_creds: list[str] = []
@@ -126,18 +132,23 @@ def validate_num_repos(git_configs, creds):
                         metadata_by_project[project].valid_creds.append(cred_slug)
                     else:
                         metadata_by_project[project] = ProjectMetadata(
-                            project_name=project, valid_creds=[cred_slug], num_repos=repo_count)
-                    msg = f"credentials preface: {cred_slug} " \
-                          f"identified {repo_count} repos in instance {git_config.git_instance_slug}/{project}"
-                    agent_logging.log_and_print(logger, logging.INFO, msg=msg)
+                            project_name=project, valid_creds=[cred_slug], num_repos=repo_count
+                        )
+                    msg = (
+                        f"credentials preface: {cred_slug} "
+                        f"identified {repo_count} repos in instance {git_config.git_instance_slug}/{project}"
+                    )
+                    logger.info(msg=msg)
 
                 except Exception as e:
                     if client and client.session:
                         client.session.close()
                     print(e)
-                    msg = f"credentials preface: {cred_slug} not valid to config preface: " \
-                          f"{git_config.git_instance_slug}, got {e}, moving on."
-                    agent_logging.log_and_print(logger, logging.WARNING, msg=msg)
+                    msg = (
+                        f"credentials preface: {cred_slug} not valid to config preface: "
+                        f"{git_config.git_instance_slug}, got {e}, moving on."
+                    )
+                    logger.warning(msg=msg)
 
     return metadata_by_project
 

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -6,7 +6,6 @@ import shutil
 from jira.exceptions import JIRAError
 from requests.exceptions import RequestException
 
-from jf_agent import agent_logging
 from jf_agent.jf_jira import _get_raw_jira_connection
 from jf_agent.jf_jira.jira_download import download_users
 from jf_agent.git import get_git_client, get_nested_repos_from_git, GithubGqlClient


### PR DESCRIPTION
Rework logging in the agent so we have a less specialized `agent_logging` class. To do this, I replaced a lot of the `log_and_print` calls with simple `logger.info` calls, and changed around the handlers in the `agent_logging.configure` function to leverage both a file emitter and an stdout emitter

To make refactoring simplier, I decided to leave in the `log_and_print_error_or_warning` function. This could probably get replaced with individual `logger.warn` and `logger.error` calls, but that is a tedious refactor that I am punting for now

---

The new pattern for logging is documented in the `agent_logging.py` file. The gist is this:

`print()` calls are still used for sensitive customer data, when we need to print to inform them about stuff. This is mainly used in `-m validation`, where we print out debug information based on their API keys and stuff

`logger.*` functions now log to stdout and the log file. `logger.debug` specifically logs to ONLY the log file, and not stdout

---

To test this I ran a full agent download and upload locally with orthogonal networks for jira and git. I tested both github and gitlab adapters, but we are unable to do anything beyond that.

See the compared logs in the Jira Ticket. The standard out is as clean (a little cleaner, imo) as it was before, and the .log file contains jellyfish specific debug information under the `debug` level