### PR TITLE
[OJ-31903] Upload on Failure or Timeout

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -10,18 +10,18 @@ from collections import namedtuple
 from glob import glob
 from pathlib import Path
 import sys
-from time import sleep
 
 import requests
 import json
+
 
 from jf_agent import (
     agent_logging,
     write_file,
     VALID_RUN_MODES,
     JELLYFISH_API_BASE,
-    BadConfigException,
 )
+from jf_agent.exception import BadConfigException
 from jf_agent.data_manifests.jira.generator import create_manifest as create_jira_manifest
 from jf_agent.data_manifests.git.generator import create_manifests as create_git_manifests
 from jf_agent.data_manifests.manifest import Manifest
@@ -33,14 +33,15 @@ from jf_agent.jf_jira import (
     load_and_dump_jira,
     print_missing_repos_found_by_jira,
 )
-from jf_agent.session import retry_session
+
 from jf_agent.validation import (
-    validate_jira,
-    validate_git,
-    validate_memory,
+    full_validate,
     validate_num_repos,
     ProjectMetadata,
 )
+
+from jf_agent.util import get_company_info, upload_file
+
 from jf_ingest import diagnostics, logging_helper
 
 logger = logging.getLogger(__name__)
@@ -102,53 +103,62 @@ def main():
         help='File path to a .env credentials file. Useful for running the agent in a local developer context',
     )
     parser.add_argument(
+        '-db',
+        '--debug-requests',
+        action='store_true',
+        help='Enable http requests debug logging. WARNING, this is VERY verbose and WILL print out all headers '
+             'and bodies of all requests made by the agent, INCLUDING bearer tokens. Use only to debug errors.')
+    parser.add_argument(
         '-s', '--since', nargs='?', default=None, help='DEPRECATED -- has no effect'
     )
     parser.add_argument(
         '-u', '--until', nargs='?', default=None, help='DEPRECATED -- has no effect'
     )
+    parser.add_argument(
+        '-f',
+        '--from-failure',
+        action='store_true',
+        help='To be run with -m send-only. Indicates that we have had a failure '
+             'but we will try to send the data anyways, but will *not* try to redownload.')
+
 
     args = parser.parse_args()
+    print(args.from_failure)
     config = obtain_config(args)
 
     if args.env_file:
         dotenv.load_dotenv(args.env_file)
 
     creds = obtain_creds(config)
-    agent_logging.configure(config.outdir)
+    agent_logging.configure(config.outdir, config.debug_http_requests)
 
     success = True
 
+    jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
+
+    logger.info("Running ingestion healthcheck validation!")
+
+    error_and_timeout_free = True
+
+
     if config.run_mode == 'validate':
