### PR TITLE
OJ-32219-move-manifest-logs-to-debugs

### DIFF
--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -127,12 +127,12 @@ def create_manifests(
                     )
                 )
         except UnsupportedGitProvider as e:
-            logger.warning(
+            logger.debug(
                 'Unsupported Git Provider exception encountered. '
                 f'This shouldn\'t affect your agent upload. Error: {e}',
             )
         except Exception as e:
-            logger.warning(
+            logger.debug(
                 'An exception happened when creating manifest. This shouldn\'t affect your agent upload. '
                 f'Exception: {e}',
             )

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -205,7 +205,7 @@ def main():
                     config=config, creds=creds, jellyfish_endpoint_info=jellyfish_endpoint_info
                 )
             except Exception as e:
-                logger.warning(
+                logger.debug(
                     'Exception encountered when trying to generate manifests. '
                     f'This should not affect your agent upload. Exception: {e}',
                 )


### PR DESCRIPTION
Move Manifest generation warning logs to DEBUG, where it will appear only in the log file and not in stdout