### PR TITLE
OJ-34323-add-skip-saving-local-run-mode-for-jira

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -118,7 +118,16 @@ jira:
   # by email domain, should null-email users be included?  uncomment this 
   # if they shouldn't:
   #
-  # is_email_required = True
+  # is_email_required: True
+
+  # This is a special run mode that allows you to skip saving your JIRA data
+  # locally, and instead continuously submit it via S3. This run mode is good
+  # if you plan to upload a VERY large amount of data (like an initial upload
+  # for a massive company). Please contact your Jellyfish representative to see
+  # if this run configuration is right for you. In general, this flag should NOT
+  # be included, or it should be set as False
+  #
+  # skip_saving_data_locally: True
 
 #############################
 # 3. Git configuration


### PR DESCRIPTION
## Description

Add in an OPTIONAL (opt in) configuration flag that allows you to skip saving JIRA files to the local disc. This is a helpful features for clients who have a large amount of Jira Issues they plan on ingesting, and they do not care about saving the files to their local disc. This feature is only available for customers using `jf_ingest` (which is almost all customers who are running off of latest). This change is made possible because `jf_ingest` uploads all jira data as soon as it's ready, instead of waiting until the end of the agent run to submit data.

## Testing

To test I ran this code with `orthogonal-networks` data with and without the new flag. I verified that with and without the new flag data makes it to our S3 bucket, but WITH the new flag there is no jira data saved locally to disc.

<img width="931" alt="Screenshot 2024-04-05 at 11 29 16 AM" src="https://github.com/Jellyfish-AI/jf_agent/assets/103140978/b24690fd-c94f-4a9e-8e87-758b4499ced7">
<img width="924" alt="Screenshot 2024-04-05 at 11 29 05 AM" src="https://github.com/Jellyfish-AI/jf_agent/assets/103140978/307b7ea9-b877-4138-9a16-54bf492d8f7e">