-        logger.info('Validating configuration...')
-
-        # Check for Jira credentials
-        if config.jira_url and (
-            (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
-        ):
-            validate_jira(config, creds)
-        else:
-            logger.info("\nNo Jira URL or credentials provided, skipping Jira validation...")
-
-        # Check for Git configs
-        if config.git_configs:
-            validate_git(config, creds)
-        else:
-            logger.info("\nNo Git configs provided, skipping Git validation...")
-
-        # Finally, display memory usage statistics.
-        validate_memory()
-
-        logger.info("\nDone")
-
-        return True
+        try:
+            full_validate(config, creds, jellyfish_endpoint_info)
+        except Exception as err:
+            logger.error(f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}")
 
     elif config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file
         pass
 
+    elif args.from_failure:
+        error_and_timeout_free = False
+
     else:
-        jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
+        try:
+            full_validate(config, creds, jellyfish_endpoint_info)
+        except Exception as err:
+            logger.error(f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}")
 
         try:
             if jellyfish_endpoint_info.jf_options.get('validate_num_repos', False):
@@ -172,6 +182,8 @@ def main():
             diagnostics.capture_run_args(
                 args.mode, args.config_file, config.outdir, args.prev_output_dir
             )
+            print(1/0)
+
             try:
                 generate_manifests(
                     config=config, creds=creds, jellyfish_endpoint_info=jellyfish_endpoint_info
@@ -207,16 +219,39 @@ def main():
                 )
 
             diagnostics.capture_outdir_size(config.outdir)
+            diagnostics.close_file()
 
             # Kills the sys_diag_collector thread
             sys_diag_done_event.set()
             sys_diag_collector.join()
 
-        finally:
+
+        except Exception as err:
+            logger.error(f"Encountered error during agent run! {err}")
+
+            # We need to close this before we send data
+            # Otherwise we'll send a .fuse_hidden file (temp file)
             diagnostics.close_file()
 
+            # Kills the sys_diag_collector thread.
+            # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
+            sys_diag_done_event.set()
+            sys_diag_collector.join()
+
+            #success &= potentially_send_data(config, creds, successful=False)
+
+            return False
+
+    success &= potentially_send_data(config, creds, successful=error_and_timeout_free)
+
+    logger.info('Done!')
+
+    return success
+
+
+def potentially_send_data(config, creds, successful=True) -> bool:
     if config.run_mode_includes_send:
-        success &= send_data(config, creds)
+        successful &= send_data(config, creds, successful)
     else:
         logger.info(
             f'\nSkipping send_data because run_mode is "{config.run_mode}"\n'
@@ -224,10 +259,7 @@ def main():
             f'To send this data to Jellyfish, use "-m send_only -od {config.outdir}"'
         )
 
-    logger.info('Done!')
-
-    return success
-
+    return successful
 
 UserProvidedCreds = namedtuple(
     'UserProvidedCreds',
@@ -407,39 +439,31 @@ def obtain_jellyfish_endpoint_info(config, creds):
 @logging_helper.log_entry_exit(logger)
 def generate_manifests(config, creds, jellyfish_endpoint_info):
     manifests: list[Manifest] = []
-    base_url = config.jellyfish_api_base
-    resp = requests.get(
-        f'{base_url}/endpoints/agent/company',
-        headers={'Jellyfish-API-Token': creds.jellyfish_api_token},
-    )
 
-    if not resp.ok:
-        logger.error(
-            f"ERROR: Couldn't get company info from {base_url}/agent/company "
-            f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
-        )
-        raise BadConfigException()
+    company_info = get_company_info(config,creds)
 
-    company_info = resp.json()
     company_slug = company_info.get('company_slug')
+
+    # temporarily disable Jira manifests
+
     # Create and add Jira Manifest
-    if config.jira_url:
-        logger.info('Attempting to generate Jira Manifest...')
-        try:
-            jira_manifest = create_jira_manifest(
-                company_slug=company_slug, config=config, creds=creds
-            )
-            if jira_manifest:
-                logger.info('Successfully created Jira Manifest')
-                manifests.append(jira_manifest)
-            else:
-                logger.warning('create_jira_manifest returned a None Type.')
-        except Exception as e:
-            logger.debug(
-                f'Error encountered when generating jira manifest. Error: {e}', exc_info=True
-            )
-    else:
-        logger.info('No Jira config detected, skipping Jira manifest generation')
+    # if config.jira_url:
+    #     logger.info('Attempting to generate Jira Manifest...')
+    #     try:
+    #         jira_manifest = create_jira_manifest(
+    #             company_slug=company_slug, config=config, creds=creds
+    #         )
+    #         if jira_manifest:
+    #             logger.info('Successfully created Jira Manifest')
+    #             manifests.append(jira_manifest)
+    #         else:
+    #             logger.warning('create_jira_manifest returned a None Type.')
+    #     except Exception as e:
+    #         logger.debug(
+    #             f'Error encountered when generating jira manifest. Error: {e}', exc_info=True
+    #         )
+    # else:
+    #     logger.info('No Jira config detected, skipping Jira manifest generation')
 
     if config.git_configs:
         try:
@@ -619,7 +643,7 @@ def _download_git_data(
     )
 
 
-def send_data(config, creds):
+def send_data(config, creds, successful=True):
     _, timestamp = os.path.split(config.outdir)
 
     def get_signed_url(files):
@@ -640,48 +664,13 @@ def send_data(config, creds):
 
     def upload_file_from_thread(filename, path_to_obj, signed_url):
         try:
-            upload_file(filename, path_to_obj, signed_url)
+            upload_file(filename, path_to_obj, signed_url, config_outdir=config.outdir)
         except Exception as e:
             thread_exceptions.append(e)
             logging_helper.log_standard_error(
                 logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
             )
 
-    def upload_file(filename, path_to_obj, signed_url, local=False):
-        filepath = filename if local else f'{config.outdir}/{filename}'
-
-        total_retries = 5
-        retry_count = 0
-        while total_retries >= retry_count:
-            try:
-                with open(filepath, 'rb') as f:
-                    # If successful, returns HTTP status code 204
-                    session = retry_session()
-                    upload_resp = session.post(
-                        signed_url['url'],
-                        data=signed_url['fields'],
-                        files={'file': (path_to_obj, f)},
-                    )
-                    upload_resp.raise_for_status()
-                    logger.info(f'Successfully uploaded {filename}')
-                    return
-            # For large file uploads, we run into intermittent 104 errors where the 'peer' (jellyfish)
-            # will appear to shut down the session connection.
-            # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
-            # Attempt to catch and retry the 104 type error here
-            except requests.exceptions.ConnectionError as e:
-                logging_helper.log_standard_error(
-                    logging.WARNING, msg_args=[filename, repr(e)], error_code=3001, exc_info=True,
-                )
-                retry_count += 1
-                # Back off logic
-                sleep(1 * retry_count)
-
-        # If we make it out of the while loop without returning, that means
-        # we failed to upload the file.
-        logging_helper.log_standard_error(
-            logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
-        )
 
     # Compress any not yet compressed files before sending
     for fname in glob(f'{config.outdir}/*.json'):
@@ -725,7 +714,6 @@ def send_data(config, creds):
     for t in threads:
         t.join()
 
-    success = True
     if any(thread_exceptions):
         # Run through exceptions and inject them into the agent log
         for exception in thread_exceptions:
@@ -735,28 +723,28 @@ def send_data(config, creds):
         logger.error(
             'ERROR: not all files uploaded to S3. Files have been saved locally. Once connectivity issues are resolved, try running the Agent in send_only mode.'
         )
-        success = False
+        successful = False
 
     # If sending agent config flag is on, upload config.yml to s3 bucket
     if config.send_agent_config:
         config_file_dict = get_signed_url(['config.yml'])['config.yml']
-        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True)
+        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True, config_outdir=config.outdir)
 
     # Log this information before we upload the log file.
