### PR TITLE
Support JPO parent fields, issue fetching by key, and fetching historical parent links past our pull_from date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "structlog>=24.4.0",
     "colorama>=0.4.6",
-    "jf-ingest==0.0.295",
+    "jf-ingest==0.0.297",
 ]
 requires-python = ">=3.13,<3.14"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ requires-dist = [
     { name = "click", specifier = "~=8.3.3" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "dateparser" },
-    { name = "jf-ingest", specifier = "==0.0.295" },
+    { name = "jf-ingest", specifier = "==0.0.297" },
     { name = "jira", specifier = "==3.10.5" },
     { name = "jsonstreams" },
     { name = "psutil" },
@@ -287,7 +287,7 @@ dev = [
 
 [[package]]
 name = "jf-ingest"
-version = "0.0.295"
+version = "0.0.297"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filemagic" },
@@ -304,9 +304,9 @@ dependencies = [
     { name = "requests-mock" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/e5/abb50ee485352af7d3393b2fc7a097b1a688cc1dca900640da5e19ffd316/jf_ingest-0.0.295.tar.gz", hash = "sha256:d2aa7c8cb1fe7d5a4cbf03586c7c5cacdc146478dbd4c0fb6777cf294a30e47d", size = 340474, upload-time = "2026-07-20T22:06:19.103Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/4d/16082e1eabb68403df4f8edd12c93edc271a5539333e0ddb6e5e0e4acaf1/jf_ingest-0.0.297.tar.gz", hash = "sha256:a74ca8622ff485f0ffc64386cad55c55c5c1df54d02a9d85fa8ed0fc17f6d215", size = 343353, upload-time = "2026-07-31T17:43:50.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/97/e798b0a22467c13fa873e759616a80cc3d56140c0f860f136468c685e366/jf_ingest-0.0.295-py3-none-any.whl", hash = "sha256:30e0e8ce341d63247a57d410ed9e9c9d78e160b186c8c87ee3416b93faab4ea2", size = 218018, upload-time = "2026-07-20T22:06:17.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/66/2abebc5fe3bb5dc3e0f80ce171fe79d153c0e25726d7c87b58c501b221c6/jf_ingest-0.0.297-py3-none-any.whl", hash = "sha256:fca54b06a215dafda9dc5d97f63dc3d29e12ecf724f2efaf8c581d5789bee984", size = 217989, upload-time = "2026-07-31T17:43:49.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Includes support for JPO custom parent fields, fetching issues by key in jql, and removing our `pull_from` date restrictions when we are pulling parent issues. This is to ensure we avoid missing historical parent issues that may not have been updated but have child tickets that were updated.