### PR TITLE
OJ-36861-setup-jf-ingest-for-github

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -17,6 +17,7 @@ from jf_ingest.config import (
     IssueMetadata,
     JiraDownloadConfig,
     GitConfig as JFIngestGitConfig,
+    GitAuthConfig as JFIngestGitAuthConfig,
 )
 
 from jf_agent.util import get_company_info
@@ -314,6 +315,52 @@ def _get_git_config_from_yaml(yaml_config) -> List[GitConfig]:
 git_providers = ['bitbucket_server', 'bitbucket_cloud', 'github', 'gitlab']
 
 
+def get_github_gql_base_url(base_url: str):
+    if base_url and 'api/v3' in base_url:
+        # Github server clients provide an API with a trailing '/api/v3'
+        # replace this with the graphql endpoint
+        return base_url.replace('api/v3', 'api/graphql')
+    else:
+        return 'https://api.github.com/graphql'
+
+
+def _get_jf_ingest_git_auth_config(
+    company_slug: str,
+    config: GitConfig,
+    git_creds: dict,
+    skip_ssl_verification: bool,
+    instance_info: dict = {},
+):
+    from jf_agent.git.utils import BBC_PROVIDER, BBS_PROVIDER, GH_PROVIDER, GL_PROVIDER
+
+    try:
+        if config.git_provider == BBS_PROVIDER:
+            return None
+
+        if config.git_provider == BBC_PROVIDER:
+            return None
+
+        if config.git_provider == GH_PROVIDER:
+            return JFIngestGitAuthConfig(
+                company_slug=company_slug,
+                token=git_creds['github_token'],
+                base_url=get_github_gql_base_url(base_url=config.git_url),
+                verify=not skip_ssl_verification,
+            )
+        if config.git_provider == GL_PROVIDER:
+            return None
+
+    except Exception as e:
+        logging_helper.log_standard_error(
+            logging.ERROR, msg_args=[config.git_provider, e], error_code=2101, exc_info=True,
+        )
+        return
+
+    logging_helper.send_to_agent_log_file(
+        f'Git Provider {config.git_provider} is not yet supported by JF Ingest'
+    )
+
+
 def get_ingest_config(
     config: ValidatedConfig, creds, endpoint_jira_info: dict, endpoint_git_instances_info: dict
 ) -> IngestionConfig:
