### PR TITLE
OJ-35758: rework log handlers to use a smart filter

### DIFF
--- a/jf_agent/__init__.py
+++ b/jf_agent/__init__.py
@@ -6,6 +6,8 @@ import logging
 from itertools import chain
 from jf_agent.util import batched
 
+from jf_ingest import logging_helper
+
 logger = logging.getLogger(__name__)
 
 JELLYFISH_API_BASE = 'https://app.jellyfish.co'
@@ -75,7 +77,9 @@ def download_and_write_streaming(
                             _get_item_by_key(item, addl_info_dict_key),
                         )
                     )
-            logger.debug(f'File: {filepath}, Size: {round(outfile.tell() / 1000000, 1)}MB')
+            logging_helper.send_to_agent_log_file(
+                f'File: {filepath}, Size: {round(outfile.tell() / 1000000, 1)}MB'
+            )
 
         outfile.close()
         batch_num += 1

--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -214,12 +214,6 @@ class AgentConsoleLogFilter(logging.Filter):
         Returns:
             bool: Returns False if jf_ingest.logging_helper.AGENT_LOG_TAG is present and set to True. Returns True on all other records
         """
-        if AGENT_LOG_TAG in record.__dict__:
-            pass
-            # print(f'\n  {record.message} tagged as an agent file log {record.__dict__.get(AGENT_LOG_TAG)}\n')
-        else:
-            pass
-            # print(f'\n  {AGENT_LOG_TAG} not found in {record.__dict__}\n')
         return not record.__dict__.get(AGENT_LOG_TAG, False)
 
 

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -11,6 +11,8 @@ from jf_agent.data_manifests.git.manifest import (
 from jf_agent.data_manifests.git.adapters.github import GithubManifestGenerator
 from jf_agent.data_manifests.manifest import ManifestSource
 
+from jf_ingest import logging_helper
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,7 +57,7 @@ def create_manifests(
         try:
             # If the git config doesn't have a git instance, do not generate a manifest
             if not instance_slug:
-                logger.debug(
+                logging_helper.send_to_agent_log_file(
                     f'Git instance for company {company_slug} was detected as NONE. The manifest for this instance will not be processed or uploaded',
                 )
                 continue
@@ -127,14 +129,16 @@ def create_manifests(
                     )
                 )
         except UnsupportedGitProvider as e:
-            logger.debug(
+            logging_helper.send_to_agent_log_file(
                 'Unsupported Git Provider exception encountered. '
                 f'This shouldn\'t affect your agent upload. Error: {e}',
+                level=logging.ERROR,
             )
         except Exception as e:
-            logger.debug(
+            logging_helper.send_to_agent_log_file(
                 'An exception happened when creating manifest. This shouldn\'t affect your agent upload. '
                 f'Exception: {e}',
+                level=logging.ERROR,
             )
 
     return manifests

--- a/jf_agent/data_manifests/jira/adapter.py
+++ b/jf_agent/data_manifests/jira/adapter.py
@@ -1,11 +1,13 @@
 import json
 import logging
 from dataclasses import dataclass
+import traceback
 from typing import Callable, Generator
 from jf_agent.jf_jira import get_basic_jira_connection
 from jf_agent.jf_jira.jira_download import download_users
 from jira import JIRAError
 
+from jf_ingest import logging_helper
 from jf_ingest.utils import retry_for_status
 
 logger = logging.getLogger(__name__)
@@ -155,12 +157,13 @@ class JiraCloudManifestAdapter:
         except Exception as e:
             # This is unexpected behavior and it should never happen, log the error
             # before returning
-            logger.debug(
+            logging_helper.send_to_agent_log_file(
                 'Unusual exception encountered when testing auth. '
                 'This should not affect agent uploading. '
                 f'JIRAError was expected but the following error was raised: {e}',
-                exc_info=True,
+                level=logging.ERROR,
             )
+            logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
             return False
 
     def get_issues_count_for_project(self, project_id: int) -> int:

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -47,9 +47,9 @@ def load_and_dump(
         )
     except Exception as e:
         logging_helper.send_to_agent_log_file(
-            f'Problem finding scopes for your API key. Error: {e}'
+            f'Problem finding scopes for your API key. Error: {e}', level=logging.ERROR
         )
-        logging_helper.send_to_agent_log_file(traceback.format_exc())
+        logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
     write_file(
         outdir, 'bb_users', compress_output_files, get_users(git_conn, config.git_include_projects),
     )

--- a/jf_agent/git/github.py
+++ b/jf_agent/git/github.py
@@ -1,3 +1,4 @@
+import traceback
 from dateutil import parser
 import logging
 from tqdm import tqdm
@@ -40,13 +41,15 @@ def load_and_dump(
     # Logic to help with debugging the scopes that clients have with their API key
     try:
         scopes = git_conn.get_scopes_of_api_token()
-        logger.debug(
+        logging_helper.send_to_agent_log_file(
             'Attempting to ingest github data with the following '
             f'scopes for {config.git_instance_slug}: {scopes}',
         )
     except Exception as e:
-        logger.debug(f'Problem finding scopes for your API key. Error: {e}', exc_info=True)
-
+        logging_helper.send_to_agent_log_file(
+            f'Problem finding scopes for your API key. Error: {e}'
+        )
+        logging_helper.send_to_agent_log_file(traceback.format_exc())
     write_file(
         outdir, 'bb_users', compress_output_files, get_users(git_conn, config.git_include_projects),
     )

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -239,7 +239,7 @@ class GithubGqlAdapter(GitAdapter):
                                 )
 
                     except Exception as e:
-                        logger.debug(traceback.format_exc())
+                        logging_helper.send_to_agent_log_file(traceback.format_exc())
                         logger.warning(
                             f':WARN: Got exception for branch {branch_name}: {e}. Skipping...'
                         )

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -239,7 +239,9 @@ class GithubGqlAdapter(GitAdapter):
                                 )
 
                     except Exception as e:
-                        logging_helper.send_to_agent_log_file(traceback.format_exc())
+                        logging_helper.send_to_agent_log_file(
+                            traceback.format_exc(), level=logging.ERROR
+                        )
                         logger.warning(
                             f':WARN: Got exception for branch {branch_name}: {e}. Skipping...'
                         )

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -644,7 +644,9 @@ def _download_jira_issues_segment(
     download onto the shared queue.
     '''
     start_at = 0
-    logger.debug(f"Beginning to download jira issues in segment of {len(jira_issue_ids_segment)}")
+    logging_helper.send_to_agent_log_file(
+        f"Beginning to download jira issues in segment of {len(jira_issue_ids_segment)}"
+    )
     try:
         while start_at < len(jira_issue_ids_segment):
             issues, num_apparently_deleted = _download_jira_issues_page(
@@ -828,7 +830,9 @@ def download_teams(jira_connection):
         logger.info('✓')
         return teams
     except Exception as e:
-        logger.debug(f"Could not fetch teams, instead got {e}")
+        logging_helper.send_to_agent_log_file(
+            f"Could not fetch teams, instead got {e}", level=logging.ERROR
+        )
         return ""
 
 
@@ -862,7 +866,7 @@ def _search_all_users(jira_connection, gdpr_active):
 
     # different jira versions / different times, the way to list all users has changed. Try a few.
     for q in [' ', '""', '%', '@']:
-        logger.debug(f'Attempting wild card search with {q}')
+        logging_helper.send_to_agent_log_file(f'Attempting wild card search with {q}')
         # iterate through pages of results
         while True:
             users = _search_users(
@@ -878,7 +882,7 @@ def _search_all_users(jira_connection, gdpr_active):
 
         # found users; no need to try other query techniques
         if jira_users:
-            logger.debug(f'Found {len(jira_users.keys())} users')
+            logging_helper.send_to_agent_log_file(f'Found {len(jira_users.keys())} users')
             return list(jira_users.values())
 
     # no users found

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -166,7 +166,8 @@ def main():
         )
     except Exception as e:
         logging_helper.send_to_agent_log_file(
-            f'Error encountered when attempting to send diagnostic heart beat start (Error: {e})'
+            f'Error encountered when attempting to send diagnostic heart beat start (Error: {e})',
+            level=logging.ERROR,
         )
 
     logger.info(f'Will write output files into {config.outdir}')
@@ -293,7 +294,8 @@ def main():
         )
     except Exception as e:
         logging_helper.send_to_agent_log_file(
-            f'Error encountered when attempting to send the Agent heart beat end marker. Error: {e}'
+            f'Error encountered when attempting to send the Agent heart beat end marker. Error: {e}',
+            level=logging.ERROR,
         )
     agent_logging.close_out(logging_config)
 
@@ -635,7 +637,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                     'This Jira submission will be marked as failed. '
                     f'Error: {e}'
                 )
-                logging_helper.send_to_agent_log_file(traceback.print_exc(), level=logging.ERROR)
+                logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
                 download_data_status.append({'type': 'Jira', 'status': 'failed'})
         else:
             download_data_status.append(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -528,9 +528,10 @@ def generate_manifests(config, creds, jellyfish_endpoint_info):
                 endpoint_git_instances_info=jellyfish_endpoint_info.git_instance_info,
             )
         except Exception as e:
-            logger.debug(
-                f'Error encountered when generating git manifests. Error: {e}', exc_info=True,
+            logging_helper.send_to_agent_log_file(
+                f'Error encountered when generating git manifests. Error: {e}', level=logging.ERROR
             )
+            logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
     else:
         logger.info('No Git Configuration detection, skipping Git manifests generation',)
 
@@ -634,7 +635,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                     'This Jira submission will be marked as failed. '
                     f'Error: {e}'
                 )
-                logger.debug(traceback.print_exc())
+                logging_helper.send_to_agent_log_file(traceback.print_exc(), level=logging.ERROR)
                 download_data_status.append({'type': 'Jira', 'status': 'failed'})
         else:
             download_data_status.append(

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:c2bb964f75c109c26b071974a2c185f082cda5b1816503974a9615047ea068ea"
+content_hash = "sha256:1a8daa6464fa3a314c7e6121a9348a3dd5a508b87faae39769ab9416832acf16"
 
 [[package]]
 name = "appdirs"
@@ -362,7 +362,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.95"
+version = "0.0.98"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -377,8 +377,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.95-py3-none-any.whl", hash = "sha256:088e805e438bf6e06d3d6a42f9082818ab508a10c6128b111b135f3dbf602bf2"},
-    {file = "jf_ingest-0.0.95.tar.gz", hash = "sha256:603d4a1364fb420c840a28c322f41ec79546ffa26b69895fa99a9ac5791f392c"},
+    {file = "jf_ingest-0.0.98-py3-none-any.whl", hash = "sha256:4ad2b119f30138825638ab1908a71e849c7e7e6eadbd99d63c9889f50b185f1a"},
+    {file = "jf_ingest-0.0.98.tar.gz", hash = "sha256:b066d8dbe1a1c46d348e5ccf424823b27cad4e947ba0f18b98fcc1caef227e48"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:646a322606a8e5055f44c50dcaf93aacca268baac277bba10e9d79dd881e7f97"
+content_hash = "sha256:c2bb964f75c109c26b071974a2c185f082cda5b1816503974a9615047ea068ea"
 
 [[package]]
 name = "appdirs"
@@ -362,7 +362,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.88"
+version = "0.0.95"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -377,7 +377,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.88-py3-none-any.whl", hash = "sha256:a28ba8a79cd2a3f0a40419831001ccec19411a191e8cf1f98d085a5dfa78c47b"},
+    {file = "jf_ingest-0.0.95-py3-none-any.whl", hash = "sha256:088e805e438bf6e06d3d6a42f9082818ab508a10c6128b111b135f3dbf602bf2"},
+    {file = "jf_ingest-0.0.95.tar.gz", hash = "sha256:603d4a1364fb420c840a28c322f41ec79546ffa26b69895fa99a9ac5791f392c"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.88",
+    "jf-ingest==0.0.95",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.95",
+    "jf-ingest==0.0.98",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Description

Improve how we divert/filter what logs go to the Console logger and what logs go to the Agent Log file.

Previously, we relied on exclusively filtering DEBUG level messages away from the Console logger, but into the Log file Handler. Now, we rely on the `send_to_agent_log_file` helper function from `jf_ingest.logging_helper`, which explicitly tags log records as being for only the agent log file. This allows us to retain the log records levels, instead of flattening them all to `logging.DEBUG`

This PR must be merged after [this ingest PR is merged and deployed](https://github.com/Jellyfish-AI/jf_ingest/pull/120)

## Testing

Here is the Agent Console output, which is very user friendly. Below that is the log file, which contains some extra logging information (NOTE: the logs around "skipping sprints" are now INFO level logs instead of DEBUG :) )

```
Logging setup complete with handlers for log file, stdout, and streaming.
Will write output files into ./output/20240605_155126
Running ingestion healthcheck validation!
Validating configuration...

Jira details:
  URL:      https://jelly-ai.atlassian.net
  Username: jira@jellyfish.co
  Password: **********
==> Testing Jira connection...
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
==> Getting Jira version...
Found Jira version as 1001.0.0-SNAPSHOT
==> Getting Jira deployment type...
Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
==> Getting Jira permissions...
Found granted permissions as ['DELETE_OWN_WORKLOGS', 'CREATE_ISSUES', 'DELETE_OWN_COMMENTS', 'WORK_ON_ISSUES', 'MODIFY_REPORTER', 'EDIT_ISSUES', 'ADD_COMMENTS', 'EDIT_OWN_COMMENTS', 'ASSIGN_ISSUES', 'BROWSE_PROJECTS', 'EDIT_OWN_WORKLOGS', 'EDIT_ALL_WORKLOGS', 'EDIT_ALL_COMMENTS', 'CLOSE_ISSUES', 'SET_ISSUE_SECURITY', 'SCHEDULE_ISSUES', 'USER_PICKER', 'DELETE_ALL_COMMENTS', 'ADMINISTER_PROJECTS', 'RESOLVE_ISSUES', 'DELETE_ISSUES', 'VIEW_READONLY_WORKFLOW', 'MOVE_ISSUES', 'ASSIGNABLE_USER', 'TRANSITION_ISSUES', 'LINK_ISSUES', 'DELETE_ALL_WORKLOGS']
==> Testing Jira user browsing permissions...
Downloading Users...
Done downloading Users! Found 469 users
We can access 469 Jira users.
==> Testing Jira project permissions...
With provided credentials, the following projects are discoverable: {'JFR', 'OJ'}.
Checking project access.
Testing access for project: "JFR"
With provided credentials, we can access issues, versions, and components within project JFR
Testing access for project: "OJ"
With provided credentials, we can access issues, versions, and components within project OJ
Checking access to fields
Checking access to resolutions
Checking access to issue types
Checking access to issue link types
Checking access to priorities
Checking access to boards
Checking access to sprints
. Skipping Git Validation.

Memory & Disk Usage:
  Available memory: 768.25 MB
  Disk usage for jf_agent/output: 301 GB / 460 GB
  Size of jf_agent/output dir:  24K
Attempting to upload healthcheck result to s3...
Successfully uploaded healthcheck.json
Successfully uploaded jf_agent.log
Successfully uploaded healthcheck result to s3!

Done
Obtained Jira configuration, attempting download...
Attempting to use JF Ingest for Jira Ingestion
Set global value INGESTION_TYPE to AGENT
Beginning load_and_push_jira_to_s3
Using local version of ingest
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
Data will not be saved locally
Data will be submitted to jellyfish
Downloading Jira Projects...
Done downloading Projects!
Downloading Jira Project Components...
Done downloading Project Components!
Downloading Jira Versions...
Done downloading Jira Versions!
Done downloading Jira Project, Components, and Version. Found 2 projects
Downloading Jira Fields...
Done downloading Jira Fields! Found 214 fields
Downloading Users...
Done downloading Users! Found 469 users
Downloading Jira Resolutions...
Done downloading Jira Resolutions! Found 9 resolutions
Downloading IssueTypes...
Done downloading IssueTypes! found 34 Issue Types
Downloading IssueLinkTypes...
Done downloading IssueLinkTypes! Found 10 Issue Link Types
Downloading Jira Priorities...
Done downloading Jira Priorities! Found 5 priorities
Downloading Jira Statuses...
Done downloading Jira Statuses! Found 122
Downloading Boards...
Done downloading Boards! Found 54 boards
Downloading Sprints...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 54/54 [00:14<00:00,  3.67it/s]
Skipping issues and worklogs bc config.skip_issues is True
Data has not been saved locally, because save_locally was set to false in the ingest config!
Data has been submitted to jellyfish
Starting Git download for 1 provided git configurations
downloading github projects... ✓
downloading github users... ✓
downloading github repos...
downloading repos for Jellyfish-AI: 1repos [00:09,  9.15s/repos]
Done downloading repos!
downloading github commits on included branches...
downloading commits for branch develop in repo jellyfish (Jellyfish-AI): 447commits [00:02, 164.70commits/s]
Done downloading commits for included branches!
downloading github prs...
processing prs for jellyfish (81621092): 419prs [00:26, 15.94prs/s]
Done downloading github PRs!
Compressing ./output/20240605_155126/diagnostics.json
Compressing ./output/20240605_155126/healthcheck.json
Sending data to Jellyfish...
Starting 8 threads
Successfully uploaded diagnostics.json.gz
Successfully uploaded git_8v1crHqhmq/bb_projects.json.gz
Successfully uploaded git_8v1crHqhmq/bb_users.json.gz
Successfully uploaded status.json.gz
Successfully uploaded healthcheck.json.gz
Successfully uploaded git_8v1crHqhmq/bb_repos.json.gz
Successfully uploaded git_8v1crHqhmq/bb_commits.json.gz
Successfully uploaded git_8v1crHqhmq/bb_prs.json.gz
Successfully uploaded config.yml
Agent run succeeded: True
Successfully uploaded jf_agent.log
Successfully uploaded .done
Done!
Closing the agent log stream.
Log stream stopped.
```

[jf_agent.log](https://github.com/user-attachments/files/15593537/jf_agent.log)
