### PR TITLE
OJ 32624 OJ-32625  add logging queue handler

### DIFF
--- a/jf_agent/__init__.py
+++ b/jf_agent/__init__.py
@@ -9,6 +9,7 @@ from jf_agent.util import batched
 logger = logging.getLogger(__name__)
 
 JELLYFISH_API_BASE = 'https://app.jellyfish.co'
+JELLYFISH_WEBHOOK_BASE = 'https://webhooks.jellyfish.co'
 VALID_RUN_MODES = (
     'validate',
     'download_and_send',

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -75,7 +75,7 @@ class CustomQueueListener(QueueListener):
     _jf_sentinel = -1
 
     def handle(self, record: Union[LogRecord, int]) -> None:
-        if record is self._jf_sentinel:
+        if record == self._jf_sentinel:
             for handler in self.handlers:
                 handler.handle(record)
                 return

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -106,9 +106,8 @@ class CustomQueueHandler(QueueHandler):
         if resp.ok:
             self.messages_to_send = []
             self.last_message_send_time = now
-            if self.create_stream:
+            if self.create_stream and resp.json()['stream_created']:
                 self.create_stream = False
-        return resp.ok
 
     def handle(self, record: Union[logging.LogRecord, int]) -> None:
         now = datetime.now()

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -112,7 +112,7 @@ class CustomQueueHandler(QueueHandler):
     def handle(self, record: Union[logging.LogRecord, int]) -> None:
         now = datetime.now()
 
-        if record is not self._sentinel:
+        if record != self._sentinel:
             msg = _standardize_log_msg(self.format(record))
             self.messages_to_send.append(
                 {
@@ -128,7 +128,7 @@ class CustomQueueHandler(QueueHandler):
             )
 
         if (
-            record is self._sentinel
+            record == self._sentinel
             or len(self.messages_to_send) >= 100
             or now - self.last_message_send_time > timedelta(minutes=5)
         ):

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -125,7 +125,7 @@ class CustomQueueHandler(QueueHandler):
             resp_data = json.loads(resp.read().decode())
             self.messages_to_send = []
             self.last_message_send_time = now
-            if self.create_stream and resp_data.get(['stream_created'], False):
+            if self.create_stream and resp_data.get('stream_created', False):
                 self.create_stream = False
 
     def handle(self, record: Union[logging.LogRecord, int]) -> None:

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -71,6 +71,7 @@ ValidatedConfig = namedtuple(
         'outdir',
         'compress_output_files',
         'jellyfish_api_base',
+        'jellyfish_webhook_base',
         'skip_ssl_verification',
         'send_agent_config',
         'git_max_concurrent',
@@ -107,6 +108,7 @@ def obtain_config(args) -> ValidatedConfig:
         )
 
     jellyfish_api_base = args.jellyfish_api_base
+    jellyfish_webhook_base = args.jellyfish_webhook_base
     config_file_path = args.config_file
 
     run_mode = args.mode
@@ -166,13 +168,17 @@ def obtain_config(args) -> ValidatedConfig:
         missing_required_fields = set(required_jira_fields) - set(jira_include_fields)
         if missing_required_fields:
             logging_helper.log_standard_error(
-                logging.WARNING, msg_args=[list(missing_required_fields)], error_code=2132,
+                logging.WARNING,
+                msg_args=[list(missing_required_fields)],
+                error_code=2132,
             )
     if jira_exclude_fields:
         excluded_required_fields = set(required_jira_fields).intersection(set(jira_exclude_fields))
         if excluded_required_fields:
             logging_helper.log_standard_error(
-                logging.WARNING, msg_args=[list(excluded_required_fields)], error_code=2142,
+                logging.WARNING,
+                msg_args=[list(excluded_required_fields)],
+                error_code=2142,
             )
 
     git_configs: List[GitConfig] = _get_git_config_from_yaml(yaml_config)
@@ -269,6 +275,7 @@ def obtain_config(args) -> ValidatedConfig:
         outdir,
         compress_output_files,
         jellyfish_api_base,
+        jellyfish_webhook_base,
         skip_ssl_verification,
         send_agent_config,
         git_max_concurrent,

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -20,6 +20,7 @@ from jf_agent import (
     write_file,
     VALID_RUN_MODES,
     JELLYFISH_API_BASE,
+    JELLYFISH_WEBHOOK_BASE,
 )
 from jf_agent.exception import BadConfigException
 from jf_agent.data_manifests.jira.generator import create_manifest as create_jira_manifest
@@ -89,6 +90,16 @@ def main():
         ),
     )
     parser.add_argument(
+        '--jellyfish-webhook-base',
+        default=JELLYFISH_WEBHOOK_BASE,
+        help=(
+            f'For Jellyfish developers: override for JELLYFISH_WEBHOOK_BASE (which defaults to {JELLYFISH_WEBHOOK_BASE}) '
+            "-- if you're running the Jellyfish webhook service locally you might use: "
+            "http://localhost:4999 (if running the agent container with --network host) or "
+            "http://172.17.0.1:4999 (if running the agent container with --network bridge)"
+        ),
+    )
+    parser.add_argument(
         '-ius',
         '--for-print-missing-repos-issues-updated-within-last-x-months',
         type=int,
@@ -133,7 +144,12 @@ def main():
         dotenv.load_dotenv(args.env_file)
 
     creds = obtain_creds(config)
-    logging_config = agent_logging.configure(config.outdir, config.debug_http_requests)
+    logging_config = agent_logging.configure(
+        config.outdir,
+        config.jellyfish_webhook_base,
+        creds.jellyfish_api_token,
+        config.debug_http_requests,
+    )
 
     success = True
 

--- a/jf_agent/util.py
+++ b/jf_agent/util.py
@@ -93,25 +93,3 @@ def upload_file(filename, path_to_obj, signed_url, config_outdir, local=False):
         error_code=3000,
         exc_info=True,
     )
