### PR TITLE
[OJ-32117] Cleanup get_ingest_config Function and Exceptions

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -4,7 +4,7 @@ from datetime import datetime, date
 import json
 import logging
 import os
-from typing import List
+from typing import List, Optional
 import urllib3
 import yaml
 
@@ -309,66 +309,62 @@ def get_ingest_config(config: ValidatedConfig, creds, endpoint_jira_info: dict) 
 
     company_slug = company_info.get('company_slug')
 
-    if not config.jira_url:
-        raise BadConfigException("No Jira URL in config!")
-
-    if (not creds.jira_username and not creds.jira_password) and not creds.jira_bearer_token:
-        raise BadConfigException("Cannot find jira credentials!")
-
-    jira_config: JiraConfig = JiraConfig(
-        company_slug=company_slug,
-        #
-        # Auth Info
-        url=config.jira_url,
-        user=creds.jira_username if creds.jira_username else "",
-        password=creds.jira_password if creds.jira_password else "",
-        bypass_ssl_verification=config.skip_ssl_verification,
-        personal_access_token=creds.jira_bearer_token if creds.jira_bearer_token else "",
-        #
-        # Server Info
-        gdpr_active=config.jira_gdpr_active,
-        #
-        # Fields Info
-        exclude_fields=config.jira_exclude_fields,
-        include_fields=config.jira_include_fields,
-        #
-        # User Info
-        required_email_domains=config.jira_required_email_domains,
-        is_email_required=config.jira_is_email_required,
-        #
-        # Projects Info
-        include_projects=config.jira_include_projects,
-        exclude_projects=config.jira_exclude_projects,
-        include_project_categories=config.jira_include_project_categories,
-        exclude_project_categories=config.jira_exclude_project_categories,
-        #
-        # Sprints/Boards Info
-        download_sprints=config.jira_download_sprints,
-        #
-        # Issues
-        full_redownload=False,
-        earliest_issue_dt=config.jira_earliest_issue_dt
-        if config.jira_earliest_issue_dt
-        else datetime.min,
-        issue_download_concurrent_threads=config.jira_issue_download_concurrent_threads,
-        jellyfish_issue_metadata=IssueMetadata.from_json(
-            endpoint_jira_info.get('issue_metadata_for_jf_ingest', "[]")
-        ),
-        jellyfish_project_ids_to_keys=json.loads(
-            endpoint_jira_info.get('jellyfish_project_ids_to_keys', "{}")
-        ),
-        skip_issues=False,
-        only_issues=False,
-        #
-        # worklogs
-        download_worklogs=config.jira_download_worklogs,
-        # Potentially solidify this with the issues date, or pull from
-        # TODO: Move this in from downloaders
-        work_logs_pull_from=None,  # work_logs_pull_from=self.get_updated_max(),
-        # Jira Ingest Feature Flags
-        # TODO: Generate from launchdarkly
-        feature_flags={},
-    )
+    jira_config: Optional[JiraConfig] = None
+    if config.jira_url and ((creds.jira_username and creds.jira_password) or creds.jira_bearer_token):
+        jira_config: JiraConfig = JiraConfig(
+            company_slug=company_slug,
+            #
+            # Auth Info
+            url=config.jira_url,
+            user=creds.jira_username if creds.jira_username else "",
+            password=creds.jira_password if creds.jira_password else "",
+            bypass_ssl_verification=config.skip_ssl_verification,
+            personal_access_token=creds.jira_bearer_token if creds.jira_bearer_token else "",
+            #
+            # Server Info
+            gdpr_active=config.jira_gdpr_active,
+            #
+            # Fields Info
+            exclude_fields=config.jira_exclude_fields,
+            include_fields=config.jira_include_fields,
+            #
+            # User Info
+            required_email_domains=config.jira_required_email_domains,
+            is_email_required=config.jira_is_email_required,
+            #
+            # Projects Info
+            include_projects=config.jira_include_projects,
+            exclude_projects=config.jira_exclude_projects,
+            include_project_categories=config.jira_include_project_categories,
+            exclude_project_categories=config.jira_exclude_project_categories,
+            #
+            # Sprints/Boards Info
+            download_sprints=config.jira_download_sprints,
+            #
+            # Issues
+            full_redownload=False,
+            earliest_issue_dt=config.jira_earliest_issue_dt
+            if config.jira_earliest_issue_dt
+            else datetime.min,
+            issue_download_concurrent_threads=config.jira_issue_download_concurrent_threads,
+            jellyfish_issue_metadata=IssueMetadata.from_json(
+                endpoint_jira_info.get('issue_metadata_for_jf_ingest', "[]")
+            ),
+            jellyfish_project_ids_to_keys=json.loads(
+                endpoint_jira_info.get('jellyfish_project_ids_to_keys', "{}")
+            ),
+            skip_issues=False,
+            only_issues=False,
+            #
+            # worklogs
+            download_worklogs=config.jira_download_worklogs,
+            # Potentially solidify this with the issues date, or pull from
+            # TODO: Move this in from downloaders
+            work_logs_pull_from=None,  # work_logs_pull_from=self.get_updated_max(),
+            # Jira Ingest Feature Flags
+            # TODO: Generate from launchdarkly
+            feature_flags={},
+        )
 
     ingestion_config = IngestionConfig(
         company_slug=company_slug,

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -580,7 +580,7 @@ def download_data(
 ):
     download_data_status = []
 
-    if config.jira_url:
+    if config.jira_url and ingest_config.jira_config:
         logger.info('Obtained Jira configuration, attempting download...',)
         jira_connection = get_basic_jira_connection(config, creds)
         if config.run_mode_is_print_all_jira_fields:

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -48,24 +48,20 @@ def full_validate(config, creds, jellyfish_endpoint_info) -> IngestionHealthChec
 
     logger.info('Validating configuration...')
 
-    # Check for Jira credentials
-    if config.jira_url and (
-        (creds.jira_username and creds.jira_password) or creds.jira_bearer_token
-    ):
-        try:
-            ingest_config = get_ingest_config(config, creds)
+    try:
+        ingest_config = get_ingest_config(config, creds, jellyfish_endpoint_info.jira_info)
+        if ingest_config.jira_config:
             jira_connection_healthcheck_result = validate_jira(ingest_config.jira_config)
+        else:
+            print("No Jira config found, skipping Jira validation...")
 
-        # Probably few/no cases that we would hit an exception here, but we want to catch them if there are any
-        # We will continue to validate git but will indicate Jira config failed.
-        except Exception as e:
-            print(f"Failed to validate Jira due to exception of type {e.__class__.__name__}!")
+    # Probably few/no cases that we would hit an exception here, but we want to catch them if there are any
+    # We will continue to validate git but will indicate Jira config failed.
+    except Exception as e:
+        print(f"Failed to validate Jira due to exception of type {e.__class__.__name__}!")
 
-            # Printing this to stdout rather than logger in case the exception has any sensitive info.
-            print(e)
-
-    else:
-        logger.info("\nNo Jira URL or credentials provided, skipping Jira validation...")
+        # Printing this to stdout rather than logger in case the exception has any sensitive info.
+        print(e)
 
     # Check for Git configs
     if config.git_configs:

--- a/tests/test_jira_download.py
+++ b/tests/test_jira_download.py
@@ -5,53 +5,8 @@ import json
 from unittest import TestCase
 from jira.resources import Issue as JiraIssue
 
-from jf_agent.jf_jira import get_basic_jira_connection
 from jf_agent.jf_jira.jira_download import get_issues, download_all_issue_metadata
-
-
-def get_connection():
-    mock_server_info_resp = (
-        '{"baseUrl":"https://test-co.atlassian.net","version":"1001.0.0-SNAPSHOT",'
-        '"versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100218,'
-        '"buildDate":"2023-03-16T08:21:48.000-0400","serverTime":"2023-03-17T16:32:45.255-0400",'
-        '"scmInfo":"9999999999999999999999999999999999999999","serverTitle":"JIRA",'
-        '"defaultLocale":{"locale":"en_US"}} '
-    )
-    mock_field_resp = (
-        '[{"id":"statuscategorychangedate","key":"statuscategorychangedate","name":"Status Category '
-        'Changed","custom":false,"orderable":false,"navigable":true,"searchable":true,"clauseNames":['
-        '"statusCategoryChangedDate"],"schema":{"type":"datetime",'
-        '"system":"statuscategorychangedate"}}] '
-    )
-
-    class PartialConfig:
-        jira_url = 'https://test-co.atlassian.net/'
-        skip_ssl_verification = False
-
-    class PartialCreds:
-        jira_password = None
-        jira_username = None
-        jira_bearer_token = 'asdf'
-
-    config = PartialConfig()
-    creds = PartialCreds()
-    # you can test behavior against a live jira instance by setting an email as `jira_username`
-    # and storing a generated token in env and retrieving like so:
-    # creds.jira_bearer_token = os.environ.get('JIRA_TOKEN')
-
-    # https://test-co.atlassian.net/rest/api/2/serverInfo
-    with requests_mock.Mocker() as m:
-        m.register_uri(
-            'GET',
-            'https://test-co.atlassian.net/rest/api/2/serverInfo',
-            text=f'{mock_server_info_resp}',
-        )
-        m.register_uri(
-            'GET', 'https://test-co.atlassian.net/rest/api/2/field', text=f'{mock_field_resp}'
-        )
-        jira_conn = get_basic_jira_connection(config, creds)
-
-    return jira_conn
+from tests.utils import get_connection
 
 
 class TestJiraDownload(TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,61 @@
+import os
+import requests_mock
+import time
+import json
+from unittest import TestCase
+from jira.resources import Issue as JiraIssue
+
+from jf_agent.jf_jira.jira_download import get_issues, download_all_issue_metadata
+from jf_agent.main import download_data
+from tests.utils import get_connection
+
+
+class TestJiraDownload(TestCase):
+
+    start_at = 0
+    max_results = 100
+
+    jira_connection = None
+    mock_response = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.jira_connection = get_connection()
+        with open(
+            f"{os.path.dirname(__file__)}/test_data/jira/test_issues_response.json", "r"
+        ) as issues_file:
+            issue_json = issues_file.read()
+        cls.mock_response = issue_json
+
+    def test_download_data_without_jira_config(self):
+        """
+        Tests that download_data runs successfully without a jira_config
+        """
+
+        class PartialConfig:
+            jira_url = 'https://test-co.atlassian.net/'
+            skip_ssl_verification = False
+            git_configs = []
+
+        class PartialIngestConfig:
+            jira_config = None
+
+        class PartialCreds:
+            jira_password = None
+            jira_username = None
+            jira_bearer_token = 'asdf'
+
+        config = PartialConfig()
+        creds = PartialCreds()
+        ingest_config = PartialIngestConfig()
+
+        statuses = download_data(
+            config,
+            creds,
+            ingest_config=ingest_config,
+            endpoint_jira_info={},
+            endpoint_git_instances_info=None,
+            jf_options=None
+        )
+
+        self.assertEqual(statuses, [])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,48 @@
+import requests_mock
+
+from jf_agent.jf_jira import get_basic_jira_connection
+
+
+def get_connection():
+    mock_server_info_resp = (
+        '{"baseUrl":"https://test-co.atlassian.net","version":"1001.0.0-SNAPSHOT",'
+        '"versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100218,'
+        '"buildDate":"2023-03-16T08:21:48.000-0400","serverTime":"2023-03-17T16:32:45.255-0400",'
+        '"scmInfo":"9999999999999999999999999999999999999999","serverTitle":"JIRA",'
+        '"defaultLocale":{"locale":"en_US"}} '
+    )
+    mock_field_resp = (
+        '[{"id":"statuscategorychangedate","key":"statuscategorychangedate","name":"Status Category '
+        'Changed","custom":false,"orderable":false,"navigable":true,"searchable":true,"clauseNames":['
+        '"statusCategoryChangedDate"],"schema":{"type":"datetime",'
+        '"system":"statuscategorychangedate"}}] '
+    )
+
+    class PartialConfig:
+        jira_url = 'https://test-co.atlassian.net/'
+        skip_ssl_verification = False
+
+    class PartialCreds:
+        jira_password = None
+        jira_username = None
+        jira_bearer_token = 'asdf'
+
+    config = PartialConfig()
+    creds = PartialCreds()
+    # you can test behavior against a live jira instance by setting an email as `jira_username`
+    # and storing a generated token in env and retrieving like so:
+    # creds.jira_bearer_token = os.environ.get('JIRA_TOKEN')
+
+    # https://test-co.atlassian.net/rest/api/2/serverInfo
+    with requests_mock.Mocker() as m:
+        m.register_uri(
+            'GET',
+            'https://test-co.atlassian.net/rest/api/2/serverInfo',
+            text=f'{mock_server_info_resp}',
+        )
+        m.register_uri(
+            'GET', 'https://test-co.atlassian.net/rest/api/2/field', text=f'{mock_field_resp}'
+        )
+        jira_conn = get_basic_jira_connection(config, creds)
+
+    return jira_conn


### PR DESCRIPTION
- Remove failure if Jira URL or credentials don't exist, as some companies use MI for Jira and agent for Git.