### PR TITLE
[OJ-31925] Disabling healthcheck temporarily

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -170,11 +170,6 @@ def main():
         logger.info(f"Mounted old output directory as {config.outdir}, will attempt to send.")
 
     else:
-        try:
-            full_validate(config, creds, jellyfish_endpoint_info)
-            pass
-        except Exception as err:
-            logger.error(f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}")
 
         try:
             if jellyfish_endpoint_info.jf_options.get('validate_num_repos', False):


### PR DESCRIPTION
We're seeing this cause extended runtimes due to excess GitHub calls, disabling until we can optimize.