### PR TITLE
[OJ-31849] Uploading logs along with validation to aid debugging

### DIFF
--- a/jf_agent/util.py
+++ b/jf_agent/util.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import Any, List
 from itertools import islice
 import requests
@@ -5,6 +6,10 @@ import requests
 from jf_agent.exception import BadConfigException
 
 import logging
+
+from jf_agent.session import retry_session
+from jf_ingest import diagnostics, logging_helper
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,3 +49,40 @@ def get_company_info(config, creds) -> dict:
     company_info = resp.json()
 
     return company_info
+
+
+def upload_file(filename, path_to_obj, signed_url, config_outdir, local=False):
+    filepath = filename if local else f'{config_outdir}/{filename}'
+
+    total_retries = 5
+    retry_count = 0
+    while total_retries >= retry_count:
+        try:
+            with open(filepath, 'rb') as f:
+                # If successful, returns HTTP status code 204
+                session = retry_session()
+                upload_resp = session.post(
+                    signed_url['url'],
+                    data=signed_url['fields'],
+                    files={'file': (path_to_obj, f)},
+                )
+                upload_resp.raise_for_status()
+                logger.info(f'Successfully uploaded {filename}')
+                return
+        # For large file uploads, we run into intermittent 104 errors where the 'peer' (jellyfish)
+        # will appear to shut down the session connection.
+        # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
+        # Attempt to catch and retry the 104 type error here
+        except requests.exceptions.ConnectionError as e:
+            logging_helper.log_standard_error(
+                logging.WARNING, msg_args=[filename, repr(e)], error_code=3001, exc_info=True,
+            )
+            retry_count += 1
+            # Back off logic
+            sleep(1 * retry_count)
+
+    # If we make it out of the while loop without returning, that means
+    # we failed to upload the file.
+    logging_helper.log_standard_error(
+        logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
+    )


### PR DESCRIPTION
Adds a step to upload the logfile via signed URL, along with healthcheck.json. 

This will add a healthcheck.json field in the output directory of the agent as well, but it will be the same one that we upload earlier in the healthcheck.