### PR TITLE
OJ-40533: pass error message along in status dot json file

### DIFF
--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -397,6 +397,7 @@ def load_and_dump_git(
             'instance': instance_slug,
             'instance_key': instance_key,
             'status': 'failed',
+            'error_message': str(e),
         }
 
     return {


### PR DESCRIPTION
### Description

When the Agent has failed due to an exception, pass the exception message as part of the status JSON (which gets saved in the status.json file). This will save us time when diagnosing errors, because we can surface the error message in Prefect which is typically the first stop in debugging. For common failure cases (like getting a 403 from an expired token) this will speed up error diagnosing