### PR TITLE
[OJ-34993] Upgrade jira to 3.1.1

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
-lock_version = "4.4"
-content_hash = "sha256:21eb68c7c463c39251b2af8df0749fd3a10270bf3d8149f8889a27bd249bbc05"
+lock_version = "4.4.1"
+content_hash = "sha256:f48f174fc6cb155fe67658e4303fb70cd1101c64253779b01174ef9cdb115b93"
 
 [[package]]
 name = "appdirs"
@@ -24,6 +24,16 @@ summary = "Classes Without Boilerplate"
 files = [
     {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
     {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.1.1"
+requires_python = ">=3.8"
+summary = "Backport of CPython tarfile module"
+files = [
+    {file = "backports.tarfile-1.1.1-py3-none-any.whl", hash = "sha256:73e0179647803d3726d82e76089d01d8549ceca9bace469953fcb4d97cf2d417"},
+    {file = "backports_tarfile-1.1.1.tar.gz", hash = "sha256:9c2ef9696cb73374f7164e17fc761389393ca76777036f5aad42e8b93fcd8009"},
 ]
 
 [[package]]
@@ -279,6 +289,19 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "7.1.0"
+requires_python = ">=3.8"
+summary = "Read metadata from Python packages"
+dependencies = [
+    "zipp>=0.5",
+]
+files = [
+    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
+    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 requires_python = ">=3.7"
@@ -286,6 +309,55 @@ summary = "brain-dead simple config-ini parsing"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+requires_python = ">=3.8"
+summary = "Utility functions for Python class constructs"
+dependencies = [
+    "more-itertools",
+]
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[[package]]
+name = "jaraco-context"
+version = "5.3.0"
+requires_python = ">=3.8"
+summary = "Useful decorators and context managers"
+dependencies = [
+    "backports-tarfile; python_version < \"3.12\"",
+]
+files = [
+    {file = "jaraco.context-5.3.0-py3-none-any.whl", hash = "sha256:3e16388f7da43d384a1a7cd3452e72e14732ac9fe459678773a3608a812bf266"},
+    {file = "jaraco.context-5.3.0.tar.gz", hash = "sha256:c2f67165ce1f9be20f32f650f25d8edfc1646a8aeee48ae06fb35f90763576d2"},
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.0.1"
+requires_python = ">=3.8"
+summary = "Functools like those found in stdlib"
+dependencies = [
+    "more-itertools",
+]
+files = [
+    {file = "jaraco.functools-4.0.1-py3-none-any.whl", hash = "sha256:3b24ccb921d6b593bdceb56ce14799204f473976e2a9d4b15b04d0f2c2326664"},
+    {file = "jaraco_functools-4.0.1.tar.gz", hash = "sha256:d33fa765374c0611b52f8b3a795f8900869aa88c84769d4d1746cd68fb28c3e8"},
+]
+
+[[package]]
+name = "jeepney"
+version = "0.8.0"
+requires_python = ">=3.7"
+summary = "Low-level, pure Python DBus protocol wrapper."
+files = [
+    {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
+    {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
 ]
 
 [[package]]
@@ -310,21 +382,20 @@ files = [
 
 [[package]]
 name = "jira"
-version = "2.0.0"
+version = "3.1.1"
+requires_python = ">=3.6"
 summary = "Python library for interacting with JIRA via REST APIs."
 dependencies = [
     "defusedxml",
-    "oauthlib[signedtoken]>=1.0.0",
-    "pbr>=3.0.0",
-    "requests-oauthlib>=0.6.1",
+    "keyring",
+    "requests-oauthlib>=1.1.0",
     "requests-toolbelt",
     "requests>=2.10.0",
     "setuptools>=20.10.1",
-    "six>=1.10.0",
 ]
 files = [
-    {file = "jira-2.0.0-py2.py3-none-any.whl", hash = "sha256:9adeead4d5f5a6aff74c630787f8bd2d4b0e154f3a3036641298064e91b2d25d"},
-    {file = "jira-2.0.0.tar.gz", hash = "sha256:e2a94adff98e45b29ded030adc76103eab34fa7d4d57303f211f572bedba0e93"},
+    {file = "jira-3.1.1-py3-none-any.whl", hash = "sha256:200c4d19f8be5ae39da3578597b78e21f3db69520c354be782bee9bd8bf21d09"},
+    {file = "jira-3.1.1.tar.gz", hash = "sha256:e2fde55d04a421c590cb197cf6b2d01176028004387d3e4cedff653dba408238"},
 ]
 
 [[package]]
@@ -338,6 +409,35 @@ dependencies = [
 files = [
     {file = "jsonstreams-0.6.0-py2.py3-none-any.whl", hash = "sha256:b2e609c2bc17eec77fe26dae4d32556ba59dafbbff30c9a4909f2e19fa5bb000"},
     {file = "jsonstreams-0.6.0.tar.gz", hash = "sha256:721cda7391e9415b7b15cebd6cf92fc7f8788ca211eda7d64162a066ee45a72e"},
+]
+
+[[package]]
+name = "keyring"
+version = "25.2.0"
+requires_python = ">=3.8"
+summary = "Store and access your passwords safely."
+dependencies = [
+    "SecretStorage>=3.2; sys_platform == \"linux\"",
+    "importlib-metadata>=4.11.4; python_version < \"3.12\"",
+    "jaraco-classes",
+    "jaraco-context",
+    "jaraco-functools",
+    "jeepney>=0.4.2; sys_platform == \"linux\"",
+    "pywin32-ctypes>=0.2.0; sys_platform == \"win32\"",
+]
+files = [
+    {file = "keyring-25.2.0-py3-none-any.whl", hash = "sha256:19f17d40335444aab84b19a0d16a77ec0758a9c384e3446ae2ed8bd6d53b67a5"},
+    {file = "keyring-25.2.0.tar.gz", hash = "sha256:7045f367268ce42dba44745050164b431e46f6e92f99ef2937dfadaef368d8cf"},
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.2.0"
+requires_python = ">=3.8"
+summary = "More routines for operating on iterables, beyond itertools"
+files = [
+    {file = "more-itertools-10.2.0.tar.gz", hash = "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"},
+    {file = "more_itertools-10.2.0-py3-none-any.whl", hash = "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684"},
 ]
 
 [[package]]
@@ -364,22 +464,6 @@ files = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.1.0"
-extras = ["signedtoken"]
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-summary = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-dependencies = [
-    "cryptography",
-    "oauthlib==3.1.0",
-    "pyjwt>=1.0.0",
-]
-files = [
-    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
-    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
-]
-
-[[package]]
 name = "packaging"
 version = "23.1"
 requires_python = ">=3.7"
@@ -397,16 +481,6 @@ summary = "Utility library for gitignore style pattern matching of file paths."
 files = [
     {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
     {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
-]
-
-[[package]]
-name = "pbr"
-version = "5.11.1"
-requires_python = ">=2.6"
-summary = "Python Build Reasonableness"
-files = [
-    {file = "pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
-    {file = "pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
 ]
 
 [[package]]
@@ -545,6 +619,16 @@ files = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.2"
+requires_python = ">=3.6"
+summary = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+files = [
+    {file = "pywin32-ctypes-0.2.2.tar.gz", hash = "sha256:3426e063bdd5fd4df74a14fa3cf80a0b42845a87e1d1e81f6549f9daec593a60"},
+    {file = "pywin32_ctypes-0.2.2-py3-none-any.whl", hash = "sha256:bf490a1a709baf35d688fe0ecf980ed4de11d2b3e37b51e5442587a75d9957e7"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 requires_python = ">=3.6"
@@ -659,6 +743,20 @@ dependencies = [
 files = [
     {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
     {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+requires_python = ">=3.6"
+summary = "Python bindings to FreeDesktop.org Secret Service API"
+dependencies = [
+    "cryptography>=2.0",
+    "jeepney>=0.6",
+]
+files = [
+    {file = "SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"},
+    {file = "SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"},
 ]
 
 [[package]]
@@ -795,4 +893,14 @@ dependencies = [
 files = [
     {file = "virtualenv-20.24.3-py3-none-any.whl", hash = "sha256:95a6e9398b4967fbcb5fef2acec5efaf9aa4972049d9ae41f95e0972a683fd02"},
     {file = "virtualenv-20.24.3.tar.gz", hash = "sha256:e5c3b4ce817b0b328af041506a2a299418c98747c4b1e68cb7527e74ced23efc"},
+]
+
+[[package]]
+name = "zipp"
+version = "3.18.1"
+requires_python = ">=3.8"
+summary = "Backport of pathlib-compatible object wrapper for zip files"
+files = [
+    {file = "zipp-3.18.1-py3-none-any.whl", hash = "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b"},
+    {file = "zipp-3.18.1.tar.gz", hash = "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ authors = [
 dependencies = [
     "urllib3>=1.26.5",
     "pyyaml>=4.21b",
-    "jira<2.1,>=2.0.0",
+    "jira<4,>=3.1.1",
     "tqdm>=4.66.2",
     "stashy",
     "dateparser",


### PR DESCRIPTION
This PR upgrades `jira` to 3.1.1 since:

1. `jf_ingest` supports that
2. `jellyfish` now runs `jira` 3.1.1
3. This is needed to eventually migrate auth to use solely Atlassian Connect

This should be a pretty safe change given it's already been verified in `jf_ingest` and has been running in `jellyfish` for over a day without any reported issues.

To test this, I ran the agent on orthog's JIRA and GitHub before and after the `jira` upgrade. The output of each is provided below. Notably, no notable differences exist between the two:


## Before the change
```
==> Testing Jira connection...
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for josiah.bruner@jellyfish.co of company orthogonal-networks
==> Getting Jira version...
Found Jira version as 1001.0.0-SNAPSHOT
==> Getting Jira deployment type...
Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
==> Getting Jira permissions...
Found granted permissions as ['DELETE_OWN_WORKLOGS', 'CREATE_ISSUES', 'WORK_ON_ISSUES', 'DELETE_OWN_COMMENTS', 'MODIFY_REPORTER', 'EDIT_ISSUES', 'ADD_COMMENTS', 'EDIT_OWN_COMMENTS', 'ASSIGN_ISSUES', 'BROWSE_PROJECTS', 'EDIT_OWN_WORKLOGS', 'EDIT_ALL_WORKLOGS', 'EDIT_ALL_COMMENTS', 'CLOSE_ISSUES', 'SET_ISSUE_SECURITY', 'SCHEDULE_ISSUES', 'USER_PICKER', 'ADMINISTER_PROJECTS', 'DELETE_ALL_COMMENTS', 'RESOLVE_ISSUES', 'DELETE_ISSUES', 'VIEW_READONLY_WORKFLOW', 'MOVE_ISSUES', 'TRANSITION_ISSUES', 'ASSIGNABLE_USER', 'LINK_ISSUES', 'DELETE_ALL_WORKLOGS']
==> Testing Jira user browsing permissions...
Downloading Users...
Done downloading Users! Found 461 users
We can access 461 Jira users.
==> Testing Jira project permissions...
With provided credentials, the following projects are discoverable: {'OJ'}.
Checking project access.
Testing access for project: "OJ"
With provided credentials, we can access issues, versions, and components within project OJ
Checking access to fields
Checking access to resolutions
Checking access to issue types
Checking access to issue link types
Checking access to priorities
Checking access to boards
Checking access to sprints
. Skipping Git Validation.

Memory & Disk Usage:
  Available memory: 14456.65 MB
  Disk usage for jf_agent/output: 322 GB / 460 GB
  Size of jf_agent/output dir: 24K
Attempting to upload healthcheck result to s3...
Successfully uploaded healthcheck.json
Successfully uploaded jf_agent.log
Successfully uploaded healthcheck result to s3!

Done
Obtained Jira configuration, attempting download...
downloading jira fields... ✓
downloading jira projects... ✓
downloading jira project components... ✓
downloading jira versions... ✓
downloading jira users...  ✓
downloading jira resolutions... ✓
downloading jira issue types...  ✓
downloading jira issue link types... ✓
downloading jira priorities... ✓
downloading jira boards...: 100%|██████████| 1/1 [00:00<00:00,  2.66it/s]
downloading jira sprints: 100%|██████████| 3/3 [00:03<00:00,  1.09s/it]
downloading issue metadata... ✓
downloading jira issues: 100%|██████████| 690/690 [00:04<00:00, 158.33it/s]
downloading jira worklogs...  ✓
downloading jira custom field options... ✓
downloading jira statuses... ✓
downloading jira teams... Starting Git download for 1 provided git configurations
downloading github users... ✓
downloading github projects... ✓
downloading github repos... ✓
downloading commits on branch develop for jellyfish: 1020commits [00:10, 94.42commits/s]
downloading PRs for jellyfish: 384prs [13:30,  2.11s/prs]
:WARN: Exception getting PRs for repo jellyfish: 'NoneType' object is not subscriptable. Skipping...

Skipping send_data because run_mode is "download_only"
You can now inspect the downloaded data in ./output/20240501_145604
To send this data to Jellyfish, use "-m send_only -od ./output/20240501_145604"
Done!
Closing the agent log stream.
Log stream stopped.
```

## After the change
```
==> Testing Jira connection...
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for josiah.bruner@jellyfish.co of company orthogonal-networks
==> Getting Jira version...
Found Jira version as 1001.0.0-SNAPSHOT
==> Getting Jira deployment type...
Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
==> Getting Jira permissions...
Found granted permissions as ['DELETE_OWN_WORKLOGS', 'CREATE_ISSUES', 'WORK_ON_ISSUES', 'DELETE_OWN_COMMENTS', 'MODIFY_REPORTER', 'EDIT_ISSUES', 'ADD_COMMENTS', 'EDIT_OWN_COMMENTS', 'ASSIGN_ISSUES', 'BROWSE_PROJECTS', 'EDIT_OWN_WORKLOGS', 'EDIT_ALL_WORKLOGS', 'EDIT_ALL_COMMENTS', 'CLOSE_ISSUES', 'SET_ISSUE_SECURITY', 'SCHEDULE_ISSUES', 'USER_PICKER', 'DELETE_ALL_COMMENTS', 'ADMINISTER_PROJECTS', 'RESOLVE_ISSUES', 'DELETE_ISSUES', 'VIEW_READONLY_WORKFLOW', 'MOVE_ISSUES', 'ASSIGNABLE_USER', 'TRANSITION_ISSUES', 'LINK_ISSUES', 'DELETE_ALL_WORKLOGS']
==> Testing Jira user browsing permissions...
Downloading Users...
Done downloading Users! Found 461 users
We can access 461 Jira users.
==> Testing Jira project permissions...
With provided credentials, the following projects are discoverable: {'OJ'}.
Checking project access.
Testing access for project: "OJ"
With provided credentials, we can access issues, versions, and components within project OJ
Checking access to fields
Checking access to resolutions
Checking access to issue types
Checking access to issue link types
Checking access to priorities
Checking access to boards
Checking access to sprints
. Skipping Git Validation.

Memory & Disk Usage:
  Available memory: 14403.04 MB
  Disk usage for jf_agent/output: 323 GB / 460 GB
  Size of jf_agent/output dir: 24K
Attempting to upload healthcheck result to s3...
Successfully uploaded healthcheck.json
Successfully uploaded jf_agent.log
Successfully uploaded healthcheck result to s3!

Done
Obtained Jira configuration, attempting download...
downloading jira fields... ✓
downloading jira projects... ✓
downloading jira project components... ✓
downloading jira versions... ✓
downloading jira users...  ✓
downloading jira resolutions... ✓
downloading jira issue types...  ✓
downloading jira issue link types... ✓
downloading jira priorities... ✓
downloading jira boards...: 100%|██████████| 1/1 [00:00<00:00,  2.79it/s]
downloading jira sprints: 100%|██████████| 3/3 [00:03<00:00,  1.08s/it]
downloading issue metadata... ✓
downloading jira issues: 100%|██████████| 691/691 [00:04<00:00, 139.48it/s]
downloading jira worklogs...  ✓
downloading jira custom field options... ✓
downloading jira statuses... ✓
downloading jira teams... Starting Git download for 1 provided git configurations
downloading github users... ✓
downloading github projects... ✓
downloading github repos... [3091] Github rate limit exceeded.  Trying again in 0:18:45.729490...
✓
downloading commits on branch develop for jellyfish: 1022commits [00:07, 128.92commits/s]
downloading PRs for jellyfish: 385prs [11:02,  1.72s/prs]
:WARN: Exception getting PRs for repo jellyfish: 'NoneType' object is not subscriptable. Skipping...

Skipping send_data because run_mode is "download_only"
You can now inspect the downloaded data in ./output/20240501_151911
To send this data to Jellyfish, use "-m send_only -od ./output/20240501_151911"
Done!
Closing the agent log stream.
Log stream stopped.
```