@@ -321,7 +368,6 @@ def get_ingest_config(
     Handles converting our agent config to the jf_ingest IngestionConfig
     shared dataclass.
     """
-
     company_info = get_company_info(config, creds)
 
     company_slug = company_info.get('company_slug')
@@ -389,24 +435,60 @@ def get_ingest_config(
         )
 
     git_configs: List[JFIngestGitConfig] = []
+    is_mult_git_mode = len(config.git_configs) > 1
     for agent_git_config in config.git_configs:
         agent_git_config: GitConfig = agent_git_config
-        instance_slug = agent_git_config.git_instance_slug
-        endpoint_git_instance_info = endpoint_git_instances_info.get(instance_slug)
+
+        if is_mult_git_mode:
+            instance_slug = agent_git_config.git_instance_slug
+            endpoint_git_instance_info = endpoint_git_instances_info.get(instance_slug)
+            instance_creds = creds.git_instance_to_creds.get(instance_slug)
+        else:
+            # If there's only one git config set, then this is "single git" mode.
+            # The instance slug is likely not to be provided
+            endpoint_git_instance_info = list(endpoint_git_instances_info.values())[0]
+            instance_creds = list(creds.git_instance_to_creds.values())[0]
+            instance_slug = endpoint_git_instance_info['slug']
+
+        jf_ingest_git_auth_config = _get_jf_ingest_git_auth_config(
+            company_slug=company_slug,
+            config=agent_git_config,
+            git_creds=instance_creds,
+            skip_ssl_verification=config.skip_ssl_verification,
+            instance_info=endpoint_git_instance_info,
+        )
+
+        repos_to_prs_last_updated = {}
+        repos_to_commits_backpopulated_to = {}
+        pull_prs_since_for_repo_in_org = {}
+        for repo_id, repo_info in endpoint_git_instance_info['repos_dict_v2'].items():
+            if repo_info['latest_pr_update_date_pulled']:
+                repos_to_prs_last_updated[repo_id] = datetime.fromisoformat(
+                    repo_info['latest_pr_update_date_pulled']
+                )
+            if repo_info['commits_backpopulated_to']:
+                repos_to_commits_backpopulated_to[repo_id] = datetime.fromisoformat(
+                    repo_info['commits_backpopulated_to']
+                )
+            if repo_info['prs_backpopulated_to']:
+                pull_prs_since_for_repo_in_org[repo_id] = datetime.fromisoformat(
+                    repo_info['prs_backpopulated_to']
+                )
+
         git_configs.append(
             JFIngestGitConfig(
                 company_slug=company_slug,
                 instance_slug=instance_slug,
                 instance_file_key=endpoint_git_instance_info['key'],
-                git_provider=agent_git_config.git_provider,  # TODO cast this
-                git_auth_config=None,  # TODO
-                url=agent_git_config.git_url,
+                git_provider=agent_git_config.git_provider,
+                git_auth_config=jf_ingest_git_auth_config,
+                url=get_github_gql_base_url(agent_git_config.git_url),
                 jf_options={},
-                pull_commits_since_for_repo_in_org=None,  # TODO
-                pull_prs_since_for_repo_in_org=None,  # TODO
-                default_pull_from_for_commits_and_prs=datetime.min,  # TODO
-                discover_orgs=False,  # TODO,
+                repos_to_prs_last_updated=repos_to_prs_last_updated,
+                repos_to_commits_backpopulated_to=repos_to_commits_backpopulated_to,
+                repos_to_prs_backpopulated_to=pull_prs_since_for_repo_in_org,
                 git_organizations=agent_git_config.git_include_projects,
+                pull_from=endpoint_git_instance_info['pull_from'],
                 excluded_organizations=agent_git_config.git_exclude_projects,
                 included_repos=agent_git_config.git_include_repos,
                 excluded_repos=agent_git_config.git_exclude_repos,

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -17,6 +17,8 @@ from jf_agent.config_file_reader import GitConfig
 
 from jf_agent import download_and_write_streaming, write_file
 from jf_ingest import logging_helper, diagnostics
+from jf_ingest.config import IngestionConfig
+from jf_ingest.jf_git.adapters import load_and_push_git_to_s3
 
 logger = logging.getLogger(__name__)
 
@@ -290,6 +292,7 @@ def load_and_dump_git(
     compress_output_files: bool,
     git_connection,
     jf_options: dict,
+    jf_ingest_config: IngestionConfig,
 ):
     # use the unique git instance agent key to collate files
     instance_slug = endpoint_git_instance_info['slug']
@@ -320,6 +323,7 @@ def load_and_dump_git(
             from jf_agent.git.github_gql_adapter import GithubGqlAdapter
 
             if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
+                load_and_push_git_to_s3(ingest_config=jf_ingest_config)
                 GithubGqlAdapter(
                     config,
                     outdir,

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -240,6 +240,14 @@ def get_git_client(
             )
 
         if config.git_provider == GH_PROVIDER:
+            legacy_client = GithubClient(
+                base_url=config.git_url,
+                token=git_creds['github_token'],
+                verify=not skip_ssl_verification,
+                session=retry_session(),
+            )
+            # scopes = legacy_client.get_scopes_of_api_token()
+            # input(f'scopes {scopes} (type: {type(scopes)}) >')
             if instance_info.get('supports_graphql_endpoints', False):
                 return GithubGqlClient(
                     base_url=config.git_url,
@@ -248,12 +256,7 @@ def get_git_client(
                     session=retry_session(),
                 )
             else:
-                return GithubClient(
-                    base_url=config.git_url,
-                    token=git_creds['github_token'],
-                    verify=not skip_ssl_verification,
-                    session=retry_session(),
-                )
+                return legacy_client
         if config.git_provider == GL_PROVIDER:
             return GitLabClient(
                 server_url=config.git_url,
@@ -289,7 +292,6 @@ def load_and_dump_git(
     instance_key = endpoint_git_instance_info['key']
     outdir = f'{outdir}/git_{instance_key}'
     os.mkdir(outdir)
-
     try:
         if config.git_provider == 'bitbucket_server':
             # using old func method, todo: refactor to use GitAdapter
@@ -310,7 +312,8 @@ def load_and_dump_git(
                 config, outdir, compress_output_files, git_connection
             ).load_and_dump_git(endpoint_git_instance_info,)
         elif config.git_provider == 'github':
-
+            # scopes = git_connection.get_scopes_of_api_token()
+            # input(f'Scopes: {scopes} > ')
             if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
                 for jf_ingest_git_config in jf_ingest_config.git_configs:
                     if jf_ingest_git_config.instance_slug == instance_slug:

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -9,6 +9,7 @@ import logging
 from jf_agent.git.github_gql_client import GithubGqlClient
 from stashy.client import Stash
 
+from jf_agent.git.utils import BBC_PROVIDER, BBS_PROVIDER, GH_PROVIDER, GL_PROVIDER
 from jf_agent.session import retry_session
 from jf_agent.git.bitbucket_cloud_client import BitbucketCloudClient
 from jf_agent.git.github_client import GithubClient
@@ -18,20 +19,9 @@ from jf_agent.config_file_reader import GitConfig
 from jf_agent import download_and_write_streaming, write_file
 from jf_ingest import logging_helper, diagnostics
 from jf_ingest.config import IngestionConfig
-from jf_ingest.jf_git.adapters import load_and_push_git_to_s3
+from jf_ingest.jf_git.adapters import GitAdapter as JFIngestGitAdapter
 
 logger = logging.getLogger(__name__)
-
-'''
-
-    Constants
-
-'''
-BBS_PROVIDER = 'bitbucket_server'
-BBC_PROVIDER = 'bitbucket_cloud'
-GH_PROVIDER = 'github'
-GL_PROVIDER = 'gitlab'
-PROVIDERS = [GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER]
 
 '''
 
@@ -320,18 +310,19 @@ def load_and_dump_git(
                 config, outdir, compress_output_files, git_connection
             ).load_and_dump_git(endpoint_git_instance_info,)
         elif config.git_provider == 'github':
-            from jf_agent.git.github_gql_adapter import GithubGqlAdapter
 
             if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
-                load_and_push_git_to_s3(ingest_config=jf_ingest_config)
-                GithubGqlAdapter(
-                    config,
-                    outdir,
-                    compress_output_files,
-                    git_connection,
-                    server_git_instance_info=endpoint_git_instance_info,
-                    jf_options=jf_options,
-                ).load_and_dump_git(endpoint_git_instance_info)
+                for jf_ingest_git_config in jf_ingest_config.git_configs:
+                    if jf_ingest_git_config.instance_slug == instance_slug:
+                        logger.info(
+                            f'Setting up JF Ingest GQL adapter for instance {jf_ingest_git_config.instance_slug}'
+                        )
+                        git_adapter: JFIngestGitAdapter = JFIngestGitAdapter.get_git_adapter(
+                            jf_ingest_git_config
+                        )
+                        git_adapter.load_and_dump_git(
+                            git_config=jf_ingest_git_config, ingest_config=jf_ingest_config
+                        )
             else:
                 # using old func method, todo: refactor to use GitAdapter
                 # NOTE: We can hopefully do this with the above githubGqlAdapter!

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -240,14 +240,6 @@ def get_git_client(
             )
 
         if config.git_provider == GH_PROVIDER:
-            legacy_client = GithubClient(
-                base_url=config.git_url,
-                token=git_creds['github_token'],
-                verify=not skip_ssl_verification,
-                session=retry_session(),
-            )
-            # scopes = legacy_client.get_scopes_of_api_token()
-            # input(f'scopes {scopes} (type: {type(scopes)}) >')
             if instance_info.get('supports_graphql_endpoints', False):
                 return GithubGqlClient(
                     base_url=config.git_url,
@@ -256,7 +248,12 @@ def get_git_client(
                     session=retry_session(),
                 )
             else:
-                return legacy_client
+                return GithubClient(
+                    base_url=config.git_url,
+                    token=git_creds['github_token'],
+                    verify=not skip_ssl_verification,
+                    session=retry_session(),
+                )
         if config.git_provider == GL_PROVIDER:
             return GitLabClient(
                 server_url=config.git_url,
@@ -312,8 +309,6 @@ def load_and_dump_git(
                 config, outdir, compress_output_files, git_connection
             ).load_and_dump_git(endpoint_git_instance_info,)
         elif config.git_provider == 'github':
-            # scopes = git_connection.get_scopes_of_api_token()
-            # input(f'Scopes: {scopes} > ')
             if endpoint_git_instance_info.get('supports_graphql_endpoints', False):
                 for jf_ingest_git_config in jf_ingest_config.git_configs:
                     if jf_ingest_git_config.instance_slug == instance_slug:

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -13,7 +13,7 @@ BBS_PROVIDER = 'bitbucket_server'
 BBC_PROVIDER = 'bitbucket_cloud'
 GH_PROVIDER = 'github'
 GL_PROVIDER = 'gitlab'
-PROVIDERS = [GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER]
+PROVIDERS = (GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER)
 
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -4,6 +4,17 @@ from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
+'''
+
+    Constants
+
+'''
+BBS_PROVIDER = 'bitbucket_server'
+BBC_PROVIDER = 'bitbucket_cloud'
+GH_PROVIDER = 'github'
+GL_PROVIDER = 'gitlab'
+PROVIDERS = [GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER]
+
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.
 def get_branches_for_standardized_repo(repo: Any, included_branches: dict):

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -639,6 +639,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                     creds=creds,
                     endpoint_jira_info=endpoint_jira_info,
                     endpoint_git_instances_info=endpoint_git_instances_info,
+                    jf_options=jf_options,
                 )
                 success = load_and_push_jira_to_s3(ingest_config)
                 success_status_str = 'success' if success else 'failed'
@@ -692,6 +693,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                 creds=creds,
                 endpoint_jira_info=endpoint_jira_info,
                 endpoint_git_instances_info=endpoint_git_instances_info,
+                jf_options=jf_options,
             )
             futures.append(
                 executor.submit(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -45,7 +45,7 @@ from jf_agent.util import get_company_info, upload_file
 
 from jf_ingest import diagnostics, logging_helper
 from jf_ingest.jf_jira import load_and_push_jira_to_s3
-from jf_ingest.config import IngestionType
+from jf_ingest.config import IngestionType, IngestionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -626,7 +626,10 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
             try:
                 logger.info(f'Attempting to use JF Ingest for Jira Ingestion')
                 ingest_config = get_ingest_config(
-                    config=config, creds=creds, endpoint_jira_info=endpoint_jira_info
+                    config=config,
+                    creds=creds,
+                    endpoint_jira_info=endpoint_jira_info,
+                    endpoint_git_instances_info=endpoint_git_instances_info,
                 )
                 success = load_and_push_jira_to_s3(ingest_config)
                 success_status_str = 'success' if success else 'failed'
@@ -674,6 +677,13 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                 if len(config.git_configs) > 1
                 else f"Starting Git download for {len(config.git_configs)} provided git configurations",
             )
+
+            ingest_config = get_ingest_config(
+                config=config,
+                creds=creds,
+                endpoint_jira_info=endpoint_jira_info,
+                endpoint_git_instances_info=endpoint_git_instances_info,
+            )
             futures.append(
                 executor.submit(
                     _download_git_data,
@@ -683,6 +693,7 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
                     endpoint_git_instances_info,
                     len(config.git_configs) > 1,
                     jf_options,
+                    ingest_config,
                 )
             )
 
@@ -690,7 +701,13 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 
 
 def _download_git_data(
-    git_config, config, creds, endpoint_git_instances_info, is_multi_git_config, jf_options
+    git_config,
+    config,
+    creds,
+    endpoint_git_instances_info,
+    is_multi_git_config,
+    jf_options,
+    jf_ingest_config: IngestionConfig,
 ) -> dict:
     if is_multi_git_config:
         instance_slug = git_config.git_instance_slug
@@ -714,6 +731,7 @@ def _download_git_data(
         compress_output_files=config.compress_output_files,
         git_connection=git_connection,
         jf_options=jf_options,
+        jf_ingest_config=jf_ingest_config,
     )
 
 

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -67,6 +67,7 @@ def full_validate(
             creds,
             jellyfish_endpoint_info.jira_info,
             jellyfish_endpoint_info.git_instance_info,
+            jf_options=jellyfish_endpoint_info.jf_options,
         )
         if ingest_config.jira_config and not skip_jira:
             jira_connection_healthcheck_result = validate_jira(ingest_config.jira_config)

--- a/jf_agent/validation.py
+++ b/jf_agent/validation.py
@@ -62,7 +62,12 @@ def full_validate(
     logger.info('Validating configuration...')
 
     try:
-        ingest_config = get_ingest_config(config, creds, jellyfish_endpoint_info.jira_info)
+        ingest_config = get_ingest_config(
+            config,
+            creds,
+            jellyfish_endpoint_info.jira_info,
+            jellyfish_endpoint_info.git_instance_info,
+        )
         if ingest_config.jira_config and not skip_jira:
             jira_connection_healthcheck_result = validate_jira(ingest_config.jira_config)
         else:

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
-lock_version = "4.4.1"
-content_hash = "sha256:7a555d399bf334cdcc08757482708066ed2902753638204ce7e2d2fa11437c17"
+lock_version = "4.4"
+content_hash = "sha256:0b3072fbd3d4b6c0e6041c8295fcb384439f87bcbba43a15b40f9ac9663fa1b1"
 
 [[package]]
 name = "appdirs"
@@ -362,7 +362,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.103"
+version = "0.0.105"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 dependencies = [
@@ -377,8 +377,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.103-py3-none-any.whl", hash = "sha256:553885ed8bc134400714019a5e67f173a4c5046599c1969de9b5aaeceb1728c1"},
-    {file = "jf_ingest-0.0.103.tar.gz", hash = "sha256:152172792839910f9497e1a47f2c21546023376cb60491b63c983f02be49f19c"},
+    {file = "jf_ingest-0.0.105-py3-none-any.whl", hash = "sha256:5b4d2b8eb025f79e59028ed50b908156aafc10f8a486774598fcb20461cd92b2"},
+    {file = "jf_ingest-0.0.105.tar.gz", hash = "sha256:7433c57e2892e098700e55be4dbde001fb064ccbf42cb11ea9d309b0a64e8b43"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.103",
+    "jf-ingest==0.0.105",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
### Description

Set up JF Ingest Github GQL for all companies that are already running the original Agent version of the GQL ingest. I tested this with orthogonal-networks in an "end to end" test; I ran an Agent run for our git instance, imported it to `stg-looking-glass` via `git_import`, and then ran the Agent again. I verified that the first Agent run and submission created a few PRs and commits and branches, and then verified that the second run didn't create anything new. 

This PR contains initial groundwork that will be helpful as we roll out ADO in the Agent (via `jf_ingest`)