### PR TITLE
[OJ-54165] Simplify Endor scan logic

### DIFF
--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -20,12 +20,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Install pre-reqs
       run: pip install --user uv
-    - name: Generate requirements.txt 
-      run: uv export --locked --no-editable --no-emit-local > requirements.txt
-    - name: Remove uv files which confuse Endor
-      run: rm uv.lock && rm pyproject.toml
-    - name: Install
-      run: pip install -r requirements.txt
     - name: Endor Labs Scan Pull Request
       if: github.event_name == 'pull_request'
       uses: endorlabs/github-action@v1.1.12 # Endor uses immutable releases so hash pinning not required

--- a/.github/workflows/endor.yml
+++ b/.github/workflows/endor.yml
@@ -12,8 +12,6 @@ jobs:
       id-token: write # Used for keyless authentication with Endor Labs
       issues: write # Required to automatically comment on PRs for new policy violations
       pull-requests: write # Required to automatically comment on PRs for new policy violations
-    env:
-      ENDOR_SCAN_ENABLE_UV_PACKAGE_MANAGER: false
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
Endor's latest release fixed their support for `uv` package managers, so we can remove our hack to make scans work.