### PR TITLE
OJ-37114 - Configure structlog

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -51,7 +51,7 @@ from jf_ingest.config import IngestionType, IngestionConfig
 # Configure structlog before any loggers are created
 agent_logging.configure_structlog()
 
-logger = structlog.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def main():


### PR DESCRIPTION
## Description

Configures structlog for use in this repository. In the current configuration, structlog will handle log message rendering and formatting before sending a finalized log message to the standard `logging` library. The next step of utilizing structlog will be replacing all instances of the standard library logger with the new structlog logger + slightly modifying the `CustomQueueHandler` based on the new logging formatting.

Example log:

```{"event": "Structlog and standard logging configured", "agent_run_uuid": "8c2c7a73-3f9f-488e-9f1c-50e274fc8ce2", "jf_meta": {"commit": "bac1462befc405d8379160790f4085ca1732c6fe", "timestamp": "20240729T144304Z"}, "upload_time": "20240730_163839", "run_mode": "download_only", "company_slug": "orthogonal-networks", "logger": "__main__", "level": "info", "timestamp": "2024-07-30T16:38:39.569866Z", "lineno": 167, "filename": "main.py", "func_name": "main"}```