### PR TITLE
[OJ-40908] Verbose Jira issue metadata logging

### DIFF
--- a/jf_agent/exception.py
+++ b/jf_agent/exception.py
@@ -1,2 +1,20 @@
+import logging
+import traceback
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
 class BadConfigException(Exception):
-    pass
+    def __exit__(
+        self,
+        msg: str = 'BadConfigException (see earlier messages)',
+        exc: Optional[Exception] = None,
+    ):
+        super().__init__(msg)
+        logger.error(msg)
+
+        if exc:
+            exc_type = type(exc).__name__
+            logger.error(msg=f'{exc_type}: {str(exc)}')
+            logger.error(msg=f'Traceback:\n{traceback.format_exc()}')

--- a/jf_agent/exception.py
+++ b/jf_agent/exception.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class BadConfigException(Exception):
-    def __exit__(
+    def __init__(
         self,
         msg: str = 'BadConfigException (see earlier messages)',
         exc: Optional[Exception] = None,

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -503,9 +503,7 @@ def obtain_jellyfish_endpoint_info(config, creds):
                 base_url, creds.jellyfish_api_token, cursor
             )
         except Exception as e:
-            raise BadConfigException(
-                f'Couldn\'t get additional Jira issues from Jellyfish API: {e}', e
-            )
+            raise BadConfigException(f'Couldn\'t get additional Jira issues from Jellyfish API', e)
 
         jira_info['issue_metadata'].update(addtl_jira_issue_metadata)
         logger.info(


### PR DESCRIPTION
Add verbose logging when pulling additional Jira issue metadata from the Jellyfish cursor-based pagination endpoint. Also, enhance the logging when a `BadConfigException` is raised.

Tested locally (some numerical values replaced with `x`):

```
2024-12-24 19:53:10 [info    ] Logging setup complete with handlers for log file, stdout, and streaming.
2024-12-24 19:53:14 [info    ] Pulling additional Jira issue metadata from Jellyfish...
2024-12-24 19:53:14 [info    ] Pulling Jira issue metadata with cursor x (request 0)...
2024-12-24 19:53:16 [info    ] Request 1 took 2.09s
2024-12-24 19:53:17 [info    ] Pulled x Jira issue metadata so far in 1 requests and 2.13s.
2024-12-24 19:53:17 [info    ] Pulling Jira issue metadata with cursor x (request 1)...
2024-12-24 19:53:18 [info    ] Request 2 took 1.71s
2024-12-24 19:53:18 [info    ] Pulled x Jira issue metadata so far in 2 requests and 3.87s.
2024-12-24 19:53:18 [info    ] Done pulling Jira issue metadata. Took 3.87s in 2 requests to pull x issue metadata
2024-12-24 19:53:18 [info    ] Pulled a total of x additional Jira issue metadata
...
```