### PR TITLE
OJ-38960: refactor agent to use feature flags and grab redownloaded i…

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -448,6 +448,9 @@ def get_ingest_config(
             skip_issues=False,
             only_issues=False,
             recursively_download_parents=config.jira_recursively_download_parents,
+            jellyfish_issue_ids_for_redownload=endpoint_jira_info.get(
+                'issue_ids_to_redownload', []
+            ),
             #
             # worklogs
             download_worklogs=config.jira_download_worklogs,
@@ -455,8 +458,7 @@ def get_ingest_config(
             # expects a datetime. Do a quick conversion here
             work_logs_pull_from=datetime.fromtimestamp(work_logs_timestamp),
             # Jira Ingest Feature Flags
-            # TODO: Generate from launchdarkly
-            feature_flags={},
+            feature_flags=endpoint_jira_info.get('jf_ingest_feature_flags', {}),
         )
 
     git_configs: List[JFIngestGitConfig] = []

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -692,24 +692,19 @@ def download_data(
         jira_connection = get_basic_jira_connection(config, creds)
         if config.run_mode_is_print_all_jira_fields:
             print_all_jira_fields(config, jira_connection)
-        if endpoint_jira_info.get('use_jf_ingest_for_jira', False):
-            try:
-                logger.info(f'Attempting to use JF Ingest for Jira Ingestion')
-                success = load_and_push_jira_to_s3(ingest_config)
-                success_status_str = 'success' if success else 'failed'
-                download_data_status.append({'type': 'Jira', 'status': success_status_str})
-            except Exception as e:
-                logger.error(
-                    'Error encountered when downloading Jira data. '
-                    'This Jira submission will be marked as failed. '
-                    f'Error: {e}'
-                )
-                logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
-                download_data_status.append({'type': 'Jira', 'status': 'failed'})
-        else:
-            download_data_status.append(
-                load_and_dump_jira(config, endpoint_jira_info, jira_connection)
+        try:
+            logger.info(f'Attempting to use JF Ingest for Jira Ingestion')
+            success = load_and_push_jira_to_s3(ingest_config)
+            success_status_str = 'success' if success else 'failed'
+            download_data_status.append({'type': 'Jira', 'status': success_status_str})
+        except Exception as e:
+            logger.error(
+                'Error encountered when downloading Jira data. '
+                'This Jira submission will be marked as failed. '
+                f'Error: {e}'
             )
+            logging_helper.send_to_agent_log_file(traceback.format_exc(), level=logging.ERROR)
+            download_data_status.append({'type': 'Jira', 'status': 'failed'})
 
     if len(config.git_configs) == 0:
         return download_data_status


### PR DESCRIPTION
### Description

Previously, the Agent wasn't taking in feature flags related to JF Ingest. Now, we read the feature flags via the API. Additionally, we now also get the list of issues IDs that need redownloading (which is needed for the "new sync path" in JF Ingest)

### Testing

To test, I ran an Agent run with the new code. I verified we use the new sync path and that we properly redownload issues marked for redownload (I manually marked one issue for redownload)

```
➜  jf_agent git:(OJ-38960-check-feature-flags-and-get-redownloaded-issue-ids) ✗ pdm run jf_agent/main.py -e ./creds.env --jellyfish-api-base http://localhost:8000
2024-10-01 18:24:04 [info    ] Logging setup complete with handlers for log file, stdout, and streaming.
2024-10-01 18:24:24 [info    ] Will write output files into ./output/20241001_182404
2024-10-01 18:24:24 [info    ] Running ingestion healthcheck validation!
2024-10-01 18:24:24 [info    ] Validating configuration...

Jira details:
  URL:      https://jelly-ai.atlassian.net
  Username: jira@jellyfish.co
  Password: **********
2024-10-01 18:24:24 [info    ] ==> Testing Jira connection...
2024-10-01 18:24:24 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
2024-10-01 18:24:25 [info    ] ==> Getting Jira version...
2024-10-01 18:24:25 [info    ] Found Jira version as 1001.0.0-SNAPSHOT
2024-10-01 18:24:25 [info    ] ==> Getting Jira deployment type...
2024-10-01 18:24:25 [info    ] Response headers does not contain X-ANODEID! Customer is NOT running Jira Data Center.
2024-10-01 18:24:25 [info    ] ==> Getting Jira permissions...
2024-10-01 18:24:25 [info    ] Found granted permissions as ['DELETE_OWN_WORKLOGS', 'CREATE_ISSUES', 'WORK_ON_ISSUES', 'DELETE_OWN_COMMENTS', 'MODIFY_REPORTER', 'EDIT_ISSUES', 'ADD_COMMENTS', 'EDIT_OWN_COMMENTS', 'ASSIGN_ISSUES', 'BROWSE_PROJECTS', 'EDIT_OWN_WORKLOGS', 'EDIT_ALL_WORKLOGS', 'EDIT_ALL_COMMENTS', 'CLOSE_ISSUES', 'SET_ISSUE_SECURITY', 'SCHEDULE_ISSUES', 'USER_PICKER', 'DELETE_ALL_COMMENTS', 'ADMINISTER_PROJECTS', 'RESOLVE_ISSUES', 'DELETE_ISSUES', 'VIEW_READONLY_WORKFLOW', 'MOVE_ISSUES', 'TRANSITION_ISSUES', 'ASSIGNABLE_USER', 'LINK_ISSUES', 'DELETE_ALL_WORKLOGS']
2024-10-01 18:24:25 [info    ] ==> Testing Jira user browsing permissions...
2024-10-01 18:24:25 [info    ] Downloading Users...
2024-10-01 18:24:26 [info    ] Done downloading Users! Found 533 users
2024-10-01 18:24:26 [info    ] We can access 533 Jira users.
2024-10-01 18:24:26 [info    ] ==> Testing Jira project permissions...
2024-10-01 18:24:26 [info    ] With provided credentials, the following projects are discoverable: {'JFR', 'OJ'}.
Checking project access.
2024-10-01 18:24:26 [info    ] Testing access for project: "JFR"
2024-10-01 18:24:27 [info    ] With provided credentials, we can access issues, versions, and components within project JFR
2024-10-01 18:24:27 [info    ] Testing access for project: "OJ"
2024-10-01 18:24:28 [info    ] With provided credentials, we can access issues, versions, and components within project OJ
2024-10-01 18:24:28 [info    ] Checking access to fields
2024-10-01 18:24:28 [info    ] Checking access to resolutions
2024-10-01 18:24:28 [info    ] Checking access to issue types
2024-10-01 18:24:29 [info    ] Checking access to issue link types
2024-10-01 18:24:29 [info    ] Checking access to priorities
2024-10-01 18:24:29 [info    ] Checking access to boards
2024-10-01 18:24:29 [info    ] Checking access to sprints
2024-10-01 18:24:41 [info    ] . Skipping Git Validation.

Memory & Disk Usage:
  Available memory: 829.41 MB
  Disk usage for jf_agent/output: 295 GB / 460 GB
  Size of jf_agent/output dir:  20K
2024-10-01 18:24:41 [info    ] Attempting to upload healthcheck result to s3...
2024-10-01 18:24:42 [info    ] Successfully uploaded healthcheck.json
2024-10-01 18:24:42 [info    ] Successfully uploaded jf_agent.log
2024-10-01 18:24:42 [info    ] Successfully uploaded healthcheck result to s3!
2024-10-01 18:24:42 [info    ]
Done
2024-10-01 18:24:43 [info    ] Obtained Jira configuration, attempting download...
2024-10-01 18:24:43 [info    ] Attempting to use JF Ingest for Jira Ingestion
Set global value INGESTION_TYPE to AGENT
2024-10-01 18:24:43 [info    ] Beginning load_and_push_jira_to_s3
2024-10-01 18:24:43 [info    ] Using local version of ingest
2024-10-01 18:24:43 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for jira@jellyfish.co of company orthogonal-networks
2024-10-01 18:24:43 [info    ] Data will not be saved locally
2024-10-01 18:24:43 [info    ] Data will be submitted to jellyfish
2024-10-01 18:24:43 [info    ] Downloading Jira Projects...
2024-10-01 18:24:43 [info    ] Done downloading Projects!
2024-10-01 18:24:43 [info    ] Downloading Jira Project Components...
2024-10-01 18:24:44 [info    ] Done downloading Project Components!
2024-10-01 18:24:44 [info    ] Downloading Jira Versions...
2024-10-01 18:24:44 [info    ] Done downloading Jira Versions!
2024-10-01 18:24:44 [info    ] Done downloading Jira Project, Components, and Version. Found 2 projects
2024-10-01 18:24:45 [info    ] Downloading Jira Fields...
2024-10-01 18:24:45 [info    ] Done downloading Jira Fields! Found 230 fields
2024-10-01 18:24:46 [info    ] Downloading Users...
2024-10-01 18:24:46 [info    ] Done downloading Users! Found 533 users
2024-10-01 18:24:47 [info    ] Downloading Jira Resolutions...
2024-10-01 18:24:47 [info    ] Done downloading Jira Resolutions! Found 9 resolutions
2024-10-01 18:24:48 [info    ] Downloading IssueTypes...
2024-10-01 18:24:48 [info    ] Done downloading IssueTypes! found 34 Issue Types
2024-10-01 18:24:48 [info    ] Downloading IssueLinkTypes...
2024-10-01 18:24:48 [info    ] Done downloading IssueLinkTypes! Found 10 Issue Link Types
2024-10-01 18:24:49 [info    ] Downloading Jira Priorities...
2024-10-01 18:24:49 [info    ] Done downloading Jira Priorities! Found 5 priorities
2024-10-01 18:24:49 [info    ] Downloading Jira Statuses...
2024-10-01 18:24:50 [info    ] Done downloading Jira Statuses! Found 129
2024-10-01 18:24:50 [info    ] Downloading Boards...
2024-10-01 18:24:51 [info    ] Done downloading Boards! Found 62 boards
2024-10-01 18:24:56 [info    ] Using 100 as batch size for issue downloads. Full Redownload is False
2024-10-01 18:24:56 [info    ] Processing projects and issues from remote
2024-10-01 18:24:56 [info    ] Fetching list of all jira issue ID/key from remote to match local
Getting total issue counts for 2 projects (Thread Count: 10): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  2.73it/s]
2024-10-01 18:25:08 [info    ] 61734 issues local, 39451 issues remote, 22385 issues deleted
2024-10-01 18:25:08 [info    ] 0 issues have been detected as being rekeyed. These will be redownloaded
2024-10-01 18:25:08 [info    ] 102 issues found on remote not found on local. These will be downloaded.
2024-10-01 18:25:08 [info    ] Attempting to pull all the full Jira Issues that have been updated since our last Jira Download across 2 projects.
Getting total issue counts for 2 projects (Thread Count: 10): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  6.13it/s]
Pulling issue data across 2 projects by Date (Thread Count: 10): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 350/350 [00:07<00:00, 45.67it/s]
2024-10-01 18:25:17 [info    ] Successfully saved 350 Jira Issues in 1 separate batches, with each batch limited to 50MB per batch
2024-10-01 18:25:17 [info    ] We have downloaded 350 issues that have been updated or created since our last pull across 2 projects.
Pulling issue data for 1 Jira Issue IDs (Thread Count: 10): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.31it/s]
2024-10-01 18:25:19 [info    ] Successfully saved 1 Jira Issues in 1 separate batches, with each batch limited to 50MB per batch
2024-10-01 18:25:19 [info    ] 22385 issues have been detected as being deleted
2024-10-01 18:25:20 [info    ] Downloading Jira Worklogs...
2024-10-01 18:25:20 [info    ] Fetching updated worklogs
2024-10-01 18:25:21 [info    ] Done fetching updated worklogs
2024-10-01 18:25:21 [info    ] Fetching deleted worklogs
2024-10-01 18:25:21 [info    ] Done fetching deleted worklogs
2024-10-01 18:25:21 [info    ] Done downloading Worklogs! Found 0 worklogs and 0 deleted worklogs
2024-10-01 18:25:21 [info    ] Data has not been saved locally, because save_locally was set to false in the ingest config!
2024-10-01 18:25:21 [info    ] Data has been submitted to jellyfish
2024-10-01 18:25:21 [info    ] Shutting down Systems Diagnostics Thread
2024-10-01 18:25:21 [info    ] Closing Diagnostics file
2024-10-01 18:25:21 [info    ] Compressing ./output/20241001_182404/diagnostics.json
2024-10-01 18:25:21 [info    ] Compressing ./output/20241001_182404/healthcheck.json
2024-10-01 18:25:21 [info    ] Sending data to Jellyfish...
2024-10-01 18:25:22 [info    ] Starting 3 threads
2024-10-01 18:25:22 [info    ] Successfully uploaded healthcheck.json.gz
2024-10-01 18:25:22 [info    ] Successfully uploaded diagnostics.json.gz
2024-10-01 18:25:22 [info    ] Successfully uploaded status.json.gz
2024-10-01 18:25:23 [info    ] Successfully uploaded config.yml
2024-10-01 18:25:23 [info    ] Agent run succeeded: True
2024-10-01 18:25:23 [info    ] Successfully uploaded jf_agent.log
2024-10-01 18:25:24 [info    ] Successfully uploaded .done
2024-10-01 18:25:24 [info    ] Done!
2024-10-01 18:25:24 [info    ] Closing the agent log stream.
2024-10-01 18:25:24 [info    ] Log stream stopped.
```