### PR TITLE
CORE-336: Honor server-delivered git branch config

### DIFF
--- a/jf_agent/config_file_reader.py
+++ b/jf_agent/config_file_reader.py
@@ -571,6 +571,26 @@ def get_ingest_config(
                 'backpopulation_window_days'
             ]
 
+        # Branch selection configured in Jellyfish wins per repo; repos the server says
+        # nothing about keep whatever the local config file asked for. Without this, a
+        # branch configured in Jellyfish silently has no effect on an agent pull, so
+        # commits made directly to a non-default branch are never collected.
+        included_branches_by_repo = dict(agent_git_config.git_include_branches)
+        included_branches_by_repo.update(
+            endpoint_git_instance_info.get('included_branches_by_repo') or {}
+        )
+        if 'pull_commits_for_all_branches' in endpoint_git_instance_info:
+            extra_kwargs['pull_all_commits_and_branches'] = endpoint_git_instance_info[
+                'pull_commits_for_all_branches'
+            ]
+        # This is the field that decides whether jf_ingest lists a repo's branches at all.
+        # included_branches_by_repo can only narrow the list discovery returns, never add
+        # to it, so without this a branch named in Jellyfish is never reached.
+        if 'repo_id_to_pull_all_commits_and_branches' in endpoint_git_instance_info:
+            extra_kwargs['repo_id_to_pull_all_commits_and_branches'] = endpoint_git_instance_info[
+                'repo_id_to_pull_all_commits_and_branches'
+            ]
+
         git_configs.append(
             JFIngestGitConfig(
                 company_slug=company_slug,
@@ -588,7 +608,7 @@ def get_ingest_config(
                 excluded_organizations=agent_git_config.git_exclude_projects,
                 included_repos=[str(incl_repo) for incl_repo in agent_git_config.git_include_repos],
                 excluded_repos=[str(excl_repo) for excl_repo in agent_git_config.git_exclude_repos],
-                included_branches_by_repo=agent_git_config.git_include_branches,
+                included_branches_by_repo=included_branches_by_repo,
                 git_redact_names_and_urls=agent_git_config.git_redact_names_and_urls,
                 git_strip_text_content=agent_git_config.git_strip_text_content,
                 check_ghc_mannequin_user_prs=agent_git_config.github_check_mannequin_users,

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -327,3 +327,98 @@ class TestBackpopulationWindowDaysPassthrough(TestCase):
         self.assertEqual(mock_jf_ingest_git_config.call_count, 1)
         kwargs = mock_jf_ingest_git_config.call_args.kwargs
         self.assertNotIn('backpopulation_window_days', kwargs)
+
+
+class TestServerDeliveredBranchConfig(TestCase):
+    """
+    Branch selection sent by the server endpoint must reach JFIngestGitConfig. Server
+    values win per repo; repos the server says nothing about keep the local config.
+    """
+
+    def _run(self, endpoint_git_instance_info, local_include_branches=None):
+        config, creds, endpoint_git_instances_info = _build_ingest_config_inputs(
+            endpoint_git_instance_info=endpoint_git_instance_info
+        )
+        if local_include_branches is not None:
+            config.git_configs[0].git_include_branches = local_include_branches
+
+        with (
+            patch('jf_agent.config_file_reader.IngestionConfig'),
+            patch('jf_agent.config_file_reader.JFIngestGitConfig') as mock_git_config,
+            patch(
+                'jf_agent.config_file_reader._get_jf_ingest_git_auth_config',
+                return_value=MagicMock(),
+            ),
+            patch(
+                'jf_agent.config_file_reader.get_company_info',
+                return_value={'company_slug': 'test-co'},
+            ),
+        ):
+            get_ingest_config(
+                config=config,
+                creds=creds,
+                endpoint_jira_info={},
+                endpoint_git_instances_info=endpoint_git_instances_info,
+                jf_options={},
+            )
+        self.assertEqual(mock_git_config.call_count, 1)
+        return mock_git_config.call_args.kwargs
+
+    def test_server_branches_win_per_repo_and_local_is_preserved(self):
+        kwargs = self._run(
+            endpoint_git_instance_info={
+                'slug': 'ado-instance-1',
+                'key': 'ado-key',
+                'repos_dict_v2': {},
+                'pull_from': '2024-01-01T00:00:00',
+                'included_branches_by_repo': {'repo_one': ['release_a', 'release_b']},
+            },
+            local_include_branches={
+                'repo_one': ['stale_branch'],
+                'other_repo': ['keep_me'],
+            },
+        )
+        self.assertEqual(
+            kwargs.get('included_branches_by_repo'),
+            {'repo_one': ['release_a', 'release_b'], 'other_repo': ['keep_me']},
+        )
+
+    def test_pull_all_commits_and_branches_forwarded_when_present(self):
+        kwargs = self._run(
+            endpoint_git_instance_info={
+                'slug': 'ado-instance-1',
+                'key': 'ado-key',
+                'repos_dict_v2': {},
+                'pull_from': '2024-01-01T00:00:00',
+                'pull_commits_for_all_branches': True,
+            }
+        )
+        self.assertTrue(kwargs.get('pull_all_commits_and_branches'))
+
+    def test_per_repo_branch_discovery_forwarded_when_present(self):
+        kwargs = self._run(
+            endpoint_git_instance_info={
+                'slug': 'ado-instance-1',
+                'key': 'ado-key',
+                'repos_dict_v2': {},
+                'pull_from': '2024-01-01T00:00:00',
+                'repo_id_to_pull_all_commits_and_branches': {'123': True},
+            }
+        )
+        self.assertEqual(
+            kwargs.get('repo_id_to_pull_all_commits_and_branches'), {'123': True}
+        )
+
+    def test_older_server_payload_leaves_local_config_untouched(self):
+        kwargs = self._run(
+            endpoint_git_instance_info={
+                'slug': 'ado-instance-1',
+                'key': 'ado-key',
+                'repos_dict_v2': {},
+                'pull_from': '2024-01-01T00:00:00',
+            },
+            local_include_branches={'other_repo': ['keep_me']},
+        )
+        self.assertEqual(kwargs.get('included_branches_by_repo'), {'other_repo': ['keep_me']})
+        self.assertNotIn('pull_all_commits_and_branches', kwargs)
+        self.assertNotIn('repo_id_to_pull_all_commits_and_branches', kwargs)


### PR DESCRIPTION
### Description

Read git branch selection from the `get_pull_state` payload in `get_ingest_config`, so branch config set on the server reaches jf_ingest.

`repo_id_to_pull_all_commits_and_branches` controls whether jf_ingest lists a repo's branches at all. Without it, `included_branches_by_repo` has nothing to narrow, since it is applied to the branches discovery already returned. The agent config file has no equivalent option, so previously `include_branches` in `config.yml` had no effect.

Server values win per repo. Repos absent from the server payload keep their local config. Each field is read only when its key is present, so an older server payload leaves current behavior unchanged.

Follows the pattern used for `backpopulation_window_days`.

Requires the paired server change.

### Testing Strategy
- [x] Local Validation

`tests/test_config_file.py` — 12 passed. Verified the three kwargs exist on `GitConfig` in the pinned `jf-ingest==0.0.308`.

### Rollback Strategy
- [x] PR Revert

### Concerns / Assumptions / Tradeoffs

This agent release is required for the server change to take effect. An older agent ignores the new payload keys silently.

Instances that already have all-branches enabled on the server will begin pulling every branch once this ships. Review those before release.