### PR TITLE
OJ-32232-bump-jf-ingest-version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:19f822b1d6a183ac8356c7d806a0d6f6f9ef50d9961c30b46f578138e68ea869"
+content_hash = "sha256:cdce98ba6c6038536a08d2a08aad4f2a4ae11fe54457266a2798ae0e7f26daa2"
 
 [[package]]
 name = "appdirs"
@@ -290,7 +290,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.50"
+version = "0.0.51"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -303,8 +303,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf-ingest-0.0.50.tar.gz", hash = "sha256:70a916f96704e10126b1accc51478d5844a7fa0b2299227326fc63033022555c"},
-    {file = "jf_ingest-0.0.50-py3-none-any.whl", hash = "sha256:043d821ccece2d590ab8a864af16e8d9bed5f7a7e06a3ae2c8f47d29a23760e2"},
+    {file = "jf-ingest-0.0.51.tar.gz", hash = "sha256:446a17a4f02c4ef334eb4a56a65debd3a4338fc81311e5cf1c99f20d055a9d44"},
+    {file = "jf_ingest-0.0.51-py3-none-any.whl", hash = "sha256:7d80ae1e8f58d33c9dfe067306bb6800eca1fdd429ec8aba29f51cfcb02082d5"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.50",
+    "jf-ingest==0.0.51",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Bump `jf_ingest` version in Agent. This was tested locally with orthogonal-networks, and this functionality is still hidden behind a config flag 