### PR TITLE
OJ-36874: introduce ado adapter to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,8 +133,8 @@ dmypy.json
 .pyre/
 
 # jf_agent configuration/credentials files (by convention)
-config.yml
-creds.env
+*.yml
+*.env
 
 # jf_agent output dir (by convention)
 output

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -13,11 +13,22 @@ BBS_PROVIDER = 'bitbucket_server'
 BBC_PROVIDER = 'bitbucket_cloud'
 GH_PROVIDER = 'github'
 GL_PROVIDER = 'gitlab'
-PROVIDERS = (GL_PROVIDER, GH_PROVIDER, BBS_PROVIDER, BBC_PROVIDER)
+ADO_PROVIDER = 'ado'
+PROVIDERS = (
+    GL_PROVIDER,
+    GH_PROVIDER,
+    BBS_PROVIDER,
+    BBC_PROVIDER,
+    ADO_PROVIDER,
+)
 
 # Must add a provider here to enable ingestion
 # through jf_ingest for that provider
-JF_INGEST_SUPPORTED_PROVIDERS = (GH_PROVIDER,)
+JF_INGEST_SUPPORTED_PROVIDERS = (
+    GH_PROVIDER,
+    ADO_PROVIDER,
+)
+
 
 # Return branches for which we should pull commits, specified by customer in git config.
 # The repo's default branch will always be included in the returned list.

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -836,12 +836,18 @@ def send_data(config: ValidatedConfig, creds, directories_to_skip: list[str], su
     filenames.remove(agent_logging.LOG_FILE_NAME)
     # get the full file paths for each of the immediate
     # subdirectories (we're assuming only a single level)
-    logger.info(f'Skipping directory upload for the following directories: {directories_to_skip}')
+    logging_helper.send_to_agent_log_file(
+        f'Skipping directory upload for the following directories: {directories_to_skip}'
+    )
     for directory in directories:
-        print(directory)
+        logging_helper.send_to_agent_log_file(f'Checking directory: {directory}...')
         if directory in directories_to_skip:
-            logger.info(f'Skipping {directory} because it is in the {directories_to_skip} list')
+            logging_helper.send_to_agent_log_file(
+                f'Skipping {directory} because it is in the {directories_to_skip} list'
+            )
             continue
+        else:
+            logging_helper.send_to_agent_log_file(f'{directory} will be uploaded!')
         path = os.path.join(config.outdir, directory)
         for file_name in os.listdir(path):
             filenames.append(f'{directory}/{file_name}')

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -1,51 +1,44 @@
 import argparse
-from concurrent.futures import ThreadPoolExecutor
-import traceback
-import dotenv
 import gzip
+import json
 import logging
 import os
 import shutil
+import sys
 import threading
+import traceback
 from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from pathlib import Path
-import sys
 
+import dotenv
 import requests
-import json
+from jf_ingest import diagnostics, logging_helper
+from jf_ingest.config import GitProvider, IngestionConfig, IngestionType
+from jf_ingest.jf_jira import load_and_push_jira_to_s3
 
 from jf_agent import (
-    agent_logging,
-    write_file,
-    VALID_RUN_MODES,
     JELLYFISH_API_BASE,
     JELLYFISH_WEBHOOK_BASE,
+    VALID_RUN_MODES,
+    agent_logging,
+    write_file,
 )
-from jf_agent.exception import BadConfigException
-from jf_agent.data_manifests.jira.generator import create_manifest as create_jira_manifest
+from jf_agent.config_file_reader import ValidatedConfig, get_ingest_config, obtain_config
 from jf_agent.data_manifests.git.generator import create_manifests as create_git_manifests
+from jf_agent.data_manifests.jira.generator import create_manifest as create_jira_manifest
 from jf_agent.data_manifests.manifest import Manifest
-from jf_agent.git import load_and_dump_git, get_git_client
-from jf_agent.config_file_reader import get_ingest_config, obtain_config
+from jf_agent.exception import BadConfigException
+from jf_agent.git import get_git_client, load_and_dump_git
 from jf_agent.jf_jira import (
     get_basic_jira_connection,
-    print_all_jira_fields,
     load_and_dump_jira,
+    print_all_jira_fields,
     print_missing_repos_found_by_jira,
 )
-
-from jf_agent.validation import (
-    full_validate,
-    validate_num_repos,
-    ProjectMetadata,
-)
-
 from jf_agent.util import get_company_info, upload_file
-
-from jf_ingest import diagnostics, logging_helper
-from jf_ingest.jf_jira import load_and_push_jira_to_s3
-from jf_ingest.config import IngestionType, IngestionConfig
+from jf_agent.validation import ProjectMetadata, full_validate, validate_num_repos
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +147,8 @@ def main():
     success = True
     jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
 
+    directories_to_skip_uploading_for = set()
+
     # send start signal to Agent heartbeat monitor
     try:
         diagnostics.send_diagnostic_start_reading(
@@ -257,9 +252,32 @@ def main():
                     return True
 
                 if config.run_mode_includes_download:
+                    ingest_config = get_ingest_config(
+                        config=config,
+                        creds=creds,
+                        endpoint_jira_info=jellyfish_endpoint_info.jira_info,
+                        endpoint_git_instances_info=jellyfish_endpoint_info.git_instance_info,
+                        jf_options=jellyfish_endpoint_info.jf_options,
+                    )
+                    # Mark some agent upload directories as skippable during out
+                    # data uploading phase, because they already get uploaded via
+                    # JF Ingest
+                    from jf_agent.git.utils import JF_INGEST_SUPPORTED_PROVIDERS
+
+                    directories_to_skip_uploading_for.update(
+                        [
+                            f'git_{git_config.instance_file_key}'
+                            for git_config in ingest_config.git_configs
+                            if git_config.git_provider.value.lower()
+                            in JF_INGEST_SUPPORTED_PROVIDERS
+                        ]
+                    )
+                    # Jira is supported by all customers, always skip it
+                    directories_to_skip_uploading_for.add('jira')
                     download_data_status = download_data(
                         config,
                         creds,
+                        ingest_config,
                         jellyfish_endpoint_info.jira_info,
                         jellyfish_endpoint_info.git_instance_info,
                         jellyfish_endpoint_info.jf_options,
@@ -289,7 +307,12 @@ def main():
         # Otherwise we'll send a .fuse_hidden file (temp file)
         diagnostics.close_file()
 
-    success &= potentially_send_data(config, creds, successful=error_and_timeout_free)
+    success &= potentially_send_data(
+        config,
+        creds,
+        directories_to_skip=list(directories_to_skip_uploading_for),
+        successful=error_and_timeout_free,
+    )
 
     logger.info('Done!')
 
@@ -311,9 +334,13 @@ def main():
     return success
 
 
-def potentially_send_data(config, creds, successful=True) -> bool:
+def potentially_send_data(
+    config: ValidatedConfig, creds, directories_to_skip: list[str], successful=True
+) -> bool:
     if config.run_mode_includes_send:
-        successful &= send_data(config, creds, successful)
+        successful &= send_data(
+            config, creds, directories_to_skip=directories_to_skip, successful=successful
+        )
     else:
         logger.info(
             f'\nSkipping send_data because run_mode is "{config.run_mode}"\n'
@@ -358,6 +385,14 @@ required_jira_fields = [
 
 
 def _get_git_instance_to_creds(git_config):
+    from jf_agent.git.utils import (
+        ADO_PROVIDER,
+        BBC_PROVIDER,
+        BBS_PROVIDER,
+        GH_PROVIDER,
+        GL_PROVIDER,
+    )
+
     def _check_and_get(envvar_name):
         envvar_val = os.environ.get(envvar_name)
         if not envvar_val:
@@ -369,20 +404,22 @@ def _get_git_instance_to_creds(git_config):
 
     git_provider = git_config.git_provider
     prefix = f'{git_config.creds_envvar_prefix}_' if git_config.creds_envvar_prefix else ''
-    if git_provider == 'github':
+    if git_provider == GH_PROVIDER:
         return {'github_token': _check_and_get(f'{prefix}GITHUB_TOKEN')}
-    elif git_provider == 'bitbucket_cloud':
+    elif git_provider == BBC_PROVIDER:
         return {
             'bb_cloud_username': _check_and_get(f'{prefix}BITBUCKET_CLOUD_USERNAME'),
             'bb_cloud_app_password': _check_and_get(f'{prefix}BITBUCKET_CLOUD_APP_PASSWORD'),
         }
-    elif git_provider == 'bitbucket_server':
+    elif git_provider == BBS_PROVIDER:
         return {
             'bb_server_username': _check_and_get(f'{prefix}BITBUCKET_USERNAME'),
             'bb_server_password': _check_and_get(f'{prefix}BITBUCKET_PASSWORD'),
         }
-    elif git_provider == 'gitlab':
+    elif git_provider == GL_PROVIDER:
         return {'gitlab_token': _check_and_get(f'{prefix}GITLAB_TOKEN')}
+    elif git_provider == ADO_PROVIDER:
+        return {'ado_token': _check_and_get(f'{prefix}ADO_TOKEN')}
 
 
 def obtain_creds(config):
@@ -544,7 +581,9 @@ def generate_manifests(config, creds, jellyfish_endpoint_info):
             )
             logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
     else:
-        logger.info('No Git Configuration detection, skipping Git manifests generation',)
+        logger.info(
+            'No Git Configuration detection, skipping Git manifests generation',
+        )
 
     logger.info(f'Attempting upload of {len(manifests)} manifest(s) to Jellyfish...')
 
@@ -623,24 +662,26 @@ def distribute_repos_between_workers(git_configs, metadata_by_project):
 
 @diagnostics.capture_timing()
 @logging_helper.log_entry_exit(logger)
-def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info, jf_options):
+def download_data(
+    config,
+    creds,
+    ingest_config: IngestionConfig,
+    endpoint_jira_info,
+    endpoint_git_instances_info,
+    jf_options,
+):
     download_data_status = []
 
     if config.jira_url:
-        logger.info('Obtained Jira configuration, attempting download...',)
+        logger.info(
+            'Obtained Jira configuration, attempting download...',
+        )
         jira_connection = get_basic_jira_connection(config, creds)
         if config.run_mode_is_print_all_jira_fields:
             print_all_jira_fields(config, jira_connection)
         if endpoint_jira_info.get('use_jf_ingest_for_jira', False):
             try:
                 logger.info(f'Attempting to use JF Ingest for Jira Ingestion')
-                ingest_config = get_ingest_config(
-                    config=config,
-                    creds=creds,
-                    endpoint_jira_info=endpoint_jira_info,
-                    endpoint_git_instances_info=endpoint_git_instances_info,
-                    jf_options=jf_options,
-                )
                 success = load_and_push_jira_to_s3(ingest_config)
                 success_status_str = 'success' if success else 'failed'
                 download_data_status.append({'type': 'Jira', 'status': success_status_str})
@@ -681,19 +722,13 @@ def download_data(config, creds, endpoint_jira_info, endpoint_git_instances_info
 
         for git_config in git_configs:
             logger.info(
-                f'Obtained {git_config.git_provider}:{git_config.git_instance_slug} configuration, attempting download '
-                + f'in parallel with {config.git_max_concurrent} workers, '
-                + f'for {len(git_config.git_include_projects)} projects'
-                if len(config.git_configs) > 1
-                else f"Starting Git download for {len(config.git_configs)} provided git configurations",
-            )
-
-            ingest_config = get_ingest_config(
-                config=config,
-                creds=creds,
-                endpoint_jira_info=endpoint_jira_info,
-                endpoint_git_instances_info=endpoint_git_instances_info,
-                jf_options=jf_options,
+                (
+                    f'Obtained {git_config.git_provider}:{git_config.git_instance_slug} configuration, attempting download '
+                    + f'in parallel with {config.git_max_concurrent} workers, '
+                    + f'for {len(git_config.git_include_projects)} projects'
+                    if len(config.git_configs) > 1
+                    else f"Starting Git download for {len(config.git_configs)} provided git configurations"
+                ),
             )
             futures.append(
                 executor.submit(
@@ -751,7 +786,7 @@ def get_timestamp_from_outdir(outdir: str):
     return timestamp
 
 
-def send_data(config, creds, successful=True):
+def send_data(config: ValidatedConfig, creds, directories_to_skip: list[str], successful=True):
     timestamp = get_timestamp_from_outdir(config.outdir)
 
     def get_signed_url(files):
@@ -776,7 +811,10 @@ def send_data(config, creds, successful=True):
         except Exception as e:
             thread_exceptions.append(e)
             logging_helper.log_standard_error(
-                logging.ERROR, msg_args=[filename], error_code=3000, exc_info=True,
+                logging.ERROR,
+                msg_args=[filename],
+                error_code=3000,
+                exc_info=True,
             )
 
     # Compress any not yet compressed files before sending
@@ -796,14 +834,13 @@ def send_data(config, creds, successful=True):
     # We want to save the jf_agent.log file and upload it last, to ensure
     # we are capturing as much information as possible
     filenames.remove(agent_logging.LOG_FILE_NAME)
-
     # get the full file paths for each of the immediate
     # subdirectories (we're assuming only a single level)
+    logger.info(f'Skipping directory upload for the following directories: {directories_to_skip}')
     for directory in directories:
-        # SKIP OVER THE JIRA DIRECTORY, WHICH IS UPLOADED VIA JF INGEST
-        # TODO: The GIT directories will also be uploaded via ingest,
-        # but for now they are handled via this 'legacy' way
-        if directory.lower() == 'jira':
+        print(directory)
+        if directory in directories_to_skip:
+            logger.info(f'Skipping {directory} because it is in the {directories_to_skip} list')
             continue
         path = os.path.join(config.outdir, directory)
         for file_name in os.listdir(path):
@@ -813,7 +850,8 @@ def send_data(config, creds, successful=True):
 
     threads = [
         threading.Thread(
-            target=upload_file_from_thread, args=[filename, file_dict['s3_path'], file_dict['url']],
+            target=upload_file_from_thread,
+            args=[filename, file_dict['s3_path'], file_dict['url']],
         )
         for (filename, file_dict) in signed_urls.items()
     ]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:7e272450961e38231c2165242c6093842be5efe42406fba5e3c9a7237988e3f3"
+content_hash = "sha256:aed4254903d63c8591ec25454a276435361aaa8b0b80c49cca18edca93c9da6a"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.11"
@@ -411,7 +411,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.105"
+version = "0.0.120"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 groups = ["default"]
@@ -428,8 +428,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.105-py3-none-any.whl", hash = "sha256:5b4d2b8eb025f79e59028ed50b908156aafc10f8a486774598fcb20461cd92b2"},
-    {file = "jf_ingest-0.0.105.tar.gz", hash = "sha256:7433c57e2892e098700e55be4dbde001fb064ccbf42cb11ea9d309b0a64e8b43"},
+    {file = "jf_ingest-0.0.120-py3-none-any.whl", hash = "sha256:3725ae78752a6754150204fbe2afdbc753b529649402134e8296b0afe6e142a2"},
+    {file = "jf_ingest-0.0.120.tar.gz", hash = "sha256:d0f9ff759076401a73856b59d949c25d1c8d9ec6dd63614de1b4b5c0d248312b"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:aed4254903d63c8591ec25454a276435361aaa8b0b80c49cca18edca93c9da6a"
+content_hash = "sha256:51dc002b07c04edbdced585767f926bb720b7609c560f138495487cfeae0c700"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.11"
@@ -411,7 +411,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.120"
+version = "0.0.121"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 groups = ["default"]
@@ -428,8 +428,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.120-py3-none-any.whl", hash = "sha256:3725ae78752a6754150204fbe2afdbc753b529649402134e8296b0afe6e142a2"},
-    {file = "jf_ingest-0.0.120.tar.gz", hash = "sha256:d0f9ff759076401a73856b59d949c25d1c8d9ec6dd63614de1b4b5c0d248312b"},
+    {file = "jf_ingest-0.0.121-py3-none-any.whl", hash = "sha256:45f920f94afe4f4982f9602408ce53e99d860cbba73b4c06bfedf25b31724ba4"},
+    {file = "jf_ingest-0.0.121.tar.gz", hash = "sha256:74bf7df3af2d3300fd26f0d3dc6997738a17e7c0ec389c5d6111be666abba48a"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:51dc002b07c04edbdced585767f926bb720b7609c560f138495487cfeae0c700"
+content_hash = "sha256:442ae381f344ac1614544494f648a90d868edf55f5fc6f6ca0b51fde2aabb135"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.11"
@@ -169,7 +169,7 @@ version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default", "dev"]
-marker = "(platform_system == \"Windows\" or sys_platform == \"win32\") and python_version >= \"3.10\" and python_version < \"3.11\""
+marker = "python_version >= \"3.10\" and python_version < \"3.11\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "jf-ingest==0.0.121",
     "structlog>=24.4.0",
+    "colorama>=0.4.6",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.120",
+    "jf-ingest==0.0.121",
     "structlog>=24.4.0",
 ]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "click~=8.0.4",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
-    "jf-ingest==0.0.105",
+    "jf-ingest==0.0.120",
     "structlog>=24.4.0",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
### Description

Introduce the ADO adapter to Agent.

A lot of this seems to be `isort` and `black`?

The bulk of this logic is to allow somebody to provide an ADO config/creds combo and run the Agent. [To see my proof of testing](https://github.com/Jellyfish-AI/jellyfish/pull/24558), see this PR (which is in Jellyfish, to protect a customer name)

### Testing

To test backwards compatibility, I ran the Agent for orthog for both Jira and Git. Additionally I did more testing for a specific customer, [but I am keeping that testing plan in this private PR](https://github.com/Jellyfish-AI/jellyfish/pull/24558) for customer privacy concerns.

```
Logging setup complete with handlers for log file, stdout, and streaming.
Will write output files into ./output/20240805_175013
Running ingestion healthcheck validation!
Validating configuration...

Jira details:
  URL:      https://jelly-ai.atlassian.net
  Username: jira@jellyfish.co
  Password: **********
==> Testing Jira connection...
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
==> Getting Jira version...
Found Jira version as 1001.0.0-SNAPSHOT
==> Getting Jira deployment type...
Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
==> Getting Jira permissions...
Found granted permissions as ['DELETE_OWN_WORKLOGS', 'CREATE_ISSUES', 'WORK_ON_ISSUES', 'DELETE_OWN_COMMENTS', 'MODIFY_REPORTER', 'EDIT_ISSUES', 'ADD_COMMENTS', 'EDIT_OWN_COMMENTS', 'ASSIGN_ISSUES', 'BROWSE_PROJECTS', 'EDIT_OWN_WORKLOGS', 'EDIT_ALL_WORKLOGS', 'EDIT_ALL_COMMENTS', 'CLOSE_ISSUES', 'SET_ISSUE_SECURITY', 'SCHEDULE_ISSUES', 'USER_PICKER', 'ADMINISTER_PROJECTS', 'DELETE_ALL_COMMENTS', 'RESOLVE_ISSUES', 'DELETE_ISSUES', 'VIEW_READONLY_WORKFLOW', 'MOVE_ISSUES', 'ASSIGNABLE_USER', 'TRANSITION_ISSUES', 'DELETE_ALL_WORKLOGS', 'LINK_ISSUES']
==> Testing Jira user browsing permissions...
Downloading Users...
Done downloading Users! Found 505 users
We can access 505 Jira users.
==> Testing Jira project permissions...
With provided credentials, the following projects are discoverable: {'JFR', 'OJ'}.
Checking project access.
Testing access for project: "JFR"
With provided credentials, we can access issues, versions, and components within project JFR
Testing access for project: "OJ"
With provided credentials, we can access issues, versions, and components within project OJ
Checking access to fields
Checking access to resolutions
Checking access to issue types
Checking access to issue link types
Checking access to priorities
Checking access to boards
Checking access to sprints
. Skipping Git Validation.

Memory & Disk Usage:
  Available memory: 743.87 MB
  Disk usage for jf_agent/output: 299 GB / 460 GB
  Size of jf_agent/output dir:  24K
Attempting to upload healthcheck result to s3...
Successfully uploaded healthcheck.json
Successfully uploaded jf_agent.log
Successfully uploaded healthcheck result to s3!

Done
Obtained Jira configuration, attempting download...
Attempting to use JF Ingest for Jira Ingestion
Set global value INGESTION_TYPE to AGENT
Beginning load_and_push_jira_to_s3
Using local version of ingest
Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
Data will not be saved locally
Data will be submitted to jellyfish
Downloading Jira Projects...
Done downloading Projects!
Downloading Jira Project Components...
Done downloading Project Components!
Downloading Jira Versions...
Done downloading Jira Versions!
Done downloading Jira Project, Components, and Version. Found 2 projects
Downloading Jira Fields...
Done downloading Jira Fields! Found 220 fields
Downloading Users...
Done downloading Users! Found 505 users
Downloading Jira Resolutions...
Done downloading Jira Resolutions! Found 9 resolutions
Downloading IssueTypes...
Done downloading IssueTypes! found 34 Issue Types
Downloading IssueLinkTypes...
Done downloading IssueLinkTypes! Found 10 Issue Link Types
Downloading Jira Priorities...
Done downloading Jira Priorities! Found 5 priorities
Downloading Jira Statuses...
Done downloading Jira Statuses! Found 124
Downloading Boards...
Done downloading Boards! Found 58 boards
Downloading Sprints...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 58/58 [00:16<00:00,  3.48it/s]
Attempting to pull issue metadata for 2 projects, with a pull from date set as 2017-01-01 00:00:00+00:00
Getting total issue counts for 2 projects (Thread Count: 10): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.20it/s]
Pulling issue data across 2 projects by Date (Thread Count: 10): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 37943/37943 [00:31<00:00, 1203.29it/s]
Attempting to pull metadata for an additional 13 issues, which represents issue parents that we need to potentially redownload. (Parent Search Depth = 1)
Pulling issue data for 13 Jira Issue IDs (Thread Count: 10): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 29.91it/s]
Only grabbing the first level of parents, because recursively_download_parents is False
Using IssueMetadata we have detected that 336 issues are missing, 745 issues are out of date, 0 issues need to be redownloaded (because of rekey and parent relations), for a total of 1081 issues to download
Attempting to pull 1081 full issues
Pulling issue data for 1081 Jira Issue IDs (Thread Count: 10): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1081/1081 [00:08<00:00, 126.51it/s]
Successfully saved 1081 Jira Issues in 2 separate batches, with each batch limited to 50MB per batch
22096 issues have been detected as being deleted
Downloading Jira Worklogs...
Fetching updated worklogs
Done fetching updated worklogs
Fetching deleted worklogs
Done fetching deleted worklogs
Done downloading Worklogs! Found 0 worklogs and 0 deleted worklogs
Data has not been saved locally, because save_locally was set to false in the ingest config!
Data has been submitted to jellyfish
Starting Git download for 1 provided git configurations
downloading github users... ✓
downloading github projects... ✓
downloading github repos... ✓
downloading commits on branch develop for jellyfish: 340commits [00:03, 104.12commits/s]
downloading PRs for jellyfish: 34prs [01:01,  1.81s/prs]
Shutting down Systems Diagnostics Thread
Closing Diagnostics file
Compressing ./output/20240805_175013/diagnostics.json
Compressing ./output/20240805_175013/healthcheck.json
Sending data to Jellyfish...
Starting 8 threads
Successfully uploaded healthcheck.json.gz
Successfully uploaded status.json.gz
Successfully uploaded git_8v1crHqhmq/bb_projects.json.gz
Successfully uploaded diagnostics.json.gz
Successfully uploaded git_8v1crHqhmq/bb_users.json.gz
Successfully uploaded git_8v1crHqhmq/bb_repos.json.gz
Successfully uploaded git_8v1crHqhmq/bb_prs.json.gz
Successfully uploaded git_8v1crHqhmq/bb_commits.json.gz
Successfully uploaded config.yml
Agent run succeeded: True
Successfully uploaded jf_agent.log
Successfully uploaded .done
Done!
Closing the agent log stream.
Log stream stopped.
```