### PR TITLE
[OJ-40908] Issue metadata improvements

### DIFF
--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -479,7 +479,7 @@ def obtain_jellyfish_endpoint_info(config, creds, skip_jf_ingest_issue_metadata:
     params = {'use_pagination': True}
 
     if skip_jf_ingest_issue_metadata:
-        logger.info('Skipping JF ingest formatted issue metadata pull from Jellyfish API, will')
+        logger.info('Skipping JF ingest formatted issue metadata pull from Jellyfish API')
         params['skip_jf_ingest_issue_metadata'] = True
 
     try:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -472,14 +472,14 @@ def obtain_creds(config):
     )
 
 
-def obtain_jellyfish_endpoint_info(config, creds, skip_jf_ingest_issue_metadata: bool = False):
+def obtain_jellyfish_endpoint_info(config, creds, skip_jf_ingest_issue_metadata: bool = True):
     logger.info('Pulling agent state from Jellyfish API (agent/pull-state)...')
     base_url = config.jellyfish_api_base
 
     params = {'use_pagination': True}
 
     if skip_jf_ingest_issue_metadata:
-        logger.info('Skipping JF ingest issue metadata pull from Jellyfish API')
+        logger.info('Skipping JF ingest formatted issue metadata pull from Jellyfish API, will')
         params['skip_jf_ingest_issue_metadata'] = True
 
     try:
@@ -520,6 +520,7 @@ def obtain_jellyfish_endpoint_info(config, creds, skip_jf_ingest_issue_metadata:
         logger.info(f'Pulled a total of {len(jira_info["issue_metadata"])} Jira issue metadata')
 
     # if we set the flag to skip pulling jf ingest issue metadata, recreate them here
+    # using the existing issue metadata (which consists of the same data)
     if not jira_info.get('issue_metadata_for_jf_ingest'):
         logger.info('Recreating Jira issue metadata in JF ingest formatting...')
         metadata_objs: list[IssueMetadata] = []


### PR DESCRIPTION
This PR consists of two functional changes with how Jira issue metadata is pulled from Jellyfish:

1. When pulling issue metadata from Jellyfish, we actually pull two copies of it - one in a `dict` format and one in an object-to-json string format. This PR adds a param to the request made to JF so that only the `dict` formatted issue metadata is required. The required string formatted data is then recreated using the one copy of the data we pull. This greatly reduces the size of the initial `pull-state` request made to JF. This functionality is dependent on https://github.com/Jellyfish-AI/jellyfish/pull/26328.
2. While pulling issue metadata using the cursor-based pagination endpoint, the initial limit is set to the max results allowed from the endpoint (25k). On failures, we'll halve the current limit and try pulling from the endpoint again. This should help address any networking issues by reducing the size of each result.

Tested changes locally:
```
2024-12-26 21:41:43 [info    ] Logging setup complete with handlers for log file, stdout, and streaming.
2024-12-26 21:41:44 [info    ] Pulling agent state from Jellyfish API (agent/pull-state)...
2024-12-26 21:41:44 [info    ] Skipping JF ingest issue metadata pull from Jellyfish API
2024-12-26 21:41:45 [info    ] Successfully pulled agent config from Jellyfish API (agent/pull-state)
2024-12-26 21:41:45 [info    ] Pulling additional Jira issue metadata from Jellyfish...
2024-12-26 21:41:45 [info    ] Pulling x Jira issue metadata with cursor 36684 (request 0)...
2024-12-26 21:41:47 [info    ] Issue metadata request 1 took 1.45s
2024-12-26 21:41:47 [info    ] Pulled x Jira issue metadata so far in 1 request(s) and 1.48s.
2024-12-26 21:41:47 [info    ] Pulling x Jira issue metadata with cursor 64421 (request 1)...
2024-12-26 21:41:48 [info    ] Issue metadata request 2 took 1.38s
2024-12-26 21:41:48 [info    ] Pulled x Jira issue metadata so far in 2 request(s) and 2.88s.
2024-12-26 21:41:48 [info    ] Done pulling Jira issue metadata. Took 2.88 seconds/2 requests to pull x issue metadata
2024-12-26 21:41:48 [info    ] Pulled a total of x Jira issue metadata
2024-12-26 21:41:48 [info    ] Recreating Jira issue metadata in JF ingest formatting...
2024-12-26 21:41:52 [info    ] Created x Jira issue metadata objects in JF ingest format
.....
```