### PR TITLE
[OJ-54453] Bump black to 26.3.1 to address CVE-2026-32274

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3.13

--- a/jf_agent/data_manifests/git/adapters/github.py
+++ b/jf_agent/data_manifests/git/adapters/github.py
@@ -1,5 +1,6 @@
-from dateutil import parser as datetime_parser
 from typing import Generator
+
+from dateutil import parser as datetime_parser
 
 from jf_agent.data_manifests.git.adapters.manifest_adapter import ManifestAdapter
 from jf_agent.data_manifests.git.manifest import (
@@ -15,11 +16,17 @@ from jf_agent.git.github_gql_client import GithubGqlClient
 # TODO: Expand or generalize this to work with things other than github (BBCloud, Gitlab, etc)
 class GithubManifestGenerator(ManifestAdapter):
     '''
-    Basic client for probing a GH instance. 
+    Basic client for probing a GH instance.
     '''
 
     def __init__(
-        self, token: str, base_url: str, company: str, org: str, instance: str, verify=True,
+        self,
+        token: str,
+        base_url: str,
+        company: str,
+        org: str,
+        instance: str,
+        verify=True,
     ) -> None:
         # Super class fields
         self.company = company
@@ -50,12 +57,14 @@ class GithubManifestGenerator(ManifestAdapter):
                 user_count=repo['users']['totalCount'],
                 pull_request_count=repo['prs']['totalCount'],
                 branch_count=repo['branches']['totalCount'],
-                commits_on_default_branch=repo['defaultBranch']['target']['history']['totalCount']
-                if repo['defaultBranch']
-                else 0,
-                default_branch_name=repo['defaultBranch']['name']
-                if repo['defaultBranch']
-                else None,
+                commits_on_default_branch=(
+                    repo['defaultBranch']['target']['history']['totalCount']
+                    if repo['defaultBranch']
+                    else 0
+                ),
+                default_branch_name=(
+                    repo['defaultBranch']['name'] if repo['defaultBranch'] else None
+                ),
             )
 
     def get_all_user_data(self) -> Generator[GitUserManifest, None, None]:

--- a/jf_agent/data_manifests/git/adapters/manifest_adapter.py
+++ b/jf_agent/data_manifests/git/adapters/manifest_adapter.py
@@ -9,6 +9,7 @@ from jf_agent.data_manifests.git.manifest import (
     GitUserManifest,
 )
 
+
 # TODO: Expand or generalize this to work with things other than github (BBCloud, Gitlab, etc)
 @dataclass
 class ManifestAdapter(ABC):

--- a/jf_agent/data_manifests/git/generator.py
+++ b/jf_agent/data_manifests/git/generator.py
@@ -1,17 +1,12 @@
 import logging
-from jf_agent.config_file_reader import GitConfig
-
-from jf_agent.data_manifests.git.adapters.manifest_adapter import ManifestAdapter
-
-from jf_agent.data_manifests.git.manifest import (
-    GitDataManifest,
-    GitRepoManifest,
-    GitUserManifest,
-)
-from jf_agent.data_manifests.git.adapters.github import GithubManifestGenerator
-from jf_agent.data_manifests.manifest import ManifestSource
 
 from jf_ingest import logging_helper
