### PR TITLE
OJ-39228: fix double uploading bug in git data

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -376,7 +376,7 @@ def get_ingest_config(
     Handles converting our agent config to the jf_ingest IngestionConfig
     shared dataclass.
     """
-    from jf_agent.git.utils import JF_INGEST_SUPPORTED_PROVIDERS
+    from jf_agent.git.utils import GH_PROVIDER, JF_INGEST_SUPPORTED_PROVIDERS
 
     company_info = get_company_info(config, creds)
 
@@ -479,6 +479,12 @@ def get_ingest_config(
             endpoint_git_instance_info = list(endpoint_git_instances_info.values())[0]
             instance_creds = list(creds.git_instance_to_creds.values())[0]
             instance_slug = endpoint_git_instance_info['slug']
+
+        if agent_git_config.git_provider == GH_PROVIDER and not endpoint_git_instance_info.get(
+            'supports_graphql_endpoints', False
+        ):
+            # For legacy reasons, to use the JF Ingest adapter for Github you need to have this feature flag enabled
+            continue
 
         jf_ingest_git_auth_config = _get_jf_ingest_git_auth_config(
             company_slug=company_slug,

--- a/jf_agent/git/utils.py
+++ b/jf_agent/git/utils.py
@@ -2,6 +2,8 @@ import fnmatch
 import logging
 from typing import Any, List
 
+from jf_ingest.config import GitProviderInJellyfishRepo
+
 logger = logging.getLogger(__name__)
 
 '''
@@ -27,6 +29,10 @@ PROVIDERS = (
 JF_INGEST_SUPPORTED_PROVIDERS = (
     GH_PROVIDER,
     ADO_PROVIDER,
+    # Agent and Jellyfish (Direct Connect) enums don't match 100%,
+    # so this list must account for both
+    GitProviderInJellyfishRepo.GITHUB.value,
+    GitProviderInJellyfishRepo.ADO.value,
 )
 
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -279,12 +279,16 @@ def main():
                     # JF Ingest
                     from jf_agent.git.utils import JF_INGEST_SUPPORTED_PROVIDERS
 
+                    # Extreme paranoia, normalize everything to lowercase
+                    lower_case_supported_providers = [
+                        provider.lower() for provider in JF_INGEST_SUPPORTED_PROVIDERS
+                    ]
                     directories_to_skip_uploading_for.update(
                         [
                             f'git_{git_config.instance_file_key}'
                             for git_config in ingest_config.git_configs
                             if git_config.git_provider.value.lower()
-                            in JF_INGEST_SUPPORTED_PROVIDERS
+                            in lower_case_supported_providers
                         ]
                     )
                     # Jira is supported by all customers, always skip it


### PR DESCRIPTION
### Description

There is a bug that occurs when uploading git data via JF Ingest. JF Ingest uploads data as it gets it, this is good and intentional. At the end of the agent processing we then check if we need to upload any additional data. There is a bug where do not detect the already uploaded git data properly, and we upload it twice

### Testing

I tested this with orthog git uploading and verified that we do not upload twice

Old upload pattern (bad 😢)
<img width="1545" alt="Screenshot 2024-10-16 at 1 06 54 PM" src="https://github.com/user-attachments/assets/506c8ab8-1705-44b2-8503-97ce89fc6638">

New upload pattern (good 😄)
<img width="1576" alt="Screenshot 2024-10-16 at 1 07 37 PM" src="https://github.com/user-attachments/assets/dc1fd302-110c-4cf2-b623-638c717e262e">