### PR TITLE
[OJ-53844] Ensure Endor scans work for uv

### DIFF
--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install pre-reqs
       run: pip install --user uv
+    - name: Install dependencies # endorctl does not seem to automatically do this
+      run: uv sync --locked --no-dev --no-editable
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.12

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -20,7 +20,7 @@ jobs:
       run: pip install --user uv
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
-      uses: endorlabs/github-action@v1.1.7
+      uses: endorlabs/github-action@v1.1.12
       with:
         namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -31,7 +31,7 @@ jobs:
         additional_args: "--exit-on-policy-warning"
     - name: Endor Labs Scan Push to main
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      uses: endorlabs/github-action@v1.1.7
+      uses: endorlabs/github-action@v1.1.12
       with:
         namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write # Used for keyless authentication with Endor Labs
       issues: write # Required to automatically comment on PRs for new policy violations
       pull-requests: write # Required to automatically comment on PRs for new policy violations
+    env:
+      ENDOR_SCAN_ENABLE_UV_PACKAGE_MANAGER: true
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -22,7 +24,7 @@ jobs:
       run: uv sync --locked --no-dev --no-editable
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
-      uses: endorlabs/github-action@v1.1.12
+      uses: endorlabs/github-action@v1.1.12 # Endor uses immutable releases so hash pinning not required
       with:
         namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -33,7 +35,7 @@ jobs:
         additional_args: "--exit-on-policy-warning"
     - name: Endor Labs Scan Push to main
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      uses: endorlabs/github-action@v1.1.12
+      uses: endorlabs/github-action@v1.1.12 # Endor uses immutable releases so hash pinning not required
       with:
         namespace: "jellyfish" # Replace with your Endor Labs tenant namespace
         scan_dependencies: true

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install pre-reqs
       run: pip install --user uv
     - name: Generate requirements.txt 
-      run: uv export > requirements.txt
+      run: uv export --locked --no-editable --no-emit-local > requirements.txt
     - name: Install
       run: pip install -r requirements.txt
     - name: Endor Labs Scan Pull Request

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -22,6 +22,8 @@ jobs:
       run: pip install --user uv
     - name: Generate requirements.txt 
       run: uv export --locked --no-editable --no-emit-local > requirements.txt
+    - name: Remove uv files which confuse Endor
+      run: rm uv.lock && rm pyproject.toml
     - name: Install
       run: pip install -r requirements.txt
     - name: Endor Labs Scan Pull Request

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -13,15 +13,17 @@ jobs:
       issues: write # Required to automatically comment on PRs for new policy violations
       pull-requests: write # Required to automatically comment on PRs for new policy violations
     env:
-      ENDOR_SCAN_ENABLE_UV_PACKAGE_MANAGER: true
+      ENDOR_SCAN_ENABLE_UV_PACKAGE_MANAGER: false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
     - name: Install pre-reqs
       run: pip install --user uv
-    - name: Install dependencies # endorctl does not seem to automatically do this
-      run: uv sync --locked --no-dev --no-editable
+    - name: Generate requirements.txt
+      run: uv export
+    - name: Install
+      run: pip install -r requirements.txt
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.12 # Endor uses immutable releases so hash pinning not required

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install pre-reqs
       run: pip install --user uv
-    - name: Generate requirements.txt
-      run: uv export
+    - name: Generate requirements.txt 
+      run: uv export > requirements.txt
     - name: Install
       run: pip install -r requirements.txt
     - name: Endor Labs Scan Pull Request


### PR DESCRIPTION
Endor (our software composition analysis solution) is not playing well with the UV migration.

This PR works around that by exporting the UV lockfile and installing using `pip`, which Endor can handle.