### PR TITLE
Oj 33568  upload health test results during full run

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -178,7 +178,9 @@ def main():
 
     elif config.run_mode == 'validate':
         try:
-            full_validate(config, creds, jellyfish_endpoint_info, upload=not config.skip_healthcheck_upload)
+            full_validate(
+                config, creds, jellyfish_endpoint_info, upload=not config.skip_healthcheck_upload
+            )
         except Exception as err:
             logger.error(
                 f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -176,13 +176,21 @@ def main():
 
         logger.info(f"Mounted old output directory as {config.outdir}, will attempt to send.")
 
+    elif config.run_mode == 'validate':
+        try:
+            full_validate(config, creds, jellyfish_endpoint_info, upload=not config.skip_healthcheck_upload)
+        except Exception as err:
+            logger.error(
+                f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"
+            )
+
     elif not config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file
         try:
             # Run Jira validation from JF ingest by default.
-            # Unless in validate mode, temporarily skip Git until we cut the validation over to JF ingest
+            # Temporarily skip Git until we cut the validation over to JF ingest
             logger.info("Running ingestion healthcheck validation!")
-            full_validate(config, creds, jellyfish_endpoint_info, skip_git=config.run_mode != 'validate')
+            full_validate(config, creds, jellyfish_endpoint_info, skip_git=True)
         except Exception as err:
             logger.error(
                 f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -161,19 +161,7 @@ def main():
     # to try to upload failed data.
     error_and_timeout_free = True
 
-    if config.run_mode == 'validate':
-        try:
-            full_validate(config, creds, jellyfish_endpoint_info)
-        except Exception as err:
-            logger.error(
-                f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"
-            )
-
-    elif config.run_mode == 'send_only':
-        # Importantly, don't overwrite the already-existing diagnostics file
-        pass
-
-    elif args.from_failure:
+    if args.from_failure:
         error_and_timeout_free = False
         old_files = os.listdir(args.output_basedir)
         files = sorted(old_files, reverse=True)
@@ -191,7 +179,15 @@ def main():
 
         logger.info(f"Mounted old output directory as {config.outdir}, will attempt to send.")
 
-    else:
+    elif not config.run_mode == 'send_only':
+        # Importantly, don't overwrite the already-existing diagnostics file
+        try:
+            full_validate(config, creds, jellyfish_endpoint_info)
+        except Exception as err:
+            logger.error(
+                f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"
+            )
+
         try:
             if jellyfish_endpoint_info.jf_options.get('validate_num_repos', False):
                 validate_num_repos(config.git_configs, creds)

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -158,7 +158,17 @@ def main():
     # to try to upload failed data.
     error_and_timeout_free = True
 
-    if args.from_failure:
+    if config.run_mode == 'validate':
+        try:
+            full_validate(
+                config, creds, jellyfish_endpoint_info, upload=not config.skip_healthcheck_upload
+            )
+        except Exception as err:
+            logger.error(
+                f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"
+            )
+
+    elif args.from_failure:
         error_and_timeout_free = False
         old_files = os.listdir(args.output_basedir)
         files = sorted(old_files, reverse=True)
@@ -175,16 +185,6 @@ def main():
         config = config._replace(outdir=os.path.join(args.output_basedir, previous_run_file))
 
         logger.info(f"Mounted old output directory as {config.outdir}, will attempt to send.")
-
-    elif config.run_mode == 'validate':
-        try:
-            full_validate(
-                config, creds, jellyfish_endpoint_info, upload=not config.skip_healthcheck_upload
-            )
-        except Exception as err:
-            logger.error(
-                f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"
-            )
 
     elif not config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -182,7 +182,9 @@ def main():
     elif not config.run_mode == 'send_only':
         # Importantly, don't overwrite the already-existing diagnostics file
         try:
-            full_validate(config, creds, jellyfish_endpoint_info)
+            # Run Jira validation from JF ingest by default.
+            # Unless in validate mode, temporarily skip Git until we cut the validation over to JF ingest
+            full_validate(config, creds, jellyfish_endpoint_info, skip_git=config.run_mode != 'validate')
         except Exception as err:
             logger.error(
                 f"Failed to run healthcheck validation due to exception, moving on. Exception: {err}"

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -152,10 +152,7 @@ def main():
     )
 
     success = True
-
     jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
-
-    logger.info("Running ingestion healthcheck validation!")
 
     # This will only get set if --from-failure is passed down, indicating that the run is being re-run from failure
     # to try to upload failed data.
@@ -184,6 +181,7 @@ def main():
         try:
             # Run Jira validation from JF ingest by default.
             # Unless in validate mode, temporarily skip Git until we cut the validation over to JF ingest
+            logger.info("Running ingestion healthcheck validation!")
             full_validate(config, creds, jellyfish_endpoint_info, skip_git=config.run_mode != 'validate')
         except Exception as err:
             logger.error(

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -281,27 +281,18 @@ def submit_health_check_to_jellyfish(jellyfish_api_base: str, jellyfish_api_toke
     """
     Uploads the given IngestionHealthCheckResult to Jellyfish
     """
-
     logger.info(f'Attempting to upload healthcheck result to s3...')
-
     agent_log_filename = 'jf_agent.log'
-
     signed_urls = get_healthcheck_signed_urls(jellyfish_api_base=jellyfish_api_base,
                                               jellyfish_api_token=jellyfish_api_token,
                                               files=[HEALTHCHECK_JSON_FILENAME, agent_log_filename])
 
-
     # Uploading healthcheck.json
-
     healthcheck_signed_url = signed_urls[HEALTHCHECK_JSON_FILENAME]
-
     upload_file(HEALTHCHECK_JSON_FILENAME, healthcheck_signed_url['s3_path'], healthcheck_signed_url['url'], config_outdir=config_outdir)
 
     # Uploading jf_agent.log
-
     logfile_signed_url = signed_urls[agent_log_filename]
-
     upload_file(agent_log_filename, logfile_signed_url['s3_path'], logfile_signed_url['url'], config_outdir=config_outdir)
-
+    
     logger.info(f'Successfully uploaded healthcheck result to s3!')
-

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -44,7 +44,7 @@ class ProjectMetadata:
         return f'project {self.project_name} accessible with {self.valid_creds} containing {self.num_repos} repos'
 
 
-def full_validate(config, creds, jellyfish_endpoint_info, skip_jira: bool = False, skip_git: bool = False) -> IngestionHealthCheckResult:
+def full_validate(config, creds, jellyfish_endpoint_info, skip_jira: bool = False, skip_git: bool = False, upload: bool = True) -> IngestionHealthCheckResult:
     """
     Runs the full validation suite.
     """
@@ -88,7 +88,7 @@ def full_validate(config, creds, jellyfish_endpoint_info, skip_jira: bool = Fals
     # Finally, display memory usage statistics.
     validate_memory(config)
 
-    healthcheck_result: IngestionHealthCheckResult = IngestionHealthCheckResult(ingestion_type=IngestionType.AGENT,
+    healthcheck_result = IngestionHealthCheckResult(ingestion_type=IngestionType.AGENT,
                                                                                 git_connection_healthcheck=git_connection_healthcheck_result,
                                                                                 jira_connection_healthcheck=jira_connection_healthcheck_result)
 
@@ -97,10 +97,10 @@ def full_validate(config, creds, jellyfish_endpoint_info, skip_jira: bool = Fals
     with open(f'{config_outdir}/{HEALTHCHECK_JSON_FILENAME}', 'w') as outfile:
         outfile.write(healthcheck_result.to_json())
 
-    if config.skip_healthcheck_upload:
-        logger.info("skip_healthcheck_upload is set to True, this healthcheck report will NOT be uploaded!")
-    else:
+    if upload:
         submit_health_check_to_jellyfish(config.jellyfish_api_base, creds.jellyfish_api_token, config_outdir)
+    else:
+        logger.info("This healthcheck report will not be uploaded.")
 
     logger.info("\nDone")
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
-lock_version = "4.4"
-content_hash = "sha256:1589f72195d92da9c5eb878e249fdcd658dd5eb064e604f2ac670230d44c42a7"
+lock_version = "4.4.1"
+content_hash = "sha256:c2b493d47fcc0dee789651a5569f3adaf48e478946d0da22feab181f94f6d5e4"
 
 [[package]]
 name = "appdirs"
@@ -290,7 +290,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.56"
+version = "0.0.62"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -303,8 +303,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf-ingest-0.0.56.tar.gz", hash = "sha256:159aeff9effd4f62e3cd5b117e3940dec3572ee1eacb288c07c798d3d0fa8994"},
-    {file = "jf_ingest-0.0.56-py3-none-any.whl", hash = "sha256:47afe2065b2a2882bb978625690c59f0b5889f6a2466ab7b455eca4131a14cd6"},
+    {file = "jf-ingest-0.0.62.tar.gz", hash = "sha256:171fe4a9da7a643f24391487ead1b70fc8375115956dc738316ee241a27a1fee"},
+    {file = "jf_ingest-0.0.62-py3-none-any.whl", hash = "sha256:983b2fa93d9c30647c4c0ec84f835d3258ceeed33306491283b7dd1dd4103d5f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.56",
+    "jf-ingest==0.0.62",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
- always run Jira validation via jf_ingest when in a pull mode
- run git validation if asked for, but not yet through jf_ingest and only when in validate mode
- bump jf_ingest so we can dump the dataclasses safely to json

taking a look at the dev bucket I can see the healthcheck file was uploaded along with the other json files.