-
-
-@contextmanager
-def temp_disable_request_loggers():
-    target_loggers = [
-        "urllib3.util.retry",
-        "urllib3.util",
-        "urllib3",
-        "urllib3.connection",
-        "urllib3.response",
-        "urllib3.connectionpool",
-        "urllib3.poolmanager",
-        "requests",
-    ]
-    for name in target_loggers:
-        logging.getLogger(name).disabled = True
-
-    try:
-        yield
-    finally:
-        for name in target_loggers:
-            logging.getLogger(name).disabled = True

--- a/jf_agent/util.py
+++ b/jf_agent/util.py
@@ -2,6 +2,7 @@ from time import sleep
 from typing import Any, List
 from itertools import islice
 import requests
+from contextlib import contextmanager
 
 from jf_agent.exception import BadConfigException
 
@@ -28,7 +29,7 @@ def batched(iterable, n: int):
     if n < 1:
         raise ValueError('n must be at least one')
     it = iter(iterable)
-    while (batch := tuple(islice(it, n))):
+    while batch := tuple(islice(it, n)):
         yield batch
 
 
@@ -75,7 +76,10 @@ def upload_file(filename, path_to_obj, signed_url, config_outdir, local=False):
         # Attempt to catch and retry the 104 type error here
         except requests.exceptions.ConnectionError as e:
             logging_helper.log_standard_error(
-                logging.WARNING, msg_args=[filename, repr(e)], error_code=3001, exc_info=True,
+                logging.WARNING,
+                msg_args=[filename, repr(e)],
+                error_code=3001,
+                exc_info=True,
             )
             retry_count += 1
             # Back off logic
@@ -84,5 +88,30 @@ def upload_file(filename, path_to_obj, signed_url, config_outdir, local=False):
     # If we make it out of the while loop without returning, that means
     # we failed to upload the file.
     logging_helper.log_standard_error(
-        logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
+        logging.ERROR,
+        msg_args=[filename],
+        error_code=3000,
+        exc_info=True,
     )
+
+
+@contextmanager
+def temp_disable_request_loggers():
+    target_loggers = [
+        "urllib3.util.retry",
+        "urllib3.util",
+        "urllib3",
+        "urllib3.connection",
+        "urllib3.response",
+        "urllib3.connectionpool",
+        "urllib3.poolmanager",
+        "requests",
+    ]
+    for name in target_loggers:
+        logging.getLogger(name).disabled = True
+
+    try:
+        yield
+    finally:
+        for name in target_loggers:
+            logging.getLogger(name).disabled = True


### PR DESCRIPTION
Add a log queue listener and handler to the logging config that will periodically post log messages to Jellyfish to reduce the latency in receiving agent logs.