### PR TITLE
[OJ-31880] Uploading logs on error state

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -210,7 +210,8 @@ def main():
             # Otherwise we'll send a .fuse_hidden file (temp file)
             diagnostics.close_file()
 
-            # Kills the sys_diag_collector thread
+            # Kills the sys_diag_collector thread.
+            # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
             sys_diag_done_event.set()
             sys_diag_collector.join()
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -202,17 +202,29 @@ def main():
 
             diagnostics.capture_outdir_size(config.outdir)
 
+
+        except Exception as err:
+            logger.error(f"Encountered error during agent run! {err}")
+
+            # We need to close this before we send data
+            # Otherwise we'll send a .fuse_hidden file (temp file)
+            diagnostics.close_file()
+
             # Kills the sys_diag_collector thread
             sys_diag_done_event.set()
             sys_diag_collector.join()
 
-        except Exception as err:
-            logger.error(f"Encountered error during agent run! {err}")
             success &= potentially_send_data(config, creds, successful=False)
+
             return False
 
-        finally:
-            diagnostics.close_file()
+    diagnostics.close_file()
+
+    # Kills the sys_diag_collector thread
+    sys_diag_done_event.set()
+    sys_diag_collector.join()
+
+    diagnostics.close_file()
 
     success &= potentially_send_data(config, creds, successful=True)
 


### PR DESCRIPTION
When the agent fails and is rolled back, we lose the logfile that got us to that point, which is bad because it hides important context. This will run the send_data step after failure, but _without_ the .done file, so we still have the data but we won't use it to actually run anything.