### PR TITLE
Add sonarqube properties file for analysis values in webhooks

### DIFF
--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.properties.exampleValue=123
+sonar.properties.projectName=jf_agent
+sonar.properties.test=false


### PR DESCRIPTION
These are test values and do not drive anything important. SonarQube will only pick up properties if included in the `.sonar-project.properties` file at the root level on the main branch. In addition to adding properties, there are a number of settings and scopes available for this configuration file. There are additional properties and values that can be set via CD/CI via `sonar-project.properties`, not included in this PR.