### PR TITLE
OJ-37554 - Add try/except around request

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -144,11 +144,11 @@ def main():
         config.debug_http_requests,
     )
 
+    company_slug = None
     try:
         company_info = get_company_info(config, creds)
         company_slug = company_info.get('company_slug')
     except Exception as e:
-        company_slug = None
         logger.warning(f"Unable to get company slug from Jellyfish API: {e}")
 
     agent_logging.bind_default_agent_context(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -144,8 +144,13 @@ def main():
         config.debug_http_requests,
     )
 
-    company_info = get_company_info(config, creds)
-    company_slug = company_info.get('company_slug')
+    try:
+        company_info = get_company_info(config, creds)
+        company_slug = company_info.get('company_slug')
+    except Exception as e:
+        company_slug = None
+        logger.warning(f"Unable to get company slug from Jellyfish API: {e}")
+
     agent_logging.bind_default_agent_context(
         config.run_mode,
         company_slug,


### PR DESCRIPTION
Adds a try/except around request to Jellyfish API when attempting to retrieve company slug