### PR TITLE
OJ-45053: bump version and change config

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -60,7 +60,7 @@ jira:
   # Generally, however, we recommend leaving this as False.
   filter_boards_by_projects: False
 
-  # When provided, we will recurively download all parents until we run out of parents
+  # When provided, we will recursively download all parents until we run out of parents
   # to download. WARNING: This may greatly increase Agent run time!
   recursively_download_parents: False
 

--- a/example.yml
+++ b/example.yml
@@ -51,6 +51,14 @@ jira:
 
   # Whether the agent should download sprints.  If omitted, defaults to True.
   download_sprints: True
+  # If False, the agent will attempt to download all boards it can see via
+  # the Jira Boards API. If set to True then we will only filter for boards
+  # that are associated with the projects you have specified in the
+  # `include_projects` or `exclude_projects` fields. This is useful if you
+  # have a large number of boards in your Jira instance and you only want
+  # to pull data from boards that are associated with the projects you are pulling.
+  # Generally, however, we recommend leaving this as False.
+  filter_boards_by_projects: False
 
   # When provided, we will recurively download all parents until we run out of parents
   # to download. WARNING: This may greatly increase Agent run time!
@@ -233,3 +241,12 @@ git:
     url: https://bitbucket-org2.yourcompany.com
     instance_slug: git_instance_slug_2
     creds_envvar_prefix: ORG2
+  - provider: gitlab
+    url: https://gitlab.yourcompany.com
+    instance_slug: git_instance_slug_3
+    creds_envvar_prefix: ORG3
+    # Gitlab only: whether to keep the base URL while paging or to use the URL returned by the response headers.
+    # This is useful when the Gitlab instance is behind a proxy and the base URL is not accessible.
+    # Leverages the keep_base_url arg provided by the gitlab API client: https://python-gitlab.readthedocs.io/en/stable/api/gitlab.html
+    # It is recommened that you DO NOT use this flag
+    keep_base_url: False

--- a/example.yml
+++ b/example.yml
@@ -248,5 +248,5 @@ git:
     # Gitlab only: whether to keep the base URL while paging or to use the URL returned by the response headers.
     # This is useful when the Gitlab instance is behind a proxy and the base URL is not accessible.
     # Leverages the keep_base_url arg provided by the gitlab API client: https://python-gitlab.readthedocs.io/en/stable/api/gitlab.html
-    # It is recommened that you DO NOT use this flag
+    # It is recommended that you DO NOT use this flag
     keep_base_url: False

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -12,6 +12,7 @@ from jf_ingest import logging_helper
 from jf_ingest.config import AzureDevopsAuthConfig as JFIngestAzureDevopsAuthConfig
 from jf_ingest.config import GitAuthConfig as JFIngestGitAuthConfig
 from jf_ingest.config import GitConfig as JFIngestGitConfig
+from jf_ingest.config import GitLabAuthConfig as JFIngestGitLabAuthConfig
 from jf_ingest.config import IngestionConfig, IngestionType, IssueMetadata, JiraDownloadConfig
 
 from jf_agent import JELLYFISH_API_BASE, VALID_RUN_MODES
@@ -37,6 +38,7 @@ class GitConfig:
     git_redact_names_and_urls: bool
     gitlab_per_page_override: bool
     git_verbose: bool
+    git_gitlab_keep_base_url: bool  # Option used only for Gitlab
     # For multi-git
     creds_envvar_prefix: str
     # legacy fields ==================
