### PR TITLE
[OJ-30981 Full_validate on every agent run

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -130,8 +130,16 @@ def main():
 
     jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
 
-    if config.run_mode == 'validate':
+    logger.info("Running ingestion healthcheck validation!")
+
+    try:
         full_validate(config, creds, jellyfish_endpoint_info)
+    except Exception as err:
+        logger.error(f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}")
+
+    if config.run_mode == 'validate':
+        # We will now run this on every run, so this is just a catch to make sure the logic flows correctly.
+        pass
 
     elif config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file


### PR DESCRIPTION
This is wrapped in a broad try except, so if anything in it fails it shouldn't bomb out the agent run. 

It does generate a lot of logs, which is partially by design, though I may make these concise and less verbose in the future. They look something like:


```
Running ingestion healthcheck validation!
Validating configuration...

Jira details:
  URL: ... 
  Username: ...
  Password: **********
==> Testing Jira connection...
Authenticating to Jira API at test using the username and password secrets for test of company test
==> Getting Jira version...
Found Jira version as [version]
==> Getting Jira deployment type...
Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
==> Getting Jira permissions...
Found granted permissions as
==> Testing Jira user browsing permissions...
Downloading Users...
Done downloading Users! Found xusers
The agent is aware of x Jira users.
==> Testing Jira project permissions...
The agent has access to projects ['A', 'B', 'C'].

Git details for instance 1/1:
  Instance slug: test
  Provider: github
  Included projects: ['A']
  Included repos: ['B', 'C']
==> Testing Git connection...
  All projects and repositories available to agent:
  -- A
    -- B
    -- C

```
