### PR TITLE
OJ-54337 Use repo slug for bitbucket URLs

### DIFF
--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -385,12 +385,12 @@ def _standardize_user(api_user):
 def _standardize_pr(
     client, repo, api_pr, strip_text_content: bool, redact_names_and_urls: bool,
 ):
-    slug = _repo_slug(repo)
+    repo_slug = _repo_slug(repo)
 
     # Process the PR's diff to get additions, deletions, changed_files
     additions, deletions, changed_files = None, None, None
     try:
-        diff_str = client.pr_diff(repo.project.id, slug, api_pr['id'])
+        diff_str = client.pr_diff(repo.project.id, repo_slug, api_pr['id'])
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
             logging_helper.log_standard_error(
@@ -426,7 +426,7 @@ def _standardize_pr(
             body=sanitize_text(c['content']['raw'], strip_text_content),
             created_at=parser.parse(c['created_on']),
         )
-        for c in client.pr_comments(repo.project.id, slug, api_pr['id'])
+        for c in client.pr_comments(repo.project.id, repo_slug, api_pr['id'])
     ]
 
     # Crawl activity for approvals, merge and closed dates
@@ -435,7 +435,7 @@ def _standardize_pr(
     merged_by = None
     closed_date = None
     try:
-        activity = list(client.pr_activity(repo.project.id, slug, api_pr['id']))
+        activity = list(client.pr_activity(repo.project.id, repo_slug, api_pr['id']))
         approvals = [
             StandardizedPullRequestReview(
                 user=_standardize_user(approval['user']),
@@ -477,7 +477,7 @@ def _standardize_pr(
             strip_text_content,
             redact_names_and_urls,
         )
-        for c in client.pr_commits(repo.project.id, slug, api_pr['id'])
+        for c in client.pr_commits(repo.project.id, repo_slug, api_pr['id'])
     ]
     merge_commit = None
     if (
@@ -487,7 +487,7 @@ def _standardize_pr(
         and api_pr['merge_commit'].get('hash')
     ):
         api_merge_commit = client.get_commit(
-            repo.project.id, slug, api_pr['merge_commit']['hash']
+            repo.project.id, repo_slug, api_pr['merge_commit']['hash']
         )
         merge_commit = _standardize_commit(
             api_merge_commit,

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -265,9 +265,10 @@ class BitbucketCloudAdapter(GitAdapter):
     @diagnostics.capture_timing()
     @logging_helper.log_entry_exit(logger)
     def get_branches(self, project, api_repo) -> List[StandardizedBranch]:
+        repo_slug = api_repo['full_name'].split('/')[-1]
         return [
             _standardize_branch(api_branch, self.config.git_redact_names_and_urls)
-            for api_branch in self.client.get_branches(project.id, api_repo['uuid'])
+            for api_branch in self.client.get_branches(project.id, repo_slug)
         ]
 
 
@@ -281,6 +282,7 @@ def _standardize_repo(
     standardized_project: StandardizedProject,
     redact_names_and_urls: bool,
 ) -> StandardizedRepository:
+    repo_slug = api_repo['full_name'].split('/')[-1]
     repo_name = (
         api_repo['name']
         if not redact_names_and_urls
@@ -289,7 +291,7 @@ def _standardize_repo(
     url = api_repo['links']['self']['href'] if not redact_names_and_urls else None
 
     return StandardizedRepository(
-        id=api_repo['uuid'],
+        id=repo_slug,
         name=repo_name,
         full_name=api_repo['full_name'],
         url=url,
@@ -305,8 +307,9 @@ def _standardize_repo(
 
 
 def _standardize_short_form_repo(api_repo, redact_names_and_urls):
+    repo_slug = api_repo['full_name'].split('/')[-1]
     return StandardizedShortRepository(
-        id=api_repo['uuid'],
+        id=repo_slug,
         name=(
             api_repo['name']
             if not redact_names_and_urls
@@ -480,7 +483,7 @@ def _standardize_pr(
         and api_pr['merge_commit'].get('hash')
     ):
         api_merge_commit = client.get_commit(
-            repo.project.id, api_pr['source']['repository']['uuid'], api_pr['merge_commit']['hash']
+            repo.project.id, repo.id, api_pr['merge_commit']['hash']
         )
         merge_commit = _standardize_commit(
             api_merge_commit,

--- a/jf_agent/git/bitbucket_cloud_adapter.py
+++ b/jf_agent/git/bitbucket_cloud_adapter.py
@@ -170,7 +170,7 @@ class BitbucketCloudAdapter(GitAdapter):
                 for branch in get_branches_for_standardized_repo(repo, included_branches):
                     for j, commit in enumerate(
                         tqdm(
-                            self.client.get_commits(repo.project.id, repo.id, branch),
+                            self.client.get_commits(repo.project.id, _repo_slug(repo), branch),
                             desc=f'downloading commits for {repo.name} on branch {branch}',
                             unit='commits',
                         ),
@@ -207,7 +207,7 @@ class BitbucketCloudAdapter(GitAdapter):
                         server_git_instance_info, repo.project.login, repo.id, 'prs'
                     )
 
-                    api_prs = self.client.get_pullrequests(repo.project.id, repo.id)
+                    api_prs = self.client.get_pullrequests(repo.project.id, _repo_slug(repo))
 
                     if not api_prs:
                         logger.info(f'no prs found for repo {repo.id}. Skipping... ')
@@ -272,6 +272,10 @@ class BitbucketCloudAdapter(GitAdapter):
         ]
 
 
+def _repo_slug(repo: StandardizedRepository) -> str:
+    return repo.full_name.split('/')[-1]
+
+
 def _standardize_project(project_name, redact_names_and_urls):
     return StandardizedProject(id=project_name, login=project_name, name=project_name, url=None)
 
@@ -282,7 +286,6 @@ def _standardize_repo(
     standardized_project: StandardizedProject,
     redact_names_and_urls: bool,
 ) -> StandardizedRepository:
-    repo_slug = api_repo['full_name'].split('/')[-1]
     repo_name = (
         api_repo['name']
         if not redact_names_and_urls
@@ -291,7 +294,7 @@ def _standardize_repo(
     url = api_repo['links']['self']['href'] if not redact_names_and_urls else None
 
     return StandardizedRepository(
-        id=repo_slug,
+        id=api_repo['uuid'],
         name=repo_name,
         full_name=api_repo['full_name'],
         url=url,
@@ -307,9 +310,8 @@ def _standardize_repo(
 
 
 def _standardize_short_form_repo(api_repo, redact_names_and_urls):
-    repo_slug = api_repo['full_name'].split('/')[-1]
     return StandardizedShortRepository(
-        id=repo_slug,
+        id=api_repo['uuid'],
         name=(
             api_repo['name']
             if not redact_names_and_urls
@@ -383,10 +385,12 @@ def _standardize_user(api_user):
 def _standardize_pr(
     client, repo, api_pr, strip_text_content: bool, redact_names_and_urls: bool,
 ):
+    slug = _repo_slug(repo)
+
     # Process the PR's diff to get additions, deletions, changed_files
     additions, deletions, changed_files = None, None, None
     try:
-        diff_str = client.pr_diff(repo.project.id, repo.id, api_pr['id'])
+        diff_str = client.pr_diff(repo.project.id, slug, api_pr['id'])
         additions, deletions, changed_files = _calculate_diff_counts(diff_str)
         if additions is None:
             logging_helper.log_standard_error(
@@ -422,7 +426,7 @@ def _standardize_pr(
             body=sanitize_text(c['content']['raw'], strip_text_content),
             created_at=parser.parse(c['created_on']),
         )
-        for c in client.pr_comments(repo.project.id, repo.id, api_pr['id'])
+        for c in client.pr_comments(repo.project.id, slug, api_pr['id'])
     ]
 
     # Crawl activity for approvals, merge and closed dates
@@ -431,7 +435,7 @@ def _standardize_pr(
     merged_by = None
     closed_date = None
     try:
-        activity = list(client.pr_activity(repo.project.id, repo.id, api_pr['id']))
+        activity = list(client.pr_activity(repo.project.id, slug, api_pr['id']))
         approvals = [
             StandardizedPullRequestReview(
                 user=_standardize_user(approval['user']),
@@ -473,7 +477,7 @@ def _standardize_pr(
             strip_text_content,
             redact_names_and_urls,
         )
-        for c in client.pr_commits(repo.project.id, repo.id, api_pr['id'])
+        for c in client.pr_commits(repo.project.id, slug, api_pr['id'])
     ]
     merge_commit = None
     if (
@@ -483,7 +487,7 @@ def _standardize_pr(
         and api_pr['merge_commit'].get('hash')
     ):
         api_merge_commit = client.get_commit(
-            repo.project.id, repo.id, api_pr['merge_commit']['hash']
+            repo.project.id, slug, api_pr['merge_commit']['hash']
         )
         merge_commit = _standardize_commit(
             api_merge_commit,

--- a/tests/test_bitbucket_cloud_adapter.py
+++ b/tests/test_bitbucket_cloud_adapter.py
@@ -87,7 +87,7 @@ class TestBitbucketCloudAdapter(TestCase):
         resulting_repo = resulting_repos[0]
         input_repo = test_repos[0]
         self.assertEqual(
-            resulting_repo.id, input_repo['uuid'], "Resulting repo id does not match input"
+            resulting_repo.id, input_repo['uuid'], "Resulting repo id should be the UUID"
         )
         self.assertEqual(
             resulting_repo.name, input_repo['name'], "Resulting repo name does not match input"
@@ -281,6 +281,73 @@ class TestBitbucketCloudAdapter(TestCase):
         )
         self.assertFalse(resulting_pr.is_closed)
         self.assertFalse(resulting_pr.is_merged)
+
+    def test_get_prs_merge_commit_uses_destination_repo(self):
+        # Arrange: a MERGED PR where source repo uuid differs from destination repo slug.
+        # This verifies the fix for the bug where get_commit was called with the source
+        # repo uuid instead of the destination repo id.
+        test_commits = _get_test_data('test_commits.json')
+        dest_slug = 'destination_repo_slug'
+        source_uuid = '{aaaaaaaa-0000-0000-0000-bbbbbbbbbbbb}'
+
+        merged_pr = {
+            'id': 99,
+            'title': 'Merged PR',
+            'description': '',
+            'state': 'MERGED',
+            'merge_commit': {'hash': 'abc123merge'},
+            'created_on': '2020-01-01T00:00:00+00:00',
+            'updated_on': '2020-01-02T00:00:00+00:00',
+            'author': {
+                'display_name': 'test_user',
+                'uuid': '{1cd06601-cd0e-4fce-be03-e9ac226978b7}',
+                'links': {'html': {'href': 'https://bitbucket.org/test_user/'}},
+            },
+            'source': {
+                'branch': {'name': 'feature'},
+                'repository': {
+                    'full_name': 'some-fork/destination_repo_slug',
+                    'name': 'fork_repo',
+                    'type': 'repository',
+                    'uuid': source_uuid,
+                    'links': {'self': {'href': 'https://api.bitbucket.org/2.0/repositories/some-fork/fork'}},
+                },
+            },
+            'destination': {
+                'branch': {'name': 'master'},
+                'repository': {
+                    'full_name': f'test_project/{dest_slug}',
+                    'name': dest_slug,
+                    'type': 'repository',
+                    'uuid': '{cccccccc-0000-0000-0000-dddddddddddd}',
+                    'links': {'self': {'href': f'https://api.bitbucket.org/2.0/repositories/test_project/{dest_slug}'}},
+                },
+            },
+            'links': {'html': {'href': 'https://bitbucket.org/test_project/pull-requests/99'}},
+        }
+
+        mock_standardized_repo = MagicMock()
+        mock_standardized_repo.id = '{cccccccc-0000-0000-0000-dddddddddddd}'
+        mock_standardized_repo.full_name = f'test_project/{dest_slug}'
+        mock_standardized_repo.project.id = 'test_project'
+        mock_standardized_repos = [mock_standardized_repo]
+
+        self.mock_client.get_pullrequests.return_value = [merged_pr]
+        self.mock_client.pr_diff.return_value = ""
+        self.mock_client.pr_comments.return_value = []
+        self.mock_client.pr_activity.return_value = []
+        self.mock_client.pr_commits.return_value = test_commits
+        self.mock_client.get_commit.return_value = test_commits[0]
+
+        test_git_instance_info = {'pull_from': '1900-07-23', 'repos_dict_v2': {}}
+
+        # Call the adapter method
+        list(self.adapter.get_pull_requests(mock_standardized_repos, test_git_instance_info))
+
+        # Assert: get_commit must be called with the destination repo slug, not the source uuid
+        self.mock_client.get_commit.assert_called_once_with(
+            'test_project', dest_slug, 'abc123merge'
+        )
 
 
 def _get_test_data(file_name):


### PR DESCRIPTION
**Relevant API Documentation:**

* https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-group-repositories
* https://developer.atlassian.com/cloud/bitbucket/proxy-object-hydration/
* https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/