### PR TITLE
OJ-30416-filter-by-empty-str-before-percent-sign

### DIFF
--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -910,7 +910,8 @@ def _search_all_users(jira_connection, gdpr_active):
     start_at = 0
 
     # different jira versions / different times, the way to list all users has changed. Try a few.
-    for q in [None, '', '%', '@']:
+    for q in [None, '', '""', '%', '@']:
+        logger.debug(f'Attempting wild card search with {q}')
         # iterate through pages of results
         while True:
             users = _search_users(
@@ -926,6 +927,7 @@ def _search_all_users(jira_connection, gdpr_active):
 
         # found users; no need to try other query techniques
         if jira_users:
+            logger.debug(f'Found {len(jira_users.keys())} users')
             return list(jira_users.values())
 
     # no users found


### PR DESCRIPTION
## Description

For a new Agent client we are having trouble getting _all_ their user data. This is happening because the way we guess at what wildcard will work for a specific jira server involves checking against the potential wildcard `%` which **is not** a wildcard character in this particular customers Jira Server. Since `%` is such an uncommon character in a username/email we typically would find no results and move on to the next wild card to try. In this instnace, however, this is one singular user with a `%` character in their first name. When we attempt to grab all users, we end up only grabbing that user#285 

To resolve this, I introduced a `""` wild card search before the `%` search. According to curl examples provided by our client, this should fetch all of their users