### PR TITLE
Oj 39015 add in status debug log

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -16,6 +16,8 @@ import colorama
 import structlog
 from jf_ingest.logging_helper import AGENT_LOG_TAG
 
+from jf_agent.util import get_latest_agent_version
+
 '''
 Guidance on logging/printing in the agent:
 
@@ -353,13 +355,21 @@ def bind_default_agent_context(
     company_slug: Optional[str],
     upload_time: str,
 ) -> None:
+    commit_sha = os.getenv("SHA")
+    latest_commit_from_agent = get_latest_agent_version()
+    # Cloudwatch serializes booleans as 0 or 1, so cast this as a string for better readability
+    commit_is_latest = 'True' if commit_sha == latest_commit_from_agent else 'False'
     structlog.contextvars.clear_contextvars()
     structlog.contextvars.bind_contextvars(
         run_mode=run_mode,
         company_slug=company_slug,
         upload_time=upload_time,
         agent_run_uuid=str(uuid.uuid4()),
-        jf_meta={'commit': os.getenv("SHA"), 'commit_build_time': os.getenv("BUILDTIME")},
+        jf_meta={
+            'commit': commit_sha,
+            'commit_build_time': os.getenv("BUILDTIME"),
+            'commit_is_latest': commit_is_latest,
+        },
     )
 
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -156,6 +156,8 @@ def main():
         get_timestamp_from_outdir(config.outdir),
     )
 
+    logger.debug(f'Starting Agent run for...')
+    download_data_status = []
     success = True
     jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
 
@@ -325,8 +327,8 @@ def main():
         directories_to_skip=list(directories_to_skip_uploading_for),
         successful=error_and_timeout_free,
     )
-
     logger.info('Done!')
+    logger.debug(f'Statuses for Agent Data processed: {download_data_status}')
 
     try:
         diagnostics.send_diagnostic_end_reading(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -328,15 +328,25 @@ def main():
         successful=error_and_timeout_free,
     )
 
-    log_extras_status_dict = dict(statuses=dict())
+    log_extras_status_dict = dict(
+        statuses=dict(
+            overall=(
+                'success'
+                if all(s.get('status', '') == 'success' for s in download_data_status)
+                else 'failed'
+            )
+        )
+    )
     for status in download_data_status:
         if status.get('type', '').lower() == 'jira':
             log_extras_status_dict['statuses']['Jira'] = status.get('status', '')
         if status.get('type', '').lower() == 'git':
             if instance_slug := status.get('instance'):
                 if 'Git' not in log_extras_status_dict:
-                    log_extras_status_dict['statuses']['Git'] = {}
-                log_extras_status_dict['statuses']['Git'][instance_slug] = status.get('status', '')
+                    log_extras_status_dict['statuses']['Git'] = []
+                log_extras_status_dict['statuses']['Git'].append(
+                    f"{instance_slug} = {status.get('status', '')}"
+                )
 
     logger.info('Done!', extra=log_extras_status_dict)
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -328,26 +328,10 @@ def main():
         successful=error_and_timeout_free,
     )
 
-    log_extras_status_dict = dict(
-        statuses=dict(
-            overall=(
-                'success'
-                if all(s.get('status', '') == 'success' for s in download_data_status)
-                else 'failed'
-            )
-        )
+    # Add some additional, structured status logging as part of the final "Done!" logging message
+    log_extras_status_dict = agent_logging.generate_logging_extras_dict_for_done_message(
+        download_data_status
     )
-    for status in download_data_status:
-        if status.get('type', '').lower() == 'jira':
-            log_extras_status_dict['statuses']['Jira'] = status.get('status', '')
-        if status.get('type', '').lower() == 'git':
-            if instance_slug := status.get('instance'):
-                if 'Git' not in log_extras_status_dict:
-                    log_extras_status_dict['statuses']['Git'] = []
-                log_extras_status_dict['statuses']['Git'].append(
-                    f"{instance_slug} = {status.get('status', '')}"
-                )
-
     logger.info('Done!', extra=log_extras_status_dict)
 
     try:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -156,7 +156,7 @@ def main():
         get_timestamp_from_outdir(config.outdir),
     )
 
-    logger.debug(f'Starting Agent run for...')
+    logger.debug(f'Starting Agent run...')
     download_data_status = []
     success = True
     jellyfish_endpoint_info = obtain_jellyfish_endpoint_info(config, creds)
@@ -327,8 +327,18 @@ def main():
         directories_to_skip=list(directories_to_skip_uploading_for),
         successful=error_and_timeout_free,
     )
-    logger.info('Done!')
-    logger.debug(f'Statuses for Agent Data processed: {download_data_status}')
+
+    log_extras_status_dict = dict(statuses=dict())
+    for status in download_data_status:
+        if status.get('type', '').lower() == 'jira':
+            log_extras_status_dict['statuses']['Jira'] = status.get('status', '')
+        if status.get('type', '').lower() == 'git':
+            if instance_slug := status.get('instance'):
+                if 'Git' not in log_extras_status_dict:
+                    log_extras_status_dict['statuses']['Git'] = {}
+                log_extras_status_dict['statuses']['Git'][instance_slug] = status.get('status', '')
+
+    logger.info('Done!', extra=log_extras_status_dict)
 
     try:
         diagnostics.send_diagnostic_end_reading(

--- a/jf_agent/util.py
+++ b/jf_agent/util.py
@@ -1,17 +1,30 @@
+import logging
+from contextlib import contextmanager
+from itertools import islice
 from time import sleep
 from typing import Any, List
-from itertools import islice
+
 import requests
-from contextlib import contextmanager
-
-from jf_agent.exception import BadConfigException
-
-import logging
-
-from jf_agent.session import retry_session
 from jf_ingest import diagnostics, logging_helper
 
+from jf_agent.exception import BadConfigException
+from jf_agent.session import retry_session
+
 logger = logging.getLogger(__name__)
+
+
+def get_latest_agent_version():
+    try:
+        request = requests.get(
+            url='https://api.github.com/repos/Jellyfish-AI/jf_agent/commits/master'
+        )
+        request.raise_for_status()
+        return request.json()['sha']
+    except Exception as e:
+        logging_helper.send_to_agent_log_file(
+            f'Exception {e} encountered when trying to get latest Agent version sha'
+        )
+        return ''
 
 
 def split(lst: List[Any], n: int) -> List[List[Any]]:


### PR DESCRIPTION
## Description

In the agent we do a pretty good job with structured logging, but there isn't a quick way to tell via Log Insights if an agent run was successful or not. To fix this, I made some small adjustments to our logging in the Agent

1. I added a clearer "Starting Agent Run..." DEBUG log message, which will show up in log insights
2. I added an `commit_is_latest` tag in the structured logging, so that you can tell if the customer is running the latest Agent SHA or not
3. On the `Done!` log message, I added some structured logs associated with it that will show the status of each individual Agent task we tried to run. This will make it easier to search and monitor via Log Insights if we shipped a breaking change

 
<img width="1355" alt="Screenshot 2024-10-02 at 3 36 59 PM" src="https://github.com/user-attachments/assets/7b81f138-be7c-43a1-b901-2159088d2a18">