@@ -70,6 +72,7 @@ ValidatedConfig = namedtuple(
         'jira_issue_jql',
         'jira_download_worklogs',
         'jira_download_sprints',
+        'jira_filter_boards_by_projects',
         'jira_recursively_download_parents',
         'jira_skip_saving_data_locally',
         'git_configs',
@@ -167,6 +170,7 @@ def obtain_config(args) -> ValidatedConfig:
     jira_issue_jql = jira_config.get('issue_jql')
     jira_download_worklogs = jira_config.get('download_worklogs', True)
     jira_download_sprints = jira_config.get('download_sprints', True)
+    jira_filter_boards_by_projects = jira_config.get('filter_boards_by_projects', False)
     jira_recursively_download_parents = jira_config.get('recursively_download_parents', False)
     jira_skip_saving_data_locally = jira_config.get('skip_saving_data_locally', False)
 
@@ -278,6 +282,7 @@ def obtain_config(args) -> ValidatedConfig:
         jira_issue_jql,
         jira_download_worklogs,
         jira_download_sprints,
+        jira_filter_boards_by_projects,
         jira_recursively_download_parents,
         jira_skip_saving_data_locally,
         git_configs,  # array of GitConfig
@@ -341,11 +346,12 @@ def _get_jf_ingest_git_auth_config(
                 verify=not skip_ssl_verification,
             )
         if config.git_provider == GL_PROVIDER:
-            return JFIngestGitAuthConfig(
+            return JFIngestGitLabAuthConfig(
                 company_slug=company_slug,
                 token=git_creds['gitlab_token'],
                 base_url=config.git_url,
                 verify=not skip_ssl_verification,
+                keep_base_url=config.keep_base_url,
             )
         if config.git_provider == ADO_PROVIDER:
             return JFIngestAzureDevopsAuthConfig(
@@ -444,6 +450,7 @@ def get_ingest_config(
             #
             # Sprints/Boards Info
             download_sprints=config.jira_download_sprints,
+            filter_boards_by_projects=config.jira_filter_boards_by_projects,
             #
             # Issues
             full_redownload=False,
@@ -662,6 +669,7 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
         gitlab_per_page_override=git_config.get('gitlab_per_page_override', None),
         git_verbose=git_config.get('verbose', False),
         creds_envvar_prefix=creds_envvar_prefix,
+        git_gitlab_keep_base_url=git_config.get('keep_base_url', False),
         # legacy fields ===========
         git_include_bbcloud_projects=list(git_include_bbcloud_projects),
         git_exclude_bbcloud_projects=list(git_exclude_bbcloud_projects),

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -38,7 +38,7 @@ class GitConfig:
     git_redact_names_and_urls: bool
     gitlab_per_page_override: bool
     git_verbose: bool
-    git_gitlab_keep_base_url: bool  # Option used only for Gitlab
+    gitlab_keep_base_url: bool
     # For multi-git
     creds_envvar_prefix: str
     # legacy fields ==================
@@ -351,7 +351,7 @@ def _get_jf_ingest_git_auth_config(
                 token=git_creds['gitlab_token'],
                 base_url=config.git_url,
                 verify=not skip_ssl_verification,
-                keep_base_url=config.keep_base_url,
+                keep_base_url=config.gitlab_keep_base_url,
             )
         if config.git_provider == ADO_PROVIDER:
             return JFIngestAzureDevopsAuthConfig(
@@ -669,7 +669,7 @@ def _get_git_config(git_config, git_provider_override=None, multiple=False) -> G
         gitlab_per_page_override=git_config.get('gitlab_per_page_override', None),
         git_verbose=git_config.get('verbose', False),
         creds_envvar_prefix=creds_envvar_prefix,
-        git_gitlab_keep_base_url=git_config.get('keep_base_url', False),
+        gitlab_keep_base_url=git_config.get('keep_base_url', False),
         # legacy fields ===========
         git_include_bbcloud_projects=list(git_include_bbcloud_projects),
         git_exclude_bbcloud_projects=list(git_exclude_bbcloud_projects),

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c514a2bb9a3ce2aca4fb814c4aed1166bae5404ff96b22254c4399b897c021a1"
+content_hash = "sha256:b461ab419c6752b61cff1929610088c9ef1152092864c34c583b6c4261c104ea"
 
 [[metadata.targets]]
 requires_python = "~=3.10.15"
@@ -475,7 +475,7 @@ files = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.209"
+version = "0.0.214"
 requires_python = ">=3.10"
 summary = "library used for ingesting jira data"
 groups = ["default"]
@@ -493,8 +493,8 @@ dependencies = [
     "tqdm>=4.66.1",
 ]
 files = [
-    {file = "jf_ingest-0.0.209-py3-none-any.whl", hash = "sha256:198fdc112c3d3c4d969be54a985f71d622d8e40d198a462a8c770a5746f8b624"},
-    {file = "jf_ingest-0.0.209.tar.gz", hash = "sha256:26c3fe9f97d821d46042a137373b14e958a414df993c08a563171ad41b9d436b"},
+    {file = "jf_ingest-0.0.214-py3-none-any.whl", hash = "sha256:45be153d6efdcf0f77da8544953008afdb27ab374568695afb7a0099991fc9cb"},
+    {file = "jf_ingest-0.0.214.tar.gz", hash = "sha256:9aebed97fb66abf2f8bd689989a48643d793f684abf6bd401ceb2c72c660580d"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.4.0",
     "colorama>=0.4.6",
-    "jf-ingest==0.0.209",
+    "jf-ingest==0.0.214",
 ]
 requires-python = "~=3.10.15"
 readme = "README.md"


### PR DESCRIPTION
### Description

Version bump JF Ingest to add some new configuration options

### Configuration Changes

  - Add `filter_boards_by_projects` which will allow customers to leverage the `projectKeyOrId` parameter on the Jira API. When provided we will only query for boards related to the projects they want to include. **This is not, and should not, be the default behavior.** Many times customers want to ingest "user" boards, which aren't associated with any projects. This flag is only for customers who don't care much about boards, have too many boards to consume, or who want to speed up their initial ingestion by pulling in the minimum amount of boards possible
  - Expose the `keep_base_url` flag for gitlab customers. When provided and set to `True` we will use the `keep_base_url` argument provided by the Gitlab Python module. This can be helpful when a customer has their Gitlab behind a proxy, and the returned headers return a different URL than the one they provided in their config