### PR TITLE
[OJ-40908] Only send diagnostic data if JF webhooks endpoint is reachable

### DIFF
--- a/jf_agent/agent_logging.py
+++ b/jf_agent/agent_logging.py
@@ -411,7 +411,7 @@ def bind_default_agent_context(
 
 def configure(
     outdir: str, webhook_base: str, api_token: str, debug_requests=False
-) -> AgentLoggingConfig:
+) -> tuple[AgentLoggingConfig, bool]:
     logging_handlers = []
     logging_listener = None
 
@@ -492,13 +492,15 @@ def configure(
             'Successful connection to JF streaming logs endpoint - Streaming logs to Jellyfish.'
         )
         logger.info(f'{log_msg}, streaming.')
+        webhook_connection_success = True
     else:
         logger.info(
             'Connection failed to JF streaming logs endpoint - Not streaming logs to Jellyfish.'
         )
         logger.info(f'{log_msg}.')
+        webhook_connection_success = False
 
-    return config
+    return config, webhook_connection_success
 
 
 def close_out(config: AgentLoggingConfig) -> None:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -140,7 +140,7 @@ def main():
         dotenv.load_dotenv(args.env_file)
 
     creds = obtain_creds(config)
-    logging_config = agent_logging.configure(
+    logging_config, webhook_connection_success = agent_logging.configure(
         config.outdir,
         config.jellyfish_webhook_base,
         creds.jellyfish_api_token,
@@ -168,20 +168,21 @@ def main():
     directories_to_skip_uploading_for = set()
 
     # send start signal to Agent heartbeat monitor
-    try:
-        diagnostics.send_diagnostic_start_reading(
-            jellyfish_webhook_base=JELLYFISH_WEBHOOK_BASE,
-            jellyfish_api_token=creds.jellyfish_api_token,
-            timestamp_key=get_timestamp_from_outdir(config.outdir),
-            will_run_git=bool(config.git_configs),
-            will_run_jira=bool(config.jira_url),
-            will_send=not config.run_mode == 'send_only',
-        )
-    except Exception as e:
-        logging_helper.send_to_agent_log_file(
-            f'Error encountered when attempting to send diagnostic heart beat start (Error: {e})',
-            level=logging.ERROR,
-        )
+    if webhook_connection_success:
+        try:
+            diagnostics.send_diagnostic_start_reading(
+                jellyfish_webhook_base=JELLYFISH_WEBHOOK_BASE,
+                jellyfish_api_token=creds.jellyfish_api_token,
+                timestamp_key=get_timestamp_from_outdir(config.outdir),
+                will_run_git=bool(config.git_configs),
+                will_run_jira=bool(config.jira_url),
+                will_send=not config.run_mode == 'send_only',
+            )
+        except Exception as e:
+            logging_helper.send_to_agent_log_file(
+                f'Error encountered when attempting to send diagnostic heart beat start (Error: {e})',
+                level=logging.ERROR,
+            )
 
     logger.info(f'Will write output files into {config.outdir}')
     diagnostics.open_file(config.outdir)
@@ -341,20 +342,21 @@ def main():
     )
     logger.info('Done!', extra=log_extras_status_dict)
 
-    try:
-        diagnostics.send_diagnostic_end_reading(
-            jellyfish_webhook_base=JELLYFISH_WEBHOOK_BASE,
-            jellyfish_api_token=creds.jellyfish_api_token,
-            timestamp_key=get_timestamp_from_outdir(config.outdir),
-            git_success=None,
-            jira_success=None,
-        )
-    except Exception as e:
-        logging_helper.send_to_agent_log_file(
-            f'Error encountered when attempting to send the Agent heart beat end marker. Error: {e}',
-            level=logging.ERROR,
-        )
-    agent_logging.close_out(logging_config)
+    if webhook_connection_success:
+        try:
+            diagnostics.send_diagnostic_end_reading(
+                jellyfish_webhook_base=JELLYFISH_WEBHOOK_BASE,
+                jellyfish_api_token=creds.jellyfish_api_token,
+                timestamp_key=get_timestamp_from_outdir(config.outdir),
+                git_success=None,
+                jira_success=None,
+            )
+        except Exception as e:
+            logging_helper.send_to_agent_log_file(
+                f'Error encountered when attempting to send the Agent heart beat end marker. Error: {e}',
+                level=logging.ERROR,
+            )
+        agent_logging.close_out(logging_config)
 
     return success
 


### PR DESCRIPTION
Only try to send agent diagnostic data to the JF webhooks endpoint if the earlier test to send logs to the same domain was successful