### PR TITLE
OJ-39279: fix error handling when submitting logs to JF

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -174,6 +174,13 @@ class CustomQueueHandler(QueueHandler):
                 ),
                 headers=headers,
             )
+
+            resp = conn.getresponse()
+
+            if resp.status == 200:
+                self.batches_sent += 1
+                self.messages_to_send = []
+                self.last_message_send_time = now
         except:
             self.post_errors += 1
             if self.post_errors < self.post_error_threshold:
@@ -185,13 +192,6 @@ class CustomQueueHandler(QueueHandler):
                     'Max errors when posting logs to Jellyfish. Giving up, but continuing with the agent run.'
                 )
             return
-
-        resp = conn.getresponse()
-
-        if resp.status == 200:
-            self.batches_sent += 1
-            self.messages_to_send = []
-            self.last_message_send_time = now
 
     def handle(self, record: Union[logging.LogRecord, int]) -> None:
         now = datetime.now()


### PR DESCRIPTION
### Description

There is some faulty error handling when submitting logs to Jellyfish. We have a `try`/`except` block around our `con.request` call, but we do not have the `conn.getresponse()` logic wrapped in the `try` block. It is possible to raise errors here (connection already closed). This is bad. We NEVER want to fail because we fail to upload logs via the log stream. We want the agent to finish, because when it does finish we can get the full log file, as well as any data we churned through

### Testing

This is a small low risk change, and I'm not sure how to specifically recreate it locally. I ran the agent against orthog as a smoke test, though