### PR TITLE
OJ-30027-add-agent-dev-mode

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -1,5 +1,6 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
+import dotenv
 import gzip
 import logging
 import os
@@ -95,6 +96,12 @@ def main():
         ),
     )
     parser.add_argument(
+        '-e',
+        '--env-file',
+        type=str,
+        help='File path to a .env credentials file. Useful for running the agent in a local developer context',
+    )
+    parser.add_argument(
         '-s', '--since', nargs='?', default=None, help='DEPRECATED -- has no effect'
     )
     parser.add_argument(
@@ -103,6 +110,10 @@ def main():
 
     args = parser.parse_args()
     config = obtain_config(args)
+
+    if args.env_file:
+        dotenv.load_dotenv(args.env_file)
+
     creds = obtain_creds(config)
     agent_logging.configure(config.outdir)
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "dev"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:ca587e0871987c467727b4d7bc6db3b12f85921309fc309364ccefba1c3a0294"
+content_hash = "sha256:5e29bf505b3bac808ed2585af4050fd0e2df1c8a9eb5064f79208ad292c75c3e"
 
 [[package]]
 name = "appdirs"
@@ -491,6 +491,16 @@ dependencies = [
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.0"
+requires_python = ">=3.8"
+summary = "Read key-value pairs from a .env file and set them as environment variables"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "black~=19.10b0",
     "click~=8.0.4",
     "requests>=2.31.0",
+    "python-dotenv>=1.0.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Working with JF Ingest locally and Agent is pretty burdensome, because you have to recreate the docker image everytime you change a dependency change (jf_ingest). To speed up dev time/quality of life, I think it makes sense to expose running the `main.py` function directly. You can already do this, but we're missing some vital logic to ingest your creds file. In this PR, I'm adding a dependency and program argument 

I have updated the proper documentation, showing you how to use this new command [here](https://jelly-ai.atlassian.net/wiki/spaces/JEL/pages/2963210264/Working+with+Jellyfish+Ingest#Working-with-JF-Ingest-in-Agent)