### PR TITLE
[SECTEAM-905] Add support for endor as a SCA tool

### DIFF
--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -4,6 +4,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch: {}
 jobs:
   scan:
     permissions:
@@ -15,10 +16,6 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
-    - name: Install pdm
-      run: pip install --user pdm
-    - name: Convert pdm.lock to requirements.txt
-      run: pdm export -o requirements.txt 
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.1

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -1,9 +1,9 @@
 name: Endor Labs Dependency Scan
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 jobs:
   scan:
     permissions:

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -17,8 +17,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install pdm
       run: pip install --user pdm
-    - name: Install Dependencies
-      run: pdm sync
+    - name: Convert pdm.lock to requirements.txt
+      run: pdm export -o requirements.txt 
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.1

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -20,7 +20,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.1
       with:
-        namespace: "jellyfish-poc" # Replace with your Endor Labs tenant namespace
+        namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
         scan_secrets: false
         pr: true
@@ -30,7 +30,7 @@ jobs:
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       uses: endorlabs/github-action@v1.1.1
       with:
-        namespace: "jellyfish-poc" # Replace with your Endor Labs tenant namespace
+        namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
         scan_secrets: false
         pr: false

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -1,0 +1,35 @@
+name: Endor Labs Dependency Scan
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  scan:
+    permissions:
+      contents: read # Used to check out a private repository
+      id-token: write # Used for keyless authentication with Endor Labs
+      issues: write # Required to automatically comment on PRs for new policy violations
+      pull-requests: write # Required to automatically comment on PRs for new policy violations
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Endor Labs Scan Pull Request
+      if: github.event_name == 'pull_request'
+      uses: endorlabs/github-action@v1.1.1
+      with:
+        namespace: "jellyfish-poc" # Replace with your Endor Labs tenant namespace
+        scan_dependencies: true
+        scan_secrets: false
+        pr: true
+        pr_baseline: "master"
+        github_token: ${{ secrets.GITHUB_TOKEN }} # Required for PR comments on new policy violations
+    - name: Endor Labs Scan Push to main
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+      uses: endorlabs/github-action@v1.1.1
+      with:
+        namespace: "jellyfish-poc" # Replace with your Endor Labs tenant namespace
+        scan_dependencies: true
+        scan_secrets: false
+        pr: false

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
+    - name: Install pdm
+      run: pip install --user pdm
+    - name: Install Dependencies
+      run: pdm sync
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.1


### PR DESCRIPTION
This PR adds support for a new tool we want to use for software composition analysis (that will replace Snyk). This adds two modes:

1. A PR-time scanning mode which determines what changed relative to master. As of now this does not block PRs or even post comments. However, it provides the framework to do so in the future.
2. A monitor-style job that runs every time new content is pushed to master, which creates a bill-of-materials and sends to our Endor labs tenant that we can use to track dependencies and vulnerabilities.

Scans take around 2 minutes to complete, and run in parallel with other jobs, so merging this should be a non-issue.