### PR TITLE
[OJ-35134] bugfix: `jira` version 3.1.1 validates `search_users` params

### DIFF
--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -190,7 +190,9 @@ def download_projects_and_versions(
 
     def project_is_accessible(project_id):
         try:
-            retry_for_status(jira_connection.search_issues, f'project = {project_id}', fields=['id'])
+            retry_for_status(
+                jira_connection.search_issues, f'project = {project_id}', fields=['id']
+            )
             return True
         except JIRAError as e:
             # Handle zombie projects that appear in the project list
@@ -859,7 +861,7 @@ def _search_all_users(jira_connection, gdpr_active):
     start_at = 0
 
     # different jira versions / different times, the way to list all users has changed. Try a few.
-    for q in [None, '', '""', '%', '@']:
+    for q in [' ', '""', '%', '@']:
         logger.debug(f'Attempting wild card search with {q}')
         # iterate through pages of results
         while True:


### PR DESCRIPTION
Fix exception: 

```
 589   │ 2024-05-06 06:19:58,942 MainThread DEBUG jf_agent.jf_jira.jira_download Attempting wild card search with
 590   │ 2024-05-06 06:19:58,942 MainThread ERROR jf_ingest.logging_helper [3002] Failed to download jira data:
 591   │ Either 'user' or 'query' arguments must be specified.
 592   │ 2024-05-06 06:19:58,944 MainThread ERROR jf_ingest.logging_helper Traceback (most recent call last):
 593   │   File "/home/jf_agent/jf_agent/jf_jira/__init__.py", line 141, in load_and_dump_jira
 594   │     download_users(
 595   │   File "/python/pkgs/jf_ingest/diagnostics.py", line 66, in wrapper
 596   │     ret = func(*args, **kwargs)
 597   │   File "/python/pkgs/jf_ingest/logging_helper.py", line 28, in wrapper
 598   │     ret = func(*args, **kwargs)
 599   │   File "/home/jf_agent/jf_agent/jf_jira/jira_download.py", line 37, in download_users
 600   │     jira_users = _search_all_users(jira_connection, gdpr_active)
 601   │   File "/home/jf_agent/jf_agent/jf_jira/jira_download.py", line 866, in _search_all_users
 602   │     users = _search_users(
 603   │   File "/home/jf_agent/jf_agent/jf_jira/jira_download.py", line 950, in _search_users
 604   │     for u in retry_for_429s(
 605   │   File "/python/pkgs/jf_ingest/utils.py", line 137, in retry_for_429s
 606   │     return f(*args, **kwargs)
 607   │   File "/python/pkgs/jira/client.py", line 3187, in search_users
 608   │     raise ValueError("Either 'user' or 'query' arguments must be specified.")
 609   │ ValueError: Either 'user' or 'query' arguments must be specified.
```