### PR TITLE
OJ-36885: always close down diagnostics file and thread

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -277,16 +277,17 @@ def main():
                 return False
 
     finally:
-        logger.info('Closing Diagnostics file')
-        # We need to close this before we send data
-        # Otherwise we'll send a .fuse_hidden file (temp file)
-        diagnostics.close_file()
 
         # Kills the sys_diag_collector thread.
         # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
         logger.info('Shutting down Systems Diagnostics Thread')
         sys_diag_done_event.set()
         sys_diag_collector.join()
+
+        logger.info('Closing Diagnostics file')
+        # We need to close this before we send data
+        # Otherwise we'll send a .fuse_hidden file (temp file)
+        diagnostics.close_file()
 
     success &= potentially_send_data(config, creds, successful=error_and_timeout_free)
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -270,15 +270,14 @@ def main():
             agent_logging.close_out(logging_config)
             return False
 
-        finally:
-            # We need to close this before we send data
-            # Otherwise we'll send a .fuse_hidden file (temp file)
-            diagnostics.close_file()
+    # We need to close this before we send data
+    # Otherwise we'll send a .fuse_hidden file (temp file)
+    diagnostics.close_file()
 
-            # Kills the sys_diag_collector thread.
-            # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
-            sys_diag_done_event.set()
-            sys_diag_collector.join()
+    # Kills the sys_diag_collector thread.
+    # We need to do this before exiting, otherwise we'll hang forever and never exit until timeout kills it.
+    sys_diag_done_event.set()
+    sys_diag_collector.join()
 
     success &= potentially_send_data(config, creds, successful=error_and_timeout_free)
 


### PR DESCRIPTION
## Description

There is a latent bug in the diagnostics monitoring thread. The logic flow to shut down the monitoring thread requires us to be in a mode where we are downloading/sending data. If the Agent is run in a `send_only` mode or `from_failure` mode, it will fail to close down the diagnostics thread and hang forever (well, technically it will get shutdown after 72 hours due to some time out logic we have in the Agent)

To resolve this issue, I moved the `diagnostics` cleanup logic (where we shut down the thread) to be part of a `try/finally` logic block so that it always gets run for ever run mode and even if we encounter an error