-    logger.info(f'Agent run succeeded: {success}')
+    logger.info(f'Agent run succeeded: {successful}')
 
     # Upload log files as last step before uploading the .done file
     log_file_dict = get_signed_url([agent_logging.LOG_FILE_NAME])[agent_logging.LOG_FILE_NAME]
-    upload_file(agent_logging.LOG_FILE_NAME, log_file_dict['s3_path'], log_file_dict['url'])
+    upload_file(agent_logging.LOG_FILE_NAME, log_file_dict['s3_path'], log_file_dict['url'], config_outdir=config.outdir)
 
-    if success:
+    if successful:
         # creating .done file, only on success
         done_file_path = f'{os.path.join(config.outdir, ".done")}'
         Path(done_file_path).touch()
         done_file_dict = get_signed_url(['.done'])['.done']
-        upload_file('.done', done_file_dict['s3_path'], done_file_dict['url'])
+        upload_file('.done', done_file_dict['s3_path'], done_file_dict['url'], config_outdir=config.outdir)
 
-    return success
+    return successful
 
 
 def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_months):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -10,18 +10,18 @@ from collections import namedtuple
 from glob import glob
 from pathlib import Path
 import sys
+from time import sleep
 
 import requests
 import json
-
 
 from jf_agent import (
     agent_logging,
     write_file,
     VALID_RUN_MODES,
     JELLYFISH_API_BASE,
+    BadConfigException,
 )
