### PR TITLE
Revert "OJ-54189 Enable using group names to pull Jira users (#452)"

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -127,18 +127,10 @@ jira:
   #   - jellyfish.co
 
   # it's possible for a user to have no email.  if we need to restrict users
-  # by email domain, should null-email users be included?  uncomment this
+  # by email domain, should null-email users be included?  uncomment this 
   # if they shouldn't:
   #
   # is_email_required: True
-
-  # If provided, only pull users who are members of these Jira groups instead
-  # of using the default bulk user search. If omitted, all discoverable users
-  # are pulled.
-  #
-  # user_group_names:
-  #   - jira-software-users
-  #   - engineering-team
 
   # This is a special run mode that allows you to skip saving your JIRA data
   # locally, and instead continuously submit it via S3. This run mode is good

--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -75,7 +75,6 @@ ValidatedConfig = namedtuple(
         'jira_exclude_project_categories',
         'jira_required_email_domains',
         'jira_is_email_required',
-        'jira_user_group_names',
         'jira_issue_jql',
         'jira_download_worklogs',
         'jira_download_sprints',
@@ -169,7 +168,6 @@ def obtain_config(args) -> ValidatedConfig:
     jira_gdpr_active = jira_config.get('gdpr_active', False)
     jira_required_email_domains = set(jira_config.get('required_email_domains', []))
     jira_is_email_required = jira_config.get('is_email_required', False)
-    jira_user_group_names = list(jira_config.get('user_group_names', []))
     jira_include_projects = set(jira_config.get('include_projects', []))
     jira_exclude_projects = set(jira_config.get('exclude_projects', []))
     jira_include_project_categories = set(jira_config.get('include_project_categories', []))
@@ -286,7 +284,6 @@ def obtain_config(args) -> ValidatedConfig:
         jira_exclude_project_categories,
         jira_required_email_domains,
         jira_is_email_required,
-        jira_user_group_names,
         jira_issue_jql,
         jira_download_worklogs,
         jira_download_sprints,
@@ -458,7 +455,6 @@ def get_ingest_config(
             # User Info
             required_email_domains=config.jira_required_email_domains,
             is_email_required=config.jira_is_email_required,
-            jira_user_group_names=config.jira_user_group_names,
             #
             # Projects Info
             include_projects=config.jira_include_projects,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.4.0",
     "colorama>=0.4.6",
-    "jf-ingest==0.0.288",
+    "jf-ingest==0.0.285",
 ]
 requires-python = ">=3.13,<3.14"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ requires-dist = [
     { name = "click", specifier = "~=8.0.4" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "dateparser" },
-    { name = "jf-ingest", specifier = "==0.0.288" },
+    { name = "jf-ingest", specifier = "==0.0.285" },
     { name = "jira", specifier = "==3.10.5" },
     { name = "jsonstreams" },
     { name = "psutil" },
@@ -287,7 +287,7 @@ dev = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.288"
+version = "0.0.285"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filemagic" },
@@ -304,9 +304,9 @@ dependencies = [
     { name = "requests-mock" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9c/3b1dae6b658d57c204fa29af27e1f7e3572131ca6882002fa34bc89076c5/jf_ingest-0.0.288.tar.gz", hash = "sha256:7fbe941398734487ef4a4db9620fc075e9972bb5183bb39a7ac3bfeaf8afc651", size = 335781, upload-time = "2026-05-11T20:40:15.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/06/a52d0a03c31b335d89062e6bb97ddd31c7b0c10a9bf71412495989990a52/jf_ingest-0.0.285.tar.gz", hash = "sha256:c7fac33212817bb5e77bc175b856f4eb69ade580ff8cd2dcf3676902819705c5", size = 332384, upload-time = "2026-04-29T23:14:51.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/96/71b7c338e6de3dbd03a2192c3a3270807269efb3418eeb0377e858e0856f/jf_ingest-0.0.288-py3-none-any.whl", hash = "sha256:689088f6dcf671e73cd57d86bfdce7b7d29759b049a587fab92aa53f6a4c6e64", size = 215316, upload-time = "2026-05-11T20:40:14.017Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2b/28b463714b6df31bec086d756d544e209064b0b555e54b01479619d1f45d/jf_ingest-0.0.285-py3-none-any.whl", hash = "sha256:6e23836d2e3e2cd34ca57417528eed0334e369adfe377361d0fc6a93a7b1a399", size = 213369, upload-time = "2026-04-29T23:14:49.491Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This reverts commit fd7d2614ee2fa66de8e73ed375ff6c08b97aefe9.

(reverting this change to err on the side of caution)