### PR TITLE
OJ-39135 - Custom field repair for Jira server/dc customers

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -406,6 +406,11 @@ def get_ingest_config(
             project_id_to_pull_from[im.project_id] = max(
                 im.updated, project_id_to_pull_from[im.project_id]
             )
+
+        jf_issue_ids_for_redownload = endpoint_jira_info.get('issue_ids_to_redownload', set())
+        if isinstance(jf_issue_ids_for_redownload, list):
+            jf_issue_ids_for_redownload = set(jf_issue_ids_for_redownload)
+
         jira_config: JiraDownloadConfig = JiraDownloadConfig(
             company_slug=company_slug,
             #
@@ -448,10 +453,7 @@ def get_ingest_config(
             skip_issues=False,
             only_issues=False,
             recursively_download_parents=config.jira_recursively_download_parents,
-            jellyfish_issue_ids_for_redownload=endpoint_jira_info.get(
-                'issue_ids_to_redownload', []
-            ),
-            #
+            jellyfish_issue_ids_for_redownload=jf_issue_ids_for_redownload,
             # worklogs
             download_worklogs=config.jira_download_worklogs,
             # we are passed the raw unix timestamp for work logs, but jf_ingest

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -89,7 +89,6 @@ def detect_and_repair_custom_fields(
     thread_count = 10
 
     # Enable use of adaptive throttler for Jira server/dc
-    # TEMP REMOVE BEFORE MERGING
     if deployment_type != 'Cloud':
         # If issue_download_concurrent_threads is set in the config, use that number of threads
         # Otherwise, use the feature flag to determine thread count for Jira server/dc

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -4,7 +4,6 @@ import traceback
 from typing import Optional
 
 from jf_ingest import diagnostics, logging_helper
-from jf_ingest.adaptive_throttler import AdaptiveThrottler
 from jf_ingest.config import IngestionConfig
 from jf_ingest.jf_jira import load_and_push_jira_to_s3
 from jf_ingest.jf_jira.auth import get_jira_connection as get_jira_connection_from_jf_ingest

--- a/jf_agent/jf_jira/jira_download.py
+++ b/jf_agent/jf_jira/jira_download.py
@@ -83,10 +83,7 @@ def detect_and_repair_custom_fields(
 ) -> Optional[set[str]]:
     jira_connection = get_jira_connection_from_jf_ingest(ingest_config.jira_config)
     deployment_type = jira_connection.server_info()['deploymentType']
-    use_adaptive_throttler = False
-
-    # Default thread count of 10
-    thread_count = 10
+    kwargs: dict[str, Union[str, int, bool]] = {}
 
     # Enable use of adaptive throttler for Jira server/dc
     if deployment_type != 'Cloud':
@@ -100,13 +97,12 @@ def detect_and_repair_custom_fields(
         )
 
         logger.info(f'Using adaptive throttler with {thread_count} threads for custom field repair')
-        use_adaptive_throttler = True
+        kwargs.update({'nthreads': thread_count, 'use_throttler': True})
 
     jcfv_update_payload: JCFVUpdateFullPayload = identify_custom_field_mismatches(
         ingest_config,
-        nthreads=thread_count,
         mark_for_redownload=submit_issues_for_repair,
-        use_throttler=use_adaptive_throttler,
+        **kwargs,
     )
 
     if submit_issues_for_repair:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d58999034370241bde9aa2b95e821fff9a0d891ae07e5f70014020e8fe5e9b3c"
+content_hash = "sha256:4a288415d61f93d7a846a2b49c8327cb1b95f330dc0f1067c5632869265a3969"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.11"
@@ -461,7 +461,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.149"
+version = "0.0.153"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 groups = ["default"]
@@ -480,8 +480,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.149-py3-none-any.whl", hash = "sha256:ef5a685d6b5d56847eb29159383555ea6dbcdc44dab676dd29cc6b94aca4d9ea"},
-    {file = "jf_ingest-0.0.149.tar.gz", hash = "sha256:ead87254b44692486a5cb7529bf6558d59db3f3fa0962850fda8926e08002fff"},
+    {file = "jf_ingest-0.0.153-py3-none-any.whl", hash = "sha256:5985aa435f074e6055225b320cc9728e43926af7cb3c196958e6433b9cee655b"},
+    {file = "jf_ingest-0.0.153.tar.gz", hash = "sha256:0c1dae67a654c98b3b07c0375c9cda880f95002dfb7508dc2f7566627f8e6a96"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:4a288415d61f93d7a846a2b49c8327cb1b95f330dc0f1067c5632869265a3969"
+content_hash = "sha256:76288b0c0beb3b779fa8d2009f90b05d96f864fd13ba7eae5130a411b429063b"
 
 [[metadata.targets]]
 requires_python = ">=3.10,<3.11"
@@ -461,7 +461,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.153"
+version = "0.0.155"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 groups = ["default"]
@@ -480,8 +480,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.153-py3-none-any.whl", hash = "sha256:5985aa435f074e6055225b320cc9728e43926af7cb3c196958e6433b9cee655b"},
-    {file = "jf_ingest-0.0.153.tar.gz", hash = "sha256:0c1dae67a654c98b3b07c0375c9cda880f95002dfb7508dc2f7566627f8e6a96"},
+    {file = "jf_ingest-0.0.155-py3-none-any.whl", hash = "sha256:6e3839bffb73438bfbae227439fe4ffe7388db8dacdde7dcc01d022eb54c719b"},
+    {file = "jf_ingest-0.0.155.tar.gz", hash = "sha256:07990fcb09a5af72daafa070aa59aea3b738c3e9aefa69a98b1a1b2a504aa5dc"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.4.0",
     "colorama>=0.4.6",
-    "jf-ingest==0.0.149",
+    "jf-ingest==0.0.153",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.4.0",
     "colorama>=0.4.6",
-    "jf-ingest==0.0.153",
+    "jf-ingest==0.0.155",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Enables custom field detect and repair for Jira server/datacenter customers. Utilizes a feature flag to quickly adjust the number of threads used during the process without requiring a code change. Also fixed a bug where `jellyfish_issue_ids_for_redownload` was a `list` object rather than a `set`.

Tested locally:

```
2024-11-21 16:36:22 [info    ] Logging setup complete with handlers for log file, stdout, and streaming.
2024-11-21 16:36:26 [info    ] Will write output files into ./output/20241121_163622
2024-11-21 16:36:26 [info    ] Running ingestion healthcheck validation!
2024-11-21 16:36:26 [info    ] Running Jira Download...
2024-11-21 16:36:26 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for eric.lheureux@jellyfish.co of company orthogonal-networks
2024-11-21 16:36:27 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for eric.lheureux@jellyfish.co of company orthogonal-networks
2024-11-21 16:36:27 [info    ] Using adaptive throttler with 10 threads for custom field repair
2024-11-21 16:36:27 [info    ] Attempting to identify custom field mismatches between Jira and Jellyfish
2024-11-21 16:36:27 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for eric.lheureux@jellyfish.co of company orthogonal-networks
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
2024-11-21 16:36:28 [info    ] No exporter configured. Using NoOpMetricProvider.
Detecting changes to custom fields in Jira...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57024/57024 [02:14<00:00, 423.19it/s]
2024-11-21 16:38:43 [info    ] Detect and repair custom fields completed successfully
2024-11-21 16:38:43 [info    ] Attempting to use JF Ingest for Jira Ingestion
2024-11-21 16:38:43 [info    ] Beginning load_and_push_jira_to_s3
2024-11-21 16:38:43 [info    ] Using local version of ingest
2024-11-21 16:38:43 [info    ] Authenticating to Jira API at https://jelly-ai.atlassian.net using the username and password secrets for eric.lheureux@jellyfish.co of company orthogonal-networks
2024-11-21 16:38:43 [info    ] Data will be saved locally to: ./output/20241121_163622
2024-11-21 16:38:43 [info    ] Data will be submitted to jellyfish
2024-11-21 16:38:43 [info    ] Downloading Jira Projects...
2024-11-21 16:38:43 [info    ] Done downloading Projects!
2024-11-21 16:38:43 [info    ] Downloading Jira Project Components...
2024-11-21 16:38:44 [info    ] Done downloading Project Components!
2024-11-21 16:38:44 [info    ] Downloading Jira Versions...
2024-11-21 16:38:44 [info    ] Done downloading Jira Versions!
2024-11-21 16:38:44 [info    ] Done downloading Jira Project, Components, and Version. Found 1 projects
2024-11-21 16:38:44 [info    ] Downloading Jira Fields...
2024-11-21 16:38:45 [info    ] Done downloading Jira Fields! Found 230 fields
2024-11-21 16:38:45 [info    ] Downloading Users...
2024-11-21 16:38:46 [info    ] Done downloading Users! Found 568 users
2024-11-21 16:38:46 [info    ] Downloading Jira Resolutions...
2024-11-21 16:38:47 [info    ] Done downloading Jira Resolutions! Found 10 resolutions
2024-11-21 16:38:47 [info    ] Downloading IssueTypes...
2024-11-21 16:38:47 [info    ] Done downloading IssueTypes! found 19 Issue Types
2024-11-21 16:38:48 [info    ] Downloading IssueLinkTypes...
2024-11-21 16:38:48 [info    ] Done downloading IssueLinkTypes! Found 10 Issue Link Types
2024-11-21 16:38:48 [info    ] Downloading Jira Priorities...
2024-11-21 16:38:48 [info    ] Done downloading Jira Priorities! Found 5 priorities
2024-11-21 16:38:49 [info    ] Downloading Jira Statuses...
2024-11-21 16:38:49 [info    ] Done downloading Jira Statuses! Found 126
2024-11-21 16:38:49 [info    ] Downloading Boards...
2024-11-21 16:38:50 [info    ] Done downloading Boards! Found 64 boards
Downloading Sprints...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [00:19<00:00,  3.20it/s]
2024-11-21 16:39:14 [info    ] Using 100 as batch size for issue downloads. Full Redownload is False
2024-11-21 16:39:14 [info    ] Processing projects and issues from remote
2024-11-21 16:39:14 [info    ] Fetching list of all jira issue ID/key from remote to match local
Getting total issue counts for 1 projects (Thread Count: 10): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.48it/s]
2024-11-21 16:39:23 [info    ] 57024 issues local, 30880 issues remote, 26154 issues deleted
2024-11-21 16:39:23 [info    ] 0 issues have been detected as being rekeyed. These will be redownloaded
2024-11-21 16:39:23 [info    ] 10 issues found on remote not found on local. These will be downloaded.
2024-11-21 16:39:23 [info    ] Attempting to pull all the full Jira Issues that have been updated since our last Jira Download across 1 projects.
Getting total issue counts for 1 projects (Thread Count: 10): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.26it/s]
Pulling issue data across 1 projects by Date (Thread Count: 10): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 158/158 [00:04<00:00, 35.26it/s]
2024-11-21 16:39:29 [info    ] Successfully saved 158 Jira Issues in 1 separate batches, with each batch limited to 50MB per batch
2024-11-21 16:39:29 [info    ] We have downloaded 158 issues that have been updated or created since our last pull across 1 projects.
2024-11-21 16:39:29 [info    ] Successfully saved 0 Jira Issues in 0 separate batches, with each batch limited to 50MB per batch
2024-11-21 16:39:29 [info    ] 26154 issues have been detected as being deleted
2024-11-21 16:39:30 [info    ] Downloading Jira Worklogs...
2024-11-21 16:39:30 [info    ] Fetching updated worklogs
2024-11-21 16:39:31 [info    ] Done fetching updated worklogs
2024-11-21 16:39:31 [info    ] Fetching deleted worklogs
2024-11-21 16:39:31 [info    ] Done fetching deleted worklogs
2024-11-21 16:39:31 [info    ] Done downloading Worklogs! Found 0 worklogs and 2 deleted worklogs
2024-11-21 16:39:31 [info    ] Data has been saved locally to: ./output/20241121_163622
2024-11-21 16:39:31 [info    ] Data has been submitted to jellyfish
2024-11-21 16:39:31 [info    ] Jira Download Complete
2024-11-21 16:39:31 [info    ] Shutting down Systems Diagnostics Thread
2024-11-21 16:39:31 [info    ] Closing Diagnostics file
2024-11-21 16:39:31 [info    ] Compressing ./output/20241121_163622/diagnostics.json
2024-11-21 16:39:31 [info    ] Sending data to Jellyfish...
2024-11-21 16:39:32 [info    ] Starting 2 threads
2024-11-21 16:39:32 [info    ] Successfully uploaded status.json.gz
2024-11-21 16:39:32 [info    ] Successfully uploaded diagnostics.json.gz
2024-11-21 16:39:32 [info    ] Successfully uploaded config.yml
2024-11-21 16:39:32 [info    ] Agent run succeeded: True
2024-11-21 16:39:33 [info    ] Successfully uploaded jf_agent.log
2024-11-21 16:39:34 [info    ] Successfully uploaded .done
2024-11-21 16:39:34 [info    ] Done!
2024-11-21 16:39:34 [info    ] Closing the agent log stream.
2024-11-21 16:39:34 [info    ] Log stream stopped.
```