### PR TITLE
log during logging setup and teardown

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -28,6 +28,8 @@ e.g., function names, iteration counts
 
 LOG_FILE_NAME = 'jf_agent.log'
 
+logger = logging.getLogger(__name__)
+
 
 # For styling in log files, I think it's best to always use new lines even when we use
 # the special character to ignore them. Leverage always_use_newlines for this
@@ -249,10 +251,14 @@ def configure(
         handlers=config.handlers,
     )
 
+    logger.info('Logging setup complete with handlers for log file, stdout, and streaming.')
+
     return config
 
 
 def close_out(config: AgentLoggingConfig) -> None:
     # send a custom sentinel so the final log batch sends, then stop the listener
+    logger.info('Closing the agent log stream.')
     config.listener.queue.put(-1)
     config.listener.stop()
+    logger.info('Log stream stopped.')


### PR DESCRIPTION
add logging to inform us when the logging config gets setup and torn down. Note that the second log in the `close_out` function: `Log stream stopped.` will not get picked up by the listener and sent to Jellyfish, as the listener is stopped before that statement is made.