### PR TITLE
sort the list of logs every time we add an item

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -131,7 +131,10 @@ class CustomQueueHandler(QueueHandler):
                 "POST",
                 self.webhook_path,
                 body=json.dumps(
-                    {'logs': self.messages_to_send, 'create_stream': self.create_stream}
+                    {
+                        'logs': self.messages_to_send,
+                        'create_stream': self.create_stream,
+                    }
                 ),
                 headers=headers,
             )
@@ -173,6 +176,7 @@ class CustomQueueHandler(QueueHandler):
                     'initiated_at': self.initiated_at,
                 }
             )
+            self.messages_to_send.sort(lambda x: x['timestamp'])
 
         if self.post_errors >= self.post_error_threshold:
             self.messages_to_send = []

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -131,10 +131,7 @@ class CustomQueueHandler(QueueHandler):
                 "POST",
                 self.webhook_path,
                 body=json.dumps(
-                    {
-                        'logs': self.messages_to_send,
-                        'create_stream': self.create_stream,
-                    }
+                    {'logs': self.messages_to_send, 'create_stream': self.create_stream}
                 ),
                 headers=headers,
             )


### PR DESCRIPTION
ensure that the list of logs to post is always sorted by timestamp. I am choosing to do this each time that we add a record to the list rather than at post time in the event that there is a race condition that adds a record to the queue while we are preparing to post