-from jf_agent.exception import BadConfigException
 from jf_agent.data_manifests.jira.generator import create_manifest as create_jira_manifest
 from jf_agent.data_manifests.git.generator import create_manifests as create_git_manifests
 from jf_agent.data_manifests.manifest import Manifest
@@ -33,15 +33,14 @@ from jf_agent.jf_jira import (
     load_and_dump_jira,
     print_missing_repos_found_by_jira,
 )
-
+from jf_agent.session import retry_session
 from jf_agent.validation import (
-    full_validate,
+    validate_jira,
+    validate_git,
+    validate_memory,
     validate_num_repos,
     ProjectMetadata,
 )
-
-from jf_agent.util import get_company_info, upload_file
-
 from jf_ingest import diagnostics, logging_helper
 
 logger = logging.getLogger(__name__)
@@ -103,12 +102,6 @@ def main():
         help='File path to a .env credentials file. Useful for running the agent in a local developer context',
     )
     parser.add_argument(
-        '-db',
-        '--debug-requests',
-        action='store_true',
-        help='Enable http requests debug logging. WARNING, this is VERY verbose and WILL print out all headers '
-             'and bodies of all requests made by the agent, INCLUDING bearer tokens. Use only to debug errors.')
-    parser.add_argument(
         '-s', '--since', nargs='?', default=None, help='DEPRECATED -- has no effect'
     )
     parser.add_argument(
@@ -122,28 +115,41 @@ def main():
         dotenv.load_dotenv(args.env_file)
 
     creds = obtain_creds(config)
-    agent_logging.configure(config.outdir, config.debug_http_requests)
+    agent_logging.configure(config.outdir)
 
     success = True
 
-    jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
-
-    logger.info("Running ingestion healthcheck validation!")
-
-    try:
-        full_validate(config, creds, jellyfish_endpoint_info)
-    except Exception as err:
-        logger.error(f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}")
-
     if config.run_mode == 'validate':
-        # We will now run this on every run, so this is just a catch to make sure the logic flows correctly.
-        pass
+        logger.info('Validating configuration...')
+
+        # Check for Jira credentials
+        if config.jira_url and (
+            (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
+        ):
+            validate_jira(config, creds)
+        else:
+            logger.info("\nNo Jira URL or credentials provided, skipping Jira validation...")
+
+        # Check for Git configs
+        if config.git_configs:
+            validate_git(config, creds)
+        else:
+            logger.info("\nNo Git configs provided, skipping Git validation...")
+
+        # Finally, display memory usage statistics.
+        validate_memory()
+
+        logger.info("\nDone")
+
+        return True
 
     elif config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file
         pass
 
     else:
+        jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
+
         try:
             if jellyfish_endpoint_info.jf_options.get('validate_num_repos', False):
                 validate_num_repos(config.git_configs, creds)
@@ -202,41 +208,15 @@ def main():
 
             diagnostics.capture_outdir_size(config.outdir)
 
-
-        except Exception as err:
-            logger.error(f"Encountered error during agent run! {err}")
-
-            # We need to close this before we send data
-            # Otherwise we'll send a .fuse_hidden file (temp file)
-            diagnostics.close_file()
-
-            # Kills the sys_diag_collector thread.
-            # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
+            # Kills the sys_diag_collector thread
             sys_diag_done_event.set()
             sys_diag_collector.join()
 
-            success &= potentially_send_data(config, creds, successful=False)
+        finally:
+            diagnostics.close_file()
 
-            return False
-
-    diagnostics.close_file()
-
-    # Kills the sys_diag_collector thread
-    sys_diag_done_event.set()
-    sys_diag_collector.join()
-
-    diagnostics.close_file()
-
-    success &= potentially_send_data(config, creds, successful=True)
-
-    logger.info('Done!')
-
-    return success
-
-
-def potentially_send_data(config, creds, successful=True) -> bool:
     if config.run_mode_includes_send:
-        successful &= send_data(config, creds, successful)
+        success &= send_data(config, creds)
     else:
         logger.info(
             f'\nSkipping send_data because run_mode is "{config.run_mode}"\n'
@@ -244,7 +224,10 @@ def potentially_send_data(config, creds, successful=True) -> bool:
             f'To send this data to Jellyfish, use "-m send_only -od {config.outdir}"'
         )
 
-    return successful
+    logger.info('Done!')
+
+    return success
+
 
 UserProvidedCreds = namedtuple(
     'UserProvidedCreds',
@@ -424,31 +407,39 @@ def obtain_jellyfish_endpoint_info(config, creds):
 @logging_helper.log_entry_exit(logger)
 def generate_manifests(config, creds, jellyfish_endpoint_info):
     manifests: list[Manifest] = []
+    base_url = config.jellyfish_api_base
+    resp = requests.get(
+        f'{base_url}/endpoints/agent/company',
+        headers={'Jellyfish-API-Token': creds.jellyfish_api_token},
+    )
 
-    company_info = get_company_info(config,creds)
+    if not resp.ok:
+        logger.error(
+            f"ERROR: Couldn't get company info from {base_url}/agent/company "
+            f'using provided JELLYFISH_API_TOKEN (HTTP {resp.status_code})'
+        )
+        raise BadConfigException()
 
+    company_info = resp.json()
     company_slug = company_info.get('company_slug')
-
-    # temporarily disable Jira manifests
-
     # Create and add Jira Manifest
-    # if config.jira_url:
-    #     logger.info('Attempting to generate Jira Manifest...')
-    #     try:
-    #         jira_manifest = create_jira_manifest(
-    #             company_slug=company_slug, config=config, creds=creds
-    #         )
-    #         if jira_manifest:
-    #             logger.info('Successfully created Jira Manifest')
-    #             manifests.append(jira_manifest)
-    #         else:
-    #             logger.warning('create_jira_manifest returned a None Type.')
-    #     except Exception as e:
-    #         logger.debug(
-    #             f'Error encountered when generating jira manifest. Error: {e}', exc_info=True
-    #         )
-    # else:
-    #     logger.info('No Jira config detected, skipping Jira manifest generation')
+    if config.jira_url:
+        logger.info('Attempting to generate Jira Manifest...')
+        try:
+            jira_manifest = create_jira_manifest(
+                company_slug=company_slug, config=config, creds=creds
+            )
+            if jira_manifest:
+                logger.info('Successfully created Jira Manifest')
+                manifests.append(jira_manifest)
+            else:
+                logger.warning('create_jira_manifest returned a None Type.')
+        except Exception as e:
+            logger.debug(
+                f'Error encountered when generating jira manifest. Error: {e}', exc_info=True
+            )
+    else:
+        logger.info('No Jira config detected, skipping Jira manifest generation')
 
     if config.git_configs:
         try:
@@ -628,7 +619,7 @@ def _download_git_data(
     )
 
 
-def send_data(config, creds, successful=True):
+def send_data(config, creds):
     _, timestamp = os.path.split(config.outdir)
 
     def get_signed_url(files):
@@ -649,13 +640,48 @@ def send_data(config, creds, successful=True):
 
     def upload_file_from_thread(filename, path_to_obj, signed_url):
         try:
-            upload_file(filename, path_to_obj, signed_url, config_outdir=config.outdir)
+            upload_file(filename, path_to_obj, signed_url)
         except Exception as e:
             thread_exceptions.append(e)
             logging_helper.log_standard_error(
                 logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
             )
 
+    def upload_file(filename, path_to_obj, signed_url, local=False):
+        filepath = filename if local else f'{config.outdir}/{filename}'
+
+        total_retries = 5
+        retry_count = 0
+        while total_retries >= retry_count:
+            try:
+                with open(filepath, 'rb') as f:
+                    # If successful, returns HTTP status code 204
+                    session = retry_session()
+                    upload_resp = session.post(
+                        signed_url['url'],
+                        data=signed_url['fields'],
+                        files={'file': (path_to_obj, f)},
+                    )
+                    upload_resp.raise_for_status()
+                    logger.info(f'Successfully uploaded {filename}')
+                    return
+            # For large file uploads, we run into intermittent 104 errors where the 'peer' (jellyfish)
+            # will appear to shut down the session connection.
+            # These exceptions ARE NOT handled by the above retry_session retry logic, which handles 500 level errors.
+            # Attempt to catch and retry the 104 type error here
+            except requests.exceptions.ConnectionError as e:
+                logging_helper.log_standard_error(
+                    logging.WARNING, msg_args=[filename, repr(e)], error_code=3001, exc_info=True,
+                )
+                retry_count += 1
+                # Back off logic
+                sleep(1 * retry_count)
+
+        # If we make it out of the while loop without returning, that means
+        # we failed to upload the file.
+        logging_helper.log_standard_error(
+            logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
+        )
 
     # Compress any not yet compressed files before sending
     for fname in glob(f'{config.outdir}/*.json'):
@@ -699,6 +725,7 @@ def send_data(config, creds, successful=True):
     for t in threads:
         t.join()
 
+    success = True
     if any(thread_exceptions):
         # Run through exceptions and inject them into the agent log
         for exception in thread_exceptions:
@@ -708,28 +735,28 @@ def send_data(config, creds, successful=True):
         logger.error(
             'ERROR: not all files uploaded to S3. Files have been saved locally. Once connectivity issues are resolved, try running the Agent in send_only mode.'
         )
-        successful = False
+        success = False
 
     # If sending agent config flag is on, upload config.yml to s3 bucket
     if config.send_agent_config:
         config_file_dict = get_signed_url(['config.yml'])['config.yml']
-        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True, config_outdir=config.outdir)
+        upload_file('config.yml', config_file_dict['s3_path'], config_file_dict['url'], local=True)
 
     # Log this information before we upload the log file.
-    logger.info(f'Agent run succeeded: {successful}')
+    logger.info(f'Agent run succeeded: {success}')
 
     # Upload log files as last step before uploading the .done file
     log_file_dict = get_signed_url([agent_logging.LOG_FILE_NAME])[agent_logging.LOG_FILE_NAME]
-    upload_file(agent_logging.LOG_FILE_NAME, log_file_dict['s3_path'], log_file_dict['url'], config_outdir=config.outdir)
+    upload_file(agent_logging.LOG_FILE_NAME, log_file_dict['s3_path'], log_file_dict['url'])
 
-    if successful:
+    if success:
         # creating .done file, only on success
         done_file_path = f'{os.path.join(config.outdir, ".done")}'
         Path(done_file_path).touch()
         done_file_dict = get_signed_url(['.done'])['.done']
-        upload_file('.done', done_file_dict['s3_path'], done_file_dict['url'], config_outdir=config.outdir)
+        upload_file('.done', done_file_dict['s3_path'], done_file_dict['url'])
 
-    return successful
+    return success
 
 
 def get_issues_to_scan_from_jellyfish(config, creds, updated_within_last_x_months):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -253,8 +253,6 @@ def main():
             sys_diag_done_event.set()
             sys_diag_collector.join()
 
-            #success &= potentially_send_data(config, creds, successful=False)
-
             return False
 
     success &= potentially_send_data(config, creds, successful=error_and_timeout_free)

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -72,7 +72,6 @@ def main():
     )
     parser.add_argument(
         '-od',
-        '-od',
         '--prev-output-dir',
         nargs='?',
         help='Path to directory containing already-downloaded files',

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -72,6 +72,7 @@ def main():
     )
     parser.add_argument(
         '-od',
+        '-od',
         '--prev-output-dir',
         nargs='?',
         help='Path to directory containing already-downloaded files',
@@ -153,6 +154,14 @@ def main():
 
     elif args.from_failure:
         error_and_timeout_free = False
+        old_files = os.listdir(args.output_basedir)
+        files = sorted(old_files, reverse=True)
+        previous_run_file = files[0]
+        print("Files:", files)
+        print('Previous run file:', previous_run_file)
+
+        config.outdir = os.path.join(args.output_basedir, previous_run_file)
+
 
     else:
         try:

--- a/rollback_on_fail.sh
+++ b/rollback_on_fail.sh
@@ -10,7 +10,7 @@ rollback () {
 echo "checking for time limit override"
 if [[ -v OVERRIDE_TIME_LIMIT ]]; then
 	echo "Time limit override detected, agent will timeout at ${OVERRIDE_TIME_LIMIT}"
-	TIME_LIMIT="${OVERRIDE_TIME_LIMIT}"
+	TIME_LIMIT="${OVERRIDE_TIME_LIMIT}"g c
 else
 	TIME_LIMIT=$(curl -H "Accept: application/json" -H "Content-Type: application/json" -H "Jellyfish-API-Token: $JELLYFISH_API_TOKEN" https://app.jellyfish.co/endpoints/agent/time-limit | jq -r .time_limit_string)
 	TIME_LIMIT="${TIME_LIMIT:-12h}"
@@ -23,5 +23,11 @@ CODE=$?
 
 if [[ $CODE -ne 0 && ! -v ROLLBACK_OVERRIDE ]]; then
     echo "encountered error or timeout, rolling back to stable"
+    timeout --preserve-status "$TIME_LIMIT" python jf_agent/main.py "$@" "-f"
+
+    CODE=$?
+
+    echo $CODE
+
     rollback "$@"
 fi

--- a/rollback_on_fail.sh
+++ b/rollback_on_fail.sh
@@ -10,7 +10,7 @@ rollback () {
 echo "checking for time limit override"
 if [[ -v OVERRIDE_TIME_LIMIT ]]; then
 	echo "Time limit override detected, agent will timeout at ${OVERRIDE_TIME_LIMIT}"
-	TIME_LIMIT="${OVERRIDE_TIME_LIMIT}"g c
+	TIME_LIMIT="${OVERRIDE_TIME_LIMIT}"
 else
 	TIME_LIMIT=$(curl -H "Accept: application/json" -H "Content-Type: application/json" -H "Jellyfish-API-Token: $JELLYFISH_API_TOKEN" https://app.jellyfish.co/endpoints/agent/time-limit | jq -r .time_limit_string)
 	TIME_LIMIT="${TIME_LIMIT:-12h}"

--- a/rollback_on_fail.sh
+++ b/rollback_on_fail.sh
@@ -23,11 +23,10 @@ CODE=$?
 
 if [[ $CODE -ne 0 && ! -v ROLLBACK_OVERRIDE ]]; then
     echo "encountered error or timeout, rolling back to stable"
+
+    echo "Will attempt to upload logs from the failed run, for debugging."
+
     timeout --preserve-status "$TIME_LIMIT" python jf_agent/main.py "$@" "-f"
-
-    CODE=$?
-
-    echo $CODE
 
     rollback "$@"
 fi


### PR DESCRIPTION
A "dead man's switch" of sorts, to allow us to upload logs in the case of _any_ failure, at least, hopefully.

Basically:
- In rollback_on_fail.sh, if we find we've failed, we kick off `main.py` _again_ with the `-f` flag, indicating `from failure`
- This will execute a fun special mode that doesn't download, but just sets the output directory to whatever we find as the last directory in the outdir.
- There's a catch-22 here that I'm trying to patch wherein we don't actually get the logs from _this_ send-only run of the agent, but working on fixing that by adding the old logfile to the curr directory.