+
+from jf_agent.config_file_reader import GitConfig
+from jf_agent.data_manifests.git.adapters.github import GithubManifestGenerator
+from jf_agent.data_manifests.git.adapters.manifest_adapter import ManifestAdapter
+from jf_agent.data_manifests.git.manifest import GitDataManifest, GitRepoManifest, GitUserManifest
+from jf_agent.data_manifests.manifest import ManifestSource
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +140,11 @@ def create_manifests(
 
 
 def get_manifest_adapter(
-    company_slug: str, git_creds: dict, git_config: GitConfig, instance: str, org: str,
+    company_slug: str,
+    git_creds: dict,
+    git_config: GitConfig,
+    instance: str,
+    org: str,
 ):
     if git_config.git_provider != 'github':
         raise UnsupportedGitProvider(

--- a/jf_agent/data_manifests/git/manifest.py
+++ b/jf_agent/data_manifests/git/manifest.py
@@ -4,11 +4,11 @@ from typing import Any, TypeVar
 
 from jf_agent.data_manifests.manifest import Manifest, ManifestSource
 
-
 IGitDataManifest = TypeVar('IGitDataManifest', bound='GitDataManifest')
 IGitRepoManifest = TypeVar('IGitRepoManifest', bound='GitRepoManifest')
 IGitUserManifest = TypeVar('IGitUserManifest', bound='GitUserManifest')
 IGitPullRequestManifest = TypeVar('IGitPullRequestManifest', bound='GitPullRequestManifest')
+
 
 # This is the parent class for all GitManifest type classes. It inherits
 # from manifests, but ensures that all 'GitManifests' have an instance

--- a/jf_agent/data_manifests/jira/generator.py
+++ b/jf_agent/data_manifests/jira/generator.py
@@ -1,12 +1,11 @@
-from concurrent.futures import ThreadPoolExecutor
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
-from jf_agent.data_manifests.jira.adapter import JiraCloudManifestAdapter
-
-from jf_agent.data_manifests.jira.manifest import JiraDataManifest, JiraProjectManifest
-from jf_agent.data_manifests.manifest import ManifestSource
 from jira import JIRAError
 
+from jf_agent.data_manifests.jira.adapter import JiraCloudManifestAdapter
+from jf_agent.data_manifests.jira.manifest import JiraDataManifest, JiraProjectManifest
+from jf_agent.data_manifests.manifest import ManifestSource
 
 logger = logging.getLogger(__name__)
 

--- a/jf_agent/data_manifests/manifest.py
+++ b/jf_agent/data_manifests/manifest.py
@@ -1,16 +1,14 @@
 import gzip
+import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-import json
 from typing import Optional, TypeVar
 
 import requests
-
 from jf_ingest import logging_helper
-
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +100,9 @@ class Manifest(ABC):
         with open(file_name, 'w') as f:
             f.write(self.to_json_str())
 
-    def upload_to_s3(self, jellyfish_api_base: str, jellyfish_api_token: str, skip_ssl_verification: bool = False) -> None:
+    def upload_to_s3(
+        self, jellyfish_api_base: str, jellyfish_api_token: str, skip_ssl_verification: bool = False
+    ) -> None:
         headers = {'Jellyfish-API-Token': jellyfish_api_token, 'content-encoding': 'gzip'}
 
         logger.info(f'Attempting to upload {self.get_unique_key()} manifest to s3...')

--- a/jf_agent/git/__init__.py
+++ b/jf_agent/git/__init__.py
@@ -373,9 +373,9 @@ def load_and_dump_git(
             else:
                 from jf_agent.git.gitlab_adapter import GitLabAdapter
 
-                GitLabAdapter(config, outdir, compress_output_files, git_connection).load_and_dump_git(
-                    endpoint_git_instance_info
-                )
+                GitLabAdapter(
+                    config, outdir, compress_output_files, git_connection
+                ).load_and_dump_git(endpoint_git_instance_info)
         elif config.git_provider == ADO_PROVIDER:
             for jf_ingest_git_config in jf_ingest_config.git_configs:
                 if jf_ingest_git_config.instance_slug == instance_slug:

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -1,29 +1,29 @@
-from jf_agent.git.utils import get_branches_for_standardized_repo
-from tqdm import tqdm
-import re
-from dateutil import parser
-from typing import List
 import logging
-import requests
+import re
+from typing import List
 
+import requests
+from dateutil import parser
+from jf_ingest import diagnostics, logging_helper
+from tqdm import tqdm
+
+from jf_agent.config_file_reader import GitConfig
 from jf_agent.git import (
     GitAdapter,
-    StandardizedUser,
-    StandardizedProject,
     StandardizedBranch,
-    StandardizedRepository,
     StandardizedCommit,
+    StandardizedProject,
     StandardizedPullRequest,
     StandardizedPullRequestComment,
     StandardizedPullRequestReview,
+    StandardizedRepository,
     StandardizedShortRepository,
+    StandardizedUser,
     pull_since_date_for_repo,
 )
 from jf_agent.git.bitbucket_cloud_client import BitbucketCloudClient
-
+from jf_agent.git.utils import get_branches_for_standardized_repo
 from jf_agent.name_redactor import NameRedactor, sanitize_text
-from jf_agent.config_file_reader import GitConfig
-from jf_ingest import diagnostics, logging_helper
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,8 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @logging_helper.log_entry_exit(logger)
     def get_repos(
-        self, standardized_projects: List[StandardizedProject],
+        self,
+        standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
         logger.info('downloading bitbucket repos...')
 
@@ -195,7 +196,9 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @logging_helper.log_entry_exit(logger)
     def get_pull_requests(
-        self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
+        self,
+        standardized_repos: List[StandardizedRepository],
+        server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
         logger.info('downloading bitbucket prs...')
         for i, repo in enumerate(
@@ -225,7 +228,9 @@ class BitbucketCloudAdapter(GitAdapter):
                                 or not api_pr['destination']['repository']
                             ):
                                 logging_helper.log_standard_error(
-                                    logging.WARNING, msg_args=[api_pr['id']], error_code=3030,
+                                    logging.WARNING,
+                                    msg_args=[api_pr['id']],
+                                    error_code=3030,
                                 )
                                 continue
 
@@ -257,7 +262,10 @@ class BitbucketCloudAdapter(GitAdapter):
                 except Exception:
                     # if something happens when pulling PRs for a repo, just keep going.
                     logging_helper.log_standard_error(
-                        logging.ERROR, msg_args=[repo.id], error_code=3021, exc_info=True,
+                        logging.ERROR,
+                        msg_args=[repo.id],
+                        error_code=3021,
+                        exc_info=True,
                     )
 
         logger.info('Done downloading PRs!')
@@ -345,9 +353,9 @@ def _standardize_commit(
         message=sanitize_text(api_commit['message'], strip_text_content),
         is_merge=len(api_commit['parents']) > 1,
         repo=standardized_repo.short(),  # use short form of repo
-        branch_name=branch_name
-        if not redact_names_and_urls
-        else _branch_redactor.redact_name(branch_name),
+        branch_name=(
+            branch_name if not redact_names_and_urls else _branch_redactor.redact_name(branch_name)
+        ),
     )
 
 
@@ -372,13 +380,26 @@ def _standardize_user(api_user):
         username, email = m.groups()
         username = username.strip()
         email = email.strip()
-        return StandardizedUser(id=raw_name, login=email, name=username, email=email,)
+        return StandardizedUser(
+            id=raw_name,
+            login=email,
+            name=username,
+            email=email,
+        )
 
-    return StandardizedUser(id=raw_name, name=raw_name, login=raw_name,)
+    return StandardizedUser(
+        id=raw_name,
+        name=raw_name,
+        login=raw_name,
+    )
 
 
 def _standardize_pr(
-    client, repo, api_pr, strip_text_content: bool, redact_names_and_urls: bool,
+    client,
+    repo,
+    api_pr,
+    strip_text_content: bool,
+    redact_names_and_urls: bool,
 ):
     # Process the PR's diff to get additions, deletions, changed_files
     additions, deletions, changed_files = None, None, None
@@ -387,7 +408,9 @@ def _standardize_pr(
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
             logging_helper.log_standard_error(
-                logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3031,
+                logging.WARNING,
+                msg_args=[api_pr["id"], repo.id],
+                error_code=3031,
             )
     except requests.exceptions.RetryError:
         # Server threw a 500 on the request for the diff and we started retrying;
@@ -401,7 +424,9 @@ def _standardize_pr(
         elif e.response.status_code == 401:
             # Server threw a 401 on the request for the diff; not sure why this would be, but it seems rare
             logging_helper.log_standard_error(
-                logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3041,
+                logging.WARNING,
+                msg_args=[api_pr["id"], repo.id],
+                error_code=3041,
             )
         else:
             # Some other HTTP error happened; Re-raise
@@ -409,7 +434,9 @@ def _standardize_pr(
     except UnicodeDecodeError:
         # Occasional diffs seem to be invalid UTF-8
         logging_helper.log_standard_error(
-            logging.WARNING, msg_args=[api_pr["id"], repo.id], error_code=3051,
+            logging.WARNING,
+            msg_args=[api_pr["id"], repo.id],
+            error_code=3051,
         )
 
     # Comments
@@ -436,7 +463,8 @@ def _standardize_pr(
                 review_state='APPROVED',
             )
             for i, approval in enumerate(
-                (a['approval'] for a in activity if 'approval' in a), start=1,
+                (a['approval'] for a in activity if 'approval' in a),
+                start=1,
             )
         ]
 

--- a/jf_agent/git/bitbucket_cloud_client.py
+++ b/jf_agent/git/bitbucket_cloud_client.py
@@ -1,14 +1,14 @@
-from collections import deque
-from datetime import datetime, timedelta
 import logging
 import time
+from collections import deque
+from datetime import datetime, timedelta
 from typing import Optional
 
 import requests
+from jf_ingest import logging_helper
 from requests.utils import default_user_agent
 
 from jf_agent.ratelimit import RateLimiter, RateLimitRealmConfig
-from jf_ingest import logging_helper
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,9 @@ class BitbucketCloudClient:
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404 and ignore404:
                         # URLs are potentially sensitive data, so print instead of log!
-                        print(f'Caught a 404 for {url} - ignoring',)
+                        print(
+                            f'Caught a 404 for {url} - ignoring',
+                        )
                         return
                     raise
 

--- a/jf_agent/git/bitbucket_server.py
+++ b/jf_agent/git/bitbucket_server.py
@@ -1,16 +1,18 @@
-from datetime import datetime
 import logging
-import stashy
+from datetime import datetime
+
 import pytz
+import stashy
+from jf_ingest import diagnostics, logging_helper
+from requests.exceptions import ChunkedEncodingError, RetryError
 from tqdm import tqdm
-from requests.exceptions import RetryError, ChunkedEncodingError
 from urllib3.exceptions import MaxRetryError
+
+from jf_agent import download_and_write_streaming, write_file
+from jf_agent.config_file_reader import GitConfig
 from jf_agent.git import pull_since_date_for_repo
 from jf_agent.git.utils import get_matching_branches
 from jf_agent.name_redactor import NameRedactor, sanitize_text
-from jf_agent import download_and_write_streaming, write_file
-from jf_agent.config_file_reader import GitConfig
-from jf_ingest import diagnostics, logging_helper
 
 logger = logging.getLogger(__name__)
 
@@ -238,9 +240,9 @@ def _standardize_commit(commit, repo, branch_name, strip_text_content, redact_na
         'message': sanitize_text(commit.get('message'), strip_text_content),
         'is_merge': len(commit['parents']) > 1,
         'repo': _standardize_pr_repo(repo, redact_names_and_urls),
-        'branch_name': branch_name
-        if not redact_names_and_urls
-        else _branch_redactor.redact_name(branch_name),
+        'branch_name': (
+            branch_name if not redact_names_and_urls else _branch_redactor.redact_name(branch_name)
+        ),
     }
 
 

--- a/jf_agent/git/github_client.py
+++ b/jf_agent/git/github_client.py
@@ -1,14 +1,15 @@
+import logging
+import time
 from collections import deque
 from datetime import datetime, timedelta
-import logging
+
 import pytz
 import requests
+from jf_ingest import logging_helper
 from requests import HTTPError, Response
 from requests.utils import default_user_agent
-import time
 
 from jf_agent.session import retry_session
-from jf_ingest import logging_helper
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,9 @@ class GithubClient:
                     raise
 
                 logging_helper.log_standard_error(
-                    logging.WARNING, msg_args=[m["url"], e.response.status_code], error_code=3061,
+                    logging.WARNING,
+                    msg_args=[m["url"], e.response.status_code],
+                    error_code=3061,
                 )
 
     def get_all_repos(self, org):
@@ -66,7 +69,9 @@ class GithubClient:
                 # we've seen some strange behavior with ghe, where we can get a 403 for
                 # a repo that comes back in the list.  SKip them.
                 logging_helper.log_standard_error(
-                    logging.WARNING, msg_args=[m["url"]], error_code=3081,
+                    logging.WARNING,
+                    msg_args=[m["url"]],
+                    error_code=3081,
                 )
 
     def get_branches(self, full_repo):
@@ -141,7 +146,9 @@ class GithubClient:
 
                 if i >= max_retries:
                     logging_helper.log_standard_error(
-                        logging.ERROR, msg_args=[url, i], error_code=3101,
+                        logging.ERROR,
+                        msg_args=[url, i],
+                        error_code=3101,
                     )
                     raise
 
@@ -163,7 +170,9 @@ class GithubClient:
                 reset_wait_in_seconds = min(reset_wait_in_seconds, 3600)
                 reset_wait_str = str(timedelta(seconds=reset_wait_in_seconds))
                 logging_helper.log_standard_error(
-                    logging.WARNING, msg_args=[reset_wait_str], error_code=3091,
+                    logging.WARNING,
+                    msg_args=[reset_wait_str],
+                    error_code=3091,
                 )
                 # often the GH reset time is off by <1 second, causing another rate-limit. 2 seconds buffer added.
                 time.sleep(reset_wait_in_seconds + 2)

--- a/jf_agent/git/github_gql_adapter.py
+++ b/jf_agent/git/github_gql_adapter.py
@@ -1,31 +1,31 @@
-from datetime import datetime, timezone
-import traceback
-from jf_agent.git.github_gql_client import GithubGqlClient
-from jf_agent.git.github_gql_utils import github_gql_format_to_datetime
-from jf_agent.git.utils import get_branches_for_standardized_repo
-from tqdm import tqdm
-from dateutil import parser
-from typing import List
 import logging
+import traceback
+from datetime import datetime, timezone
+from typing import List
+
+from dateutil import parser
+from jf_ingest import diagnostics, logging_helper
+from tqdm import tqdm
+
+from jf_agent.config_file_reader import GitConfig
 from jf_agent.git import (
     GitAdapter,
-    StandardizedUser,
-    StandardizedProject,
     StandardizedBranch,
-    StandardizedRepository,
     StandardizedCommit,
+    StandardizedProject,
     StandardizedPullRequest,
     StandardizedPullRequestComment,
     StandardizedPullRequestReview,
+    StandardizedRepository,
     StandardizedShortRepository,
+    StandardizedUser,
     pull_since_date_for_repo,
 )
-from jf_agent.git.utils import log_and_print_request_error
+from jf_agent.git.github_gql_client import GithubGqlClient
+from jf_agent.git.github_gql_utils import github_gql_format_to_datetime
+from jf_agent.git.utils import get_branches_for_standardized_repo, log_and_print_request_error
 from jf_agent.main import JellyfishEndpointInfo
 from jf_agent.name_redactor import NameRedactor, sanitize_text
-from jf_agent.config_file_reader import GitConfig
-
-from jf_ingest import diagnostics, logging_helper
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,10 @@ class GithubGqlAdapter(GitAdapter):
                 continue
 
             projects.append(
-                _standardize_project(organization, self.config.git_redact_names_and_urls,)
+                _standardize_project(
+                    organization,
+                    self.config.git_redact_names_and_urls,
+                )
             )
         logger.info('✓')
 
@@ -99,7 +102,8 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @logging_helper.log_entry_exit(logger)
     def get_repos(
-        self, standardized_projects: List[StandardizedProject],
+        self,
+        standardized_projects: List[StandardizedProject],
     ) -> List[StandardizedRepository]:
         logger.info('downloading github repos...')
 
@@ -250,7 +254,9 @@ class GithubGqlAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @logging_helper.log_entry_exit(logger)
     def get_pull_requests(
-        self, standardized_repos: List[StandardizedRepository], server_git_instance_info,
+        self,
+        standardized_repos: List[StandardizedRepository],
+        server_git_instance_info,
     ) -> List[StandardizedPullRequest]:
         logger.info('downloading github prs...')
 
@@ -341,7 +347,12 @@ def _standardize_user(api_user) -> StandardizedUser:
     email = api_user.get('email')
     # raw user, just have email (e.g. from a commit)
     if not id:
-        return StandardizedUser(id=email, login=email, name=name, email=email,)
+        return StandardizedUser(
+            id=email,
+            login=email,
+            name=name,
+            email=email,
+        )
 
     # API user, where github matched to a known account
     return StandardizedUser(id=id, login=login, name=name, email=email)
@@ -351,24 +362,30 @@ def _standardize_project(api_org: dict, redact_names_and_urls: bool) -> Standard
     return StandardizedProject(
         id=api_org['id'],
         login=api_org['login'],
-        name=api_org.get('name')
-        if not redact_names_and_urls
-        else _project_redactor.redact_name(api_org.get('name')),
+        name=(
+            api_org.get('name')
+            if not redact_names_and_urls
+            else _project_redactor.redact_name(api_org.get('name'))
+        ),
         url=api_org['url'] if not redact_names_and_urls else None,
     )
 
 
 def _standardize_branch(api_branch, redact_names_and_urls: bool) -> StandardizedBranch:
     return StandardizedBranch(
-        name=api_branch['name']
-        if not redact_names_and_urls
-        else _branch_redactor.redact_name(api_branch['name']),
+        name=(
+            api_branch['name']
+            if not redact_names_and_urls
+            else _branch_redactor.redact_name(api_branch['name'])
+        ),
         sha=api_branch['target']['sha'],
     )
 
 
 def _standardize_repo(
-    api_repo, standardized_project: StandardizedProject, redact_names_and_urls: bool,
+    api_repo,
+    standardized_project: StandardizedProject,
+    redact_names_and_urls: bool,
 ) -> StandardizedRepository:
     repo_name = (
         api_repo['name']
@@ -428,9 +445,9 @@ def _standardize_commit(
         message=sanitize_text(api_commit['message'], strip_text_content),
         is_merge=api_commit['parents']['totalCount'] > 1,
         repo=standardized_repo.short(),  # use short form of repo
-        branch_name=branch_name
-        if not redact_names_and_urls
-        else _branch_redactor.redact_name(branch_name),
+        branch_name=(
+            branch_name if not redact_names_and_urls else _branch_redactor.redact_name(branch_name)
+        ),
     )
 
 

--- a/jf_agent/git/github_gql_client.py
+++ b/jf_agent/git/github_gql_client.py
@@ -1,13 +1,14 @@
 import json
 import logging
-from datetime import datetime
 import time
-from requests import Session
-import requests
-from requests.utils import default_user_agent
+from datetime import datetime
 from typing import Generator
-from jf_agent.git.github_gql_utils import datetime_to_gql_str_format, github_gql_format_to_datetime
 
+import requests
+from requests import Session
+from requests.utils import default_user_agent
+
+from jf_agent.git.github_gql_utils import datetime_to_gql_str_format, github_gql_format_to_datetime
 from jf_agent.session import retry_session
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class GithubGqlClient:
                 if attempt_number > max_attempts:
                     raise
 
-                sleep_time = attempt_number ** 2
+                sleep_time = attempt_number**2
                 # Overwrite sleep time if github gives us a specific wait time
                 if e.response.headers.get('retry-after') and attempt_number == 1:
                     retry_after = int(e.response.headers.get('retry-after'))
@@ -186,7 +187,9 @@ class GithubGqlClient:
                 # past. In that case, wait for 5 mins just in case.
                 if sleep_time <= 0:
                     sleep_time = 300
-                logger.warning(f'GQL Rate Limit hit. Sleeping for {sleep_time} seconds',)
+                logger.warning(
+                    f'GQL Rate Limit hit. Sleeping for {sleep_time} seconds',
+                )
                 time.sleep(sleep_time)
             finally:
                 attempt_number += 1

--- a/jf_agent/jf_jira/utils.py
+++ b/jf_agent/jf_jira/utils.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, Callable, Any
+from typing import Any, Callable, Optional
 
 from jf_ingest import logging_helper
 
@@ -22,7 +22,7 @@ def get_wait_time(e: Optional[Exception], retries: int) -> int:
     if retry_after is not None:
         return int(retry_after)
     else:
-        return 5 ** retries
+        return 5**retries
 
 
 def retry_for_status(f: Callable[..., Any], *args, max_retries: int = 5, **kwargs) -> Any:

--- a/jf_agent/main.py
+++ b/jf_agent/main.py
@@ -607,7 +607,9 @@ def obtain_jellyfish_endpoint_info(config, creds, skip_jf_ingest_issue_metadata:
     return JellyfishEndpointInfo(jira_info, git_instance_info, jf_options)
 
 
-def _get_additional_jira_issue_metadata(base_url: str, api_token: str, cursor: int, skip_ssl_verification: bool = False) -> dict:
+def _get_additional_jira_issue_metadata(
+    base_url: str, api_token: str, cursor: int, skip_ssl_verification: bool = False
+) -> dict:
     headers = {'Jellyfish-API-Token': api_token}
     endpoint = f'{base_url}/endpoints/agent/jira-issue-metadata'
 

--- a/jf_agent/ratelimit.py
+++ b/jf_agent/ratelimit.py
@@ -1,13 +1,12 @@
 import bisect
-from collections import namedtuple, defaultdict
-from contextlib import contextmanager
-from datetime import datetime, timedelta
 import logging
 import threading
 import time
+from collections import defaultdict, namedtuple
+from contextlib import contextmanager
+from datetime import datetime, timedelta
 
 import requests
-
 from jf_ingest import logging_helper
 
 logger = logging.getLogger(__name__)
@@ -54,7 +53,9 @@ class RateLimiter(object):
                     if e.response.status_code == 429:
                         # Got rate limited anyway!
                         logging_helper.log_standard_error(
-                            logging.ERROR, msg_args=[calls_made, max_calls, realm], error_code=3010,
+                            logging.ERROR,
+                            msg_args=[calls_made, max_calls, realm],
+                            error_code=3010,
                         )
                     raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ default = true
 dev = [
     "requests-mock",
     "pytest>=7.4.0",
-    "black==24.4.2",
+    "black==26.3.1",
     "isort==5.13.2",
     "pre-commit>=3.6.0",
 ]

--- a/tests/test_bitbucket_cloud_client.py
+++ b/tests/test_bitbucket_cloud_client.py
@@ -1,13 +1,12 @@
+import json
 import os
 from datetime import datetime, timedelta
+from unittest import TestCase
 
 import requests_mock
-import json
-from unittest import TestCase
 
 from jf_agent.git.bitbucket_cloud_client import BitbucketCloudClient
 from jf_agent.session import retry_session
-
 
 URI = 'https://bitbucket.testco.com'
 TEST_INPUT_FILE_PATH = 'test_data/bitbucket_cloud/'

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "black"
-version = "24.4.2"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -12,10 +12,16 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
+    { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/47/c9997eb470a7f48f7aaddd3d9a828244a2e4199569e38128715c48059ac1/black-24.4.2.tar.gz", hash = "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d", size = 642299, upload-time = "2024-04-26T00:32:15.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl", hash = "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c", size = 205925, upload-time = "2024-04-26T00:32:12.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -272,7 +278,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = "==24.4.2" },
+    { name = "black", specifier = "==26.3.1" },
     { name = "isort", specifier = "==5.13.2" },
     { name = "pre-commit", specifier = ">=3.6.0" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -656,6 +662,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/02645bc9d71554e7a263b118e4e55dafe4c4735c1ba74f9712232ed84054/python_gitlab-8.0.0.tar.gz", hash = "sha256:03eae5a9d105448796e6c0e192d402c266057e75790cf4f42c143dddf91313ce", size = 401334, upload-time = "2026-01-28T01:22:27.005Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/60/ba68e51e90a99b14af639463e5d617239029ec25927a0990ff28bd851916/python_gitlab-8.0.0-py3-none-any.whl", hash = "sha256:c635e6722c5710d35ddadfcf95c362b0aa8de11ab3972bc4f230ebd58a6c49ee", size = 144483, upload-time = "2026-01-28T01:22:25.772Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR bumps our `black` version to 26.3.1 which addresses CVE-2026-32274.

While I was at it, I just went ahead and reformatted the code since we have not been diligent about running the formatter. The old `black` version reported *more* issues than this new one.