### PR TITLE
OJ-34225-string-escape-manifest-generation

### DIFF
--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -164,7 +164,7 @@ class JiraCloudManifestAdapter:
             return False
 
     def get_issues_count_for_project(self, project_id: int) -> int:
-        return self._get_jql_search(jql_search=f"project = {project_id}", max_results=0)['total']
+        return self._get_jql_search(jql_search=f'project = "{project_id}"', max_results=0)['total']
 
     def _get_raw_result(self, url) -> dict:
         response = retry_for_429s(self.jira_connection._session.get, url)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:315e5fee136e157e69cbff48bf4b98dd375de024b9d73255cdd44249c3394cb2"
+content_hash = "sha256:56e9236cc767f70ac2d1c79f91376e201edc06735caee06114cc1dfd18ea7a95"
 
 [[package]]
 name = "appdirs"
@@ -290,10 +290,11 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.64"
+version = "0.0.66"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
+    "PyJWT<2.0",
     "jira<=3.1.1,>=2.0.0",
     "psutil>=5.9.6",
     "python-dateutil>=2.8.2",
@@ -303,8 +304,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf-ingest-0.0.64.tar.gz", hash = "sha256:230f3dc969911030cb479bbfa104505b3d7b286492528067ad151d7629915f64"},
-    {file = "jf_ingest-0.0.64-py3-none-any.whl", hash = "sha256:3f27f430aaaa97454729824cbff2d44094592d302a16046ab16f85d649693dd0"},
+    {file = "jf-ingest-0.0.66.tar.gz", hash = "sha256:94645f0bcbb214e516dadb4905a619a2cad1f730446b8e0b0a14b674f546afb1"},
+    {file = "jf_ingest-0.0.66-py3-none-any.whl", hash = "sha256:8e4378ca120d14889314b8046b442aee1e40202526b7e93f4f7103d1acee7355"},
 ]
 
 [[package]]
@@ -354,28 +355,28 @@ files = [
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
-requires_python = ">=3.6"
+version = "3.1.0"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 summary = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
+    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
 ]
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
+version = "3.1.0"
 extras = ["signedtoken"]
-requires_python = ">=3.6"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 summary = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 dependencies = [
-    "cryptography>=3.0.0",
-    "oauthlib==3.2.2",
-    "pyjwt<3,>=2.0.0",
+    "cryptography",
+    "oauthlib==3.1.0",
+    "pyjwt>=1.0.0",
 ]
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
+    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
 ]
 
 [[package]]
@@ -472,12 +473,11 @@ files = [
 
 [[package]]
 name = "pyjwt"
-version = "2.8.0"
-requires_python = ">=3.7"
+version = "1.7.1"
 summary = "JSON Web Token implementation in Python"
 files = [
-    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
-    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
+    {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
+    {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.64",
+    "jf-ingest==0.0.66",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
String escape Jira Manifest creation (when querying for project counts via JQL), and bump JF Ingest version which does the same string escaping logic for validation