### PR TITLE
[OJ-40908] Use cursor based pagination for Jira issue metadata

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -491,7 +491,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
     jf_options = agent_config_from_api.get("jf_options", {})
 
     # Most likely we'll need to pull additional Jira issue metadata. This is done
-    # using batches to prevent timeouts.
+    # using cursor based pagination to prevent timeouts.
     if jira_info.get('issue_metadata_cursor'):
         logger.info('Pulling additional Jira issue metadata from Jellyfish...')
         addtl_jira_issue_metadata = _get_additional_jira_issue_metadata(

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -475,6 +475,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
     resp = requests.get(
         f'{base_url}/endpoints/agent/pull-state',
         headers={'Jellyfish-API-Token': creds.jellyfish_api_token},
+        params={'use_pagination': True},
     )
 
     if not resp.ok:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -493,10 +493,10 @@ def obtain_jellyfish_endpoint_info(config, creds):
 
     # Most likely we'll need to pull additional Jira issue metadata. This is done
     # using cursor based pagination to prevent timeouts.
-    if jira_info.get('issue_metadata_cursor'):
+    if cursor := jira_info.get('issue_metadata_cursor'):
         logger.info('Pulling additional Jira issue metadata from Jellyfish...')
         addtl_jira_issue_metadata = _get_additional_jira_issue_metadata(
-            base_url, creds.jellyfish_api_token, jira_info['issue_metadata_cursor']
+            base_url, creds.jellyfish_api_token, cursor
         )
         jira_info['issue_metadata'].update(addtl_jira_issue_metadata)
         logger.info(f'Pulled a total of {len(jira_info["issue_metadata"])} Jira issue metadata')

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -495,7 +495,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
     if jira_info.get('issue_metadata_cursor'):
         logger.info('Pulling additional Jira issue metadata from Jellyfish...')
         addtl_jira_issue_metadata = _get_additional_jira_issue_metadata(
-            base_url, creds.jellyfish_api_token, jira_info['jira_issue_metadata_cursor']
+            base_url, creds.jellyfish_api_token, jira_info['issue_metadata_cursor']
         )
         jira_info['issue_metadata'].update(addtl_jira_issue_metadata)
         logger.info(f'Pulled a total of {len(jira_info["issue_metadata"])} Jira issue metadata')
@@ -559,8 +559,9 @@ def obtain_jellyfish_endpoint_info(config, creds):
 
 def _get_additional_jira_issue_metadata(base_url: str, api_token: str, cursor: int) -> dict:
     headers = {'Jellyfish-API-Token': api_token}
+    endpoint = f'{base_url}/endpoints/agent/jira-issue-metadata'
+
     next_cursor = cursor
-    base_endpoint = f'{base_url}/endpoints/agent/pull-state/jira-issue-metadata'
     jira_issues = {}
     req_count = 0
 

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -37,6 +37,7 @@ from jf_agent.jf_jira import (
     print_missing_repos_found_by_jira,
 )
 from jf_agent.jf_jira.jira_download import run_jira_download
+from jf_agent.jf_jira.utils import retry_for_status
 from jf_agent.util import UserProvidedCreds, get_company_info, upload_file
 from jf_agent.validation import ProjectMetadata, full_validate, validate_num_repos
 
@@ -489,11 +490,15 @@ def obtain_jellyfish_endpoint_info(config, creds):
     git_instance_info = agent_config_from_api.get('git_instance_info')
     jf_options = agent_config_from_api.get("jf_options", {})
 
+    # Most likely we'll need to pull additional Jira issue metadata. This is done
+    # using batches to prevent timeouts.
     if jira_info.get('issue_metadata_cursor'):
+        logger.info('Pulling additional Jira issue metadata from Jellyfish...')
         addtl_jira_issue_metadata = _get_additional_jira_issue_metadata(
             base_url, creds.jellyfish_api_token, jira_info['jira_issue_metadata_cursor']
         )
         jira_info['issue_metadata'].update(addtl_jira_issue_metadata)
+        logger.info(f'Pulled a total of {len(jira_info["issue_metadata"])} Jira issue metadata')
 
     # if no git info has returned from the endpoint, then an instance may not have been provisioned
     if len(config.git_configs) > 0 and not len(git_instance_info.values()):
@@ -555,23 +560,33 @@ def obtain_jellyfish_endpoint_info(config, creds):
 def _get_additional_jira_issue_metadata(base_url: str, api_token: str, cursor: int) -> dict:
     headers = {'Jellyfish-API-Token': api_token}
     next_cursor = cursor
-    endpoint = f'{base_url}/endpoints/agent/pull-state/jira-issue-metadata'
+    base_endpoint = f'{base_url}/endpoints/agent/pull-state/jira-issue-metadata'
     jira_issues = {}
+    req_count = 0
 
     while next_cursor:
-        r = requests.get(endpoint, headers=headers, params=params)
+        r = retry_for_status(
+            requests.get,
+            endpoint,
+            headers=headers,
+            params={'cursor': next_cursor},
+        )
 
         if not r.ok:
             logger.error(
-                f"ERROR: Couldn't get additional Jira issues from {endpoint} "
+                f'ERROR: Couldn\'t get additional Jira issues from {endpoint} '
                 f'using provided JELLYFISH_API_TOKEN (HTTP {r.status_code})'
             )
             raise BadConfigException()
 
-        data = r.json()
-        jira_issues.update(data['jira_issues'])
-        next_cursor = data.get('next_cursor', None)
+        rj = r.json()
+        jira_issues.update(rj['issue_metadata'])
+        next_cursor = rj['next_cursor']
+        req_count += 1
 
+    logger.info(
+        f'Pulled {len(jira_issues)} additional Jira issue metadata in {req_count} request(s)'
+    )
     return jira_issues
 
 


### PR DESCRIPTION
This change updates the logic for pulling Jira issue metadata from Jellyfish. This ensures customers with larger data sets aren't experiencing timeouts from substantial responses from the Jellyfish API endpoint for `agent/pull-state`.

This change cannot be merged until https://github.com/Jellyfish-AI/jellyfish/pull/26290 is deployed.

Tested locally (replaced values with `x`):

```
     ~/c/jf_agent     OJ-40908-pagination-jid !1  pdm run jf_agent/main.py -e ./creds.env --jellyfish-api-base http://localhost:8000
2024-12-20 19:00:52 [info    ] Logging setup complete with handlers for log file, stdout, and streaming.
2024-12-20 19:00:55 [info    ] Pulling additional Jira issue metadata from Jellyfish...
2024-12-20 19:01:02 [info    ] Pulled x additional Jira issue metadata in x request(s)
2024-12-20 19:01:02 [info    ] Pulled a total of x Jira issue metadata
2024-12-20 19:01:03 [info    ] Will write output files into ./output/20241220_190052
2024-12-20 19:01:03 [info    ] Running ingestion healthcheck validation!
.....
```