### PR TITLE
[OJ-30980] Move validate run mode to use jf_ingest validation methods

### DIFF
--- a/jf_agent/__init__.py
+++ b/jf_agent/__init__.py
@@ -1,4 +1,3 @@
-import sys
 import gzip
 import json
 import jsonstreams
@@ -18,10 +17,6 @@ VALID_RUN_MODES = (
     'print_all_jira_fields',
     'print_apparently_missing_git_repos',
 )
-
-
-class BadConfigException(Exception):
-    pass
 
 
 def write_file(outdir, filename_prefix, compress, results):

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -7,8 +7,13 @@ from typing import List
 import urllib3
 import yaml
 
-from jf_agent import VALID_RUN_MODES, BadConfigException
+from jf_agent import VALID_RUN_MODES
+from jf_agent.exception import BadConfigException
 from jf_ingest import logging_helper
+from jf_ingest.jf_jira import JiraIngestionConfig
+from jf_ingest.jf_jira.auth import JiraAuthConfig
+
+from jf_agent.util import get_company_info
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +294,70 @@ def _get_git_config_from_yaml(yaml_config) -> List[GitConfig]:
 
 
 git_providers = ['bitbucket_server', 'bitbucket_cloud', 'github', 'gitlab']
+
+
+def get_jira_ingest_config(config: ValidatedConfig, creds) -> JiraIngestionConfig:
+    """
+    Handles converting our agent config to the jf_ingest JiraIngestionConfig
+    shared dataclass.
+    """
+
+    company_info = get_company_info(config,creds)
+
+    company_slug = company_info.get('company_slug')
+
+
+    if config.jira_url and (
+            (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
+    ):
+        if creds.jira_username and creds.jira_password:
+            auth_config = JiraAuthConfig(
+                company_slug=company_slug,
+                url=config.jira_url,
+                user=creds.jira_username,
+                password=creds.jira_password,
+                bypass_ssl_verification=config.skip_ssl_verification
+            )
+        else:
+            auth_config = JiraAuthConfig(
+                company_slug=company_slug,
+                url=config.jira_url,
+                personal_access_token=creds.jira_bearer_token,
+                bypass_ssl_verification=config.skip_ssl_verification
+
+            )
+    else:
+        raise BadConfigException("Cannot find jira credentials! Skipping auth config.")
+
+    ingestion_config = JiraIngestionConfig(
+        auth_config=auth_config,
+        gdpr_active=config.jira_gdpr_active,
+        exclude_fields=config.jira_exclude_fields,
+        include_fields=config.jira_include_fields,
+        required_email_domains=config.jira_required_email_domains,
+        is_email_required=config.jira_is_email_required,
+        include_projects=config.jira_include_projects,
+        exclude_projects=config.jira_exclude_projects,
+        include_project_categories=config.jira_include_project_categories,
+        exclude_project_categories=config.jira_exclude_project_categories,
+        download_sprints=config.jira_download_sprints,
+        download_worklogs=config.jira_download_worklogs,
+        s3_bucket=None,
+        s3_path=None,
+        upload_to_s3=False,
+        local_file_path=None,
+        company_slug=company_slug,
+        force_search_users_by_letter=False,
+        search_users_by_letter_email_domain=False,
+        earliest_issue_dt=None,
+        issue_download_concurrent_threads=True,
+        issue_jql=None,
+        jellyfish_issue_metadata={},
+        jellyfish_project_ids_to_keys={},
+        work_logs_pull_from=None
+    )
+
+    return ingestion_config
 
 
 def _get_git_config(git_config, git_provider_override=None, multiple=False) -> GitConfig:

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -117,7 +117,7 @@ def obtain_config(args) -> ValidatedConfig:
     run_mode_includes_send = run_mode in ('download_and_send', 'send_only')
     run_mode_is_print_all_jira_fields = run_mode == 'print_all_jira_fields'
     run_mode_is_print_apparently_missing_git_repos = (
-        run_mode == 'print_apparently_missing_git_repos'
+            run_mode == 'print_apparently_missing_git_repos'
     )
 
     debug_http_requests = args.debug_requests
@@ -306,26 +306,25 @@ def get_jira_ingest_config(config: ValidatedConfig, creds) -> JiraIngestionConfi
 
     company_slug = company_info.get('company_slug')
 
+    if not config.jira_url:
+        raise BadConfigException("No Jira URL in config!")
 
-    if config.jira_url and (
-            (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
-    ):
-        if creds.jira_username and creds.jira_password:
-            auth_config = JiraAuthConfig(
-                company_slug=company_slug,
-                url=config.jira_url,
-                user=creds.jira_username,
-                password=creds.jira_password,
-                bypass_ssl_verification=config.skip_ssl_verification
-            )
-        else:
-            auth_config = JiraAuthConfig(
-                company_slug=company_slug,
-                url=config.jira_url,
-                personal_access_token=creds.jira_bearer_token,
-                bypass_ssl_verification=config.skip_ssl_verification
+    if creds.jira_username and creds.jira_password:
+        auth_config = JiraAuthConfig(
+            company_slug=company_slug,
+            url=config.jira_url,
+            user=creds.jira_username,
+            password=creds.jira_password,
+            bypass_ssl_verification=config.skip_ssl_verification
+        )
+    elif creds.jira_bearer_token:
+        auth_config = JiraAuthConfig(
+            company_slug=company_slug,
+            url=config.jira_url,
+            personal_access_token=creds.jira_bearer_token,
+            bypass_ssl_verification=config.skip_ssl_verification
 
-            )
+        )
     else:
         raise BadConfigException("Cannot find jira credentials!")
 

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -327,7 +327,7 @@ def get_jira_ingest_config(config: ValidatedConfig, creds) -> JiraIngestionConfi
 
             )
     else:
-        raise BadConfigException("Cannot find jira credentials! Skipping auth config.")
+        raise BadConfigException("Cannot find jira credentials!")
 
     ingestion_config = JiraIngestionConfig(
         auth_config=auth_config,

--- a/jf_agent/exception.py
+++ b/jf_agent/exception.py
@@ -1,0 +1,2 @@
+class BadConfigException(Exception):
+    pass

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -37,9 +37,7 @@ from jf_agent.jf_jira import (
 from jf_agent.session import retry_session
 
 from jf_agent.validation import (
-    validate_jira,
-    validate_git,
-    validate_memory,
+    full_validate,
     validate_num_repos,
     ProjectMetadata,
 )
@@ -131,28 +129,7 @@ def main():
     success = True
 
     if config.run_mode == 'validate':
-        logger.info('Validating configuration...')
-
-        # Check for Jira credentials
-        if config.jira_url and (
-            (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
-        ):
-            validate_jira(config, creds)
-        else:
-            logger.info("\nNo Jira URL or credentials provided, skipping Jira validation...")
-
-        # Check for Git configs
-        if config.git_configs:
-            validate_git(config, creds)
-        else:
-            logger.info("\nNo Git configs provided, skipping Git validation...")
-
-        # Finally, display memory usage statistics.
-        validate_memory()
-
-        logger.info("\nDone")
-
-        return True
+        full_validate(config, creds)
 
     elif config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file

--- a/jf_agent/util.py
+++ b/jf_agent/util.py
@@ -1,5 +1,11 @@
 from typing import Any, List
 from itertools import islice
+import requests
+
+from jf_agent.exception import BadConfigException
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 def split(lst: List[Any], n: int) -> List[List[Any]]:
@@ -19,3 +25,22 @@ def batched(iterable, n: int):
     it = iter(iterable)
     while (batch := tuple(islice(it, n))):
         yield batch
+
+
+def get_company_info(config, creds) -> dict:
+    base_url = config.jellyfish_api_base
+    resp = requests.get(
+        f'{base_url}/endpoints/agent/company',
+        headers={'Jellyfish-API-Token': creds.jellyfish_api_token},
+    )
+
+    if not resp.ok:
+        logger.error(
+            f"ERROR: Couldn't get company info from {base_url}/agent/company "
+            f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
+        )
+        raise BadConfigException()
+
+    company_info = resp.json()
+
+    return company_info

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -40,14 +40,32 @@ def full_validate(config, creds):
     if config.jira_url and (
             (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
     ):
-        ingest_config = get_jira_ingest_config(config, creds)
-        validate_jira(ingest_config)
+        try:
+            ingest_config = get_jira_ingest_config(config, creds)
+            validate_jira(ingest_config)
+
+        # Probably few cases that we would hit an exception here, but we want to catch them if there are any
+        # We will continue to validate git but will indicate Jira config failed.
+        except Exception as e:
+            print(f"Failed to validate Jira due to exception of type {e.__class__.__name__}!")
+
+            # Printing this to stdout rather than logger in case the exception has any sensitive info.
+            print(e)
+
     else:
         logger.info("\nNo Jira URL or credentials provided, skipping Jira validation...")
 
     # Check for Git configs
     if config.git_configs:
-        validate_git(config, creds)
+        try:
+            git_success = validate_git(config, creds)
+        except Exception as e:
+            print(f"Failed to validate Git due to exception of type {e.__class__.__name__}!")
+
+            # Printing this to stdout rather than logger in case the exception has any sensitive info.
+            print(e)
+
+
     else:
         logger.info("\nNo Git configs provided, skipping Git validation...")
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:a4fe92c67c0d4268f733fbf0cbd586d5ba02b039ac345caaf8e24ee31b91a910"
+content_hash = "sha256:c3e71d22b46f824d2d16eb4c159fc9a3efd41aedf37ff6fdf9e1784408de86e2"
 
 [[package]]
 name = "appdirs"
@@ -690,16 +690,6 @@ dependencies = [
 ]
 files = [
     {file = "stashy-0.7.tar.gz", hash = "sha256:9965aa18509b7576bbd4b068962d9a9a4828cec8ce22ee5a365ddbcebffa09f5"},
-]
-
-[[package]]
-name = "structlog"
-version = "23.2.0"
-requires_python = ">=3.8"
-summary = "Structured Logging for Python"
-files = [
-    {file = "structlog-23.2.0-py3-none-any.whl", hash = "sha256:16a167e87b9fa7fae9a972d5d12805ef90e04857a93eba479d4be3801a6a1482"},
-    {file = "structlog-23.2.0.tar.gz", hash = "sha256:334666b94707f89dbc4c81a22a8ccd34449f0201d5b1ee097a030b577fa8c858"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:c3e71d22b46f824d2d16eb4c159fc9a3efd41aedf37ff6fdf9e1784408de86e2"
+content_hash = "sha256:027fa403ff096a54190b82bac6fca57574d38bec1b21c414d3b236710c32a08a"
 
 [[package]]
 name = "appdirs"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:027fa403ff096a54190b82bac6fca57574d38bec1b21c414d3b236710c32a08a"
+content_hash = "sha256:9c2d576ffed3abd5e0401f1efde2ce356de941c3aaea9693cda1072816dfcabf"
 
 [[package]]
 name = "appdirs"
@@ -290,7 +290,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.24"
+version = "0.0.25"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -302,8 +302,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf-ingest-0.0.24.tar.gz", hash = "sha256:dcc13aa36f3b6d4253f2d8dc210542e450faf7d492bd0006c2dc9c803291d739"},
-    {file = "jf_ingest-0.0.24-py3-none-any.whl", hash = "sha256:654d86b55f1b9e16e21dc5e2a76e9bb5fba70248478ecfab19cbf797a78ce4c4"},
+    {file = "jf-ingest-0.0.25.tar.gz", hash = "sha256:e5fa430d1557728ac543ad5ae0c80629382158e6e8aa6633a2464b8cb9a2fc6d"},
+    {file = "jf_ingest-0.0.25-py3-none-any.whl", hash = "sha256:bf9a4e5c5f825d394dac2ee3e6c816c6ad81a4b6c94e991dc1cdca51420ed77b"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "dev"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:dc1a788b6d16cc93e1d2eb131a0cc23e59c13ab5ed57e71ac2b5977b4c49957d"
+strategy = ["cross_platform"]
+lock_version = "4.4"
+content_hash = "sha256:a4fe92c67c0d4268f733fbf0cbd586d5ba02b039ac345caaf8e24ee31b91a910"
 
 [[package]]
 name = "appdirs"
@@ -291,7 +290,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.10"
+version = "0.0.24"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -299,10 +298,12 @@ dependencies = [
     "psutil>=5.9.6",
     "pytz>=2023.3.post1",
     "requests-mock==1.11.0",
+    "requests>=2.31.0",
+    "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf-ingest-0.0.10.tar.gz", hash = "sha256:9584feba05c6e51cb0fd61ae6ca1f40d4f30aca46ce97d42fc5861647e110af7"},
-    {file = "jf_ingest-0.0.10-py3-none-any.whl", hash = "sha256:38f6c5615854f868caf565ef9d7000a9d321042d52b27fcfae237b5d0e16acc5"},
+    {file = "jf-ingest-0.0.24.tar.gz", hash = "sha256:dcc13aa36f3b6d4253f2d8dc210542e450faf7d492bd0006c2dc9c803291d739"},
+    {file = "jf_ingest-0.0.24-py3-none-any.whl", hash = "sha256:654d86b55f1b9e16e21dc5e2a76e9bb5fba70248478ecfab19cbf797a78ce4c4"},
 ]
 
 [[package]]
@@ -689,6 +690,16 @@ dependencies = [
 ]
 files = [
     {file = "stashy-0.7.tar.gz", hash = "sha256:9965aa18509b7576bbd4b068962d9a9a4828cec8ce22ee5a365ddbcebffa09f5"},
+]
+
+[[package]]
+name = "structlog"
+version = "23.2.0"
+requires_python = ">=3.8"
+summary = "Structured Logging for Python"
+files = [
+    {file = "structlog-23.2.0-py3-none-any.whl", hash = "sha256:16a167e87b9fa7fae9a972d5d12805ef90e04857a93eba479d4be3801a6a1482"},
+    {file = "structlog-23.2.0.tar.gz", hash = "sha256:334666b94707f89dbc4c81a22a8ccd34449f0201d5b1ee097a030b577fa8c858"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ dependencies = [
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
     "jf-ingest>=0.0.24",
-    "structlog>=23.2.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.24",
+    "jf-ingest==0.0.25",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.10",
+    "jf-ingest>=0.0.24",
+    "structlog>=23.2.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest>=0.0.24",
+    "jf-ingest==0.0.24",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
A few medium-sized changes to agent code:
- Cuts over the validation run mode to use the validate_function that has been moved into jf_ingest.
- Adds a helper function, `get_jira_ingest_config`, that will take in the agent config and credentials and output a JiraIngestionConfig as defined in jf_ingest.
- Moves around some logic, including the get_company_info call, which is now encapsulated in it's own function.
- Fixes an issue with validate_memory to use the config file's outdir rather than a hardcoded one.

This will make it easier for us to use the jf_ingest validation code and other parts of jf_ingest Jira code, and will help share this logic to aid